### PR TITLE
Fixed typo in NetDll_setsockopt logging.

### DIFF
--- a/src/xenia/kernel/xam_net.cc
+++ b/src/xenia/kernel/xam_net.cc
@@ -113,7 +113,7 @@ SHIM_CALL NetDll_setsockopt_shim(
   uint32_t optval_ptr = SHIM_GET_ARG_32(4);
   uint32_t optlen = SHIM_GET_ARG_32(5);
   XELOGD(
-      "NetDll_send(%d, %.8X, %d, %d, %.8X, %d)",
+      "NetDll_setsockopt(%d, %.8X, %d, %d, %.8X, %d)",
       arg0,
       socket_ptr,
       level,


### PR DESCRIPTION
I just noticed that when you are logging the NetDll_setsockopt there is a typo and it prints out that it is actually NetDll_send.
