### PR TITLE
Linux: Fix vulkan init and GTK abstraction to run window-vulkan-demo

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -77,6 +77,11 @@ filter({"configurations:Debug", "platforms:Linux"})
     "_GLIBCXX_DEBUG",   -- make dbg symbols work on some distros
   })
 
+filter({"configurations:Debug", "platforms:Linux"})
+  buildoptions({
+    "-g"
+  })
+
 filter("configurations:Release")
   runtime("Release")
   defines({

--- a/src/xenia/app/premake5.lua
+++ b/src/xenia/app/premake5.lua
@@ -73,7 +73,6 @@ project("xenia-app")
       "X11",
       "xcb",
       "X11-xcb",
-      "vulkan",
       "SDL2",
     })
 

--- a/src/xenia/base/main_posix.cc
+++ b/src/xenia/base/main_posix.cc
@@ -9,6 +9,8 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include "build/version.h"
+#include "xenia/base/main.h"
 
 #include "xenia/base/cvar.h"
 #include "xenia/base/main.h"
@@ -40,6 +42,9 @@ extern "C" int main(int argc, char** argv) {
 
   // Initialize logging. Needs parsed FLAGS.
   xe::InitializeLogging(entry_info.name);
+
+  // Print version info.
+  XELOGI("Build: " XE_BUILD_BRANCH " / " XE_BUILD_COMMIT " on " XE_BUILD_DATE);
 
   // Call app-provided entry point.
   int result = entry_info.entry_point(args);

--- a/src/xenia/cpu/ppc/testing/premake5.lua
+++ b/src/xenia/cpu/ppc/testing/premake5.lua
@@ -13,6 +13,7 @@ project("xenia-cpu-ppc-tests")
     "xenia-core",
     "xenia-cpu-backend-x64",
     "xenia-cpu",
+    "xenia-ui",
     "xenia-base",
   })
   files({

--- a/src/xenia/gpu/vulkan/premake5.lua
+++ b/src/xenia/gpu/vulkan/premake5.lua
@@ -70,7 +70,6 @@ project("xenia-gpu-vulkan-trace-viewer")
       "X11",
       "xcb",
       "X11-xcb",
-      "GL",
     })
 
   filter("platforms:Windows")
@@ -137,7 +136,6 @@ project("xenia-gpu-vulkan-trace-dump")
       "X11",
       "xcb",
       "X11-xcb",
-      "GL",
     })
 
   filter("platforms:Windows")

--- a/src/xenia/gpu/vulkan/premake5.lua
+++ b/src/xenia/gpu/vulkan/premake5.lua
@@ -71,7 +71,6 @@ project("xenia-gpu-vulkan-trace-viewer")
       "xcb",
       "X11-xcb",
       "GL",
-      "vulkan",
     })
 
   filter("platforms:Windows")
@@ -139,7 +138,6 @@ project("xenia-gpu-vulkan-trace-dump")
       "xcb",
       "X11-xcb",
       "GL",
-      "vulkan",
     })
 
   filter("platforms:Windows")

--- a/src/xenia/gpu/vulkan/vulkan_graphics_system.cc
+++ b/src/xenia/gpu/vulkan/vulkan_graphics_system.cc
@@ -271,7 +271,7 @@ VulkanGraphicsSystem::CreateCommandProcessor() {
 }
 
 void VulkanGraphicsSystem::Swap(xe::ui::UIEvent* e) {
-  if (!command_processor_) {
+  if (!command_processor_ || !display_context_) {
     return;
   }
 

--- a/src/xenia/ui/vulkan/premake5.lua
+++ b/src/xenia/ui/vulkan/premake5.lua
@@ -57,5 +57,4 @@ project("xenia-ui-window-vulkan-demo")
       "xcb",
       "X11-xcb",
       "GL",
-      "vulkan",
     })

--- a/src/xenia/ui/vulkan/premake5.lua
+++ b/src/xenia/ui/vulkan/premake5.lua
@@ -56,5 +56,4 @@ project("xenia-ui-window-vulkan-demo")
       "X11",
       "xcb",
       "X11-xcb",
-      "GL",
     })

--- a/src/xenia/ui/vulkan/vulkan_context.cc
+++ b/src/xenia/ui/vulkan/vulkan_context.cc
@@ -74,7 +74,7 @@ bool VulkanContext::Initialize() {
 #elif XE_PLATFORM_LINUX
 #ifdef GDK_WINDOWING_X11
     GtkWidget* window_handle =
-        static_cast<GtkWidget*>(target_window_->native_handle());
+        dynamic_cast<GTKWindow*>(target_window_)->native_window_handle();
     xcb_window_t window =
         gdk_x11_window_get_xid(gtk_widget_get_window(window_handle));
     VkXcbSurfaceCreateInfoKHR create_info;

--- a/src/xenia/ui/vulkan/vulkan_context.cc
+++ b/src/xenia/ui/vulkan/vulkan_context.cc
@@ -75,10 +75,6 @@ bool VulkanContext::Initialize() {
 #ifdef GDK_WINDOWING_X11
     GtkWidget* window_handle =
         static_cast<GtkWidget*>(target_window_->native_handle());
-    GdkDisplay* gdk_display = gtk_widget_get_display(window_handle);
-    assert(GDK_IS_X11_DISPLAY(gdk_display));
-    xcb_connection_t* connection =
-        XGetXCBConnection(gdk_x11_display_get_xdisplay(gdk_display));
     xcb_window_t window =
         gdk_x11_window_get_xid(gtk_widget_get_window(window_handle));
     VkXcbSurfaceCreateInfoKHR create_info;

--- a/src/xenia/ui/vulkan/vulkan_instance.cc
+++ b/src/xenia/ui/vulkan/vulkan_instance.cc
@@ -71,6 +71,21 @@ VulkanInstance::VulkanInstance() {
 
   DeclareRequiredExtension(VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
                            Version::Make(0, 0, 0), true);
+  DeclareRequiredExtension(VK_KHR_SURFACE_EXTENSION_NAME,
+                           Version::Make(0, 0, 0), true);
+#if XE_PLATFORM_WIN32
+  DeclareRequiredExtension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+                           Version::Make(0, 0, 0), true);
+#elif XE_PLATFORM_LINUX
+#ifdef GDK_WINDOWING_X11
+  DeclareRequiredExtension(VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+                           Version::Make(0, 0, 0), true);
+#else
+#error No Vulkan surface extension for the GDK backend defined yet.
+#endif
+#else
+#error No Vulkan surface extension for the platform defined yet.
+#endif
 }
 
 VulkanInstance::~VulkanInstance() { DestroyInstance(); }

--- a/src/xenia/ui/vulkan/vulkan_provider.cc
+++ b/src/xenia/ui/vulkan/vulkan_provider.cc
@@ -52,10 +52,13 @@ bool VulkanProvider::Initialize() {
   instance_ = std::make_unique<VulkanInstance>();
 
   // Always enable the swapchain.
+  instance_->DeclareRequiredExtension(VK_KHR_SURFACE_EXTENSION_NAME,
+                                      Version::Make(0, 0, 0), false);
 #if XE_PLATFORM_WIN32
-  instance_->DeclareRequiredExtension("VK_KHR_surface", Version::Make(0, 0, 0),
-                                      false);
-  instance_->DeclareRequiredExtension("VK_KHR_win32_surface",
+  instance_->DeclareRequiredExtension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+                                      Version::Make(0, 0, 0), false);
+#elif XE_PLATFORM_LINUX
+  instance_->DeclareRequiredExtension(VK_KHR_XCB_SURFACE_EXTENSION_NAME,
                                       Version::Make(0, 0, 0), false);
 #endif
 

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -172,8 +172,9 @@ class Window {
   Loop* loop_ = nullptr;
   std::unique_ptr<MenuItem> main_menu_;
   std::string title_;
-  int32_t width_ = 0;
-  int32_t height_ = 0;
+  // GTK must have a default value here that isn't 0
+  int32_t width_ = 1280;
+  int32_t height_ = 720;
   bool has_focus_ = true;
   bool is_cursor_visible_ = true;
   bool is_imgui_input_enabled_ = false;

--- a/src/xenia/ui/window_gtk.cc
+++ b/src/xenia/ui/window_gtk.cc
@@ -7,11 +7,14 @@
  ******************************************************************************
  */
 
+#include "xenia/ui/window_gtk.h"
+#include <algorithm>
 #include <string>
 
 #include <X11/Xlib-xcb.h>
 
 #include "xenia/base/assert.h"
+#include "xenia/base/clock.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/platform_linux.h"
 #include "xenia/ui/virtual_key.h"
@@ -39,14 +42,14 @@ GTKWindow::GTKWindow(Loop* loop, const std::string& title)
 GTKWindow::~GTKWindow() {
   OnDestroy();
   if (window_) {
-    gtk_widget_destroy(window_);
+    if (GTK_IS_WIDGET(window_)) gtk_widget_destroy(window_);
     window_ = nullptr;
   }
 }
 
 bool GTKWindow::Initialize() { return OnCreate(); }
 
-void gtk_event_handler_(GtkWidget* widget, GdkEvent* event, gpointer data) {
+gboolean gtk_event_handler(GtkWidget* widget, GdkEvent* event, gpointer data) {
   GTKWindow* window = reinterpret_cast<GTKWindow*>(data);
   switch (event->type) {
     case GDK_OWNER_CHANGE:
@@ -60,34 +63,80 @@ void gtk_event_handler_(GtkWidget* widget, GdkEvent* event, gpointer data) {
       window->HandleKeyboard(&(event->key));
       break;
     case GDK_SCROLL:
-    case GDK_BUTTON_PRESS:
     case GDK_MOTION_NOTIFY:
+    case GDK_BUTTON_PRESS:
+    case GDK_BUTTON_RELEASE:
       window->HandleMouse(&(event->any));
       break;
     case GDK_FOCUS_CHANGE:
       window->HandleWindowFocus(&(event->focus_change));
       break;
     case GDK_CONFIGURE:
-      window->HandleWindowResize(&(event->configure));
+      // Only handle the event for the drawing area so we don't save
+      // a width and height that includes the menu bar on the full window
+      if (event->configure.window ==
+          gtk_widget_get_window(window->drawing_area_))
+        window->HandleWindowResize(&(event->configure));
+      break;
     default:
       // Do nothing
-      return;
+      break;
   }
+  // Propagate the event to other handlers
+  return GDK_EVENT_PROPAGATE;
+}
+
+gboolean draw_callback(GtkWidget* widget, GdkFrameClock* frame_clock,
+                       gpointer data) {
+  GTKWindow* window = reinterpret_cast<GTKWindow*>(data);
+  window->HandleWindowPaint();
+  return G_SOURCE_CONTINUE;
+}
+
+gboolean close_callback(GtkWidget* widget, gpointer data) {
+  GTKWindow* window = reinterpret_cast<GTKWindow*>(data);
+  window->Close();
+  return G_SOURCE_CONTINUE;
 }
 
 void GTKWindow::Create() {
+  // GTK optionally allows passing argv and argc here for parsing gtk specific
+  // options. We won't bother
+  gtk_init(nullptr, nullptr);
   window_ = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  gtk_window_set_title(GTK_WINDOW(window_), (gchar*)title_.c_str());
-  gtk_window_set_default_size(GTK_WINDOW(window_), 1280, 720);
-  gtk_widget_show_all(window_);
-  g_signal_connect(G_OBJECT(window_), "destroy", G_CALLBACK(gtk_main_quit),
-                   NULL);
-  g_signal_connect(G_OBJECT(window_), "event", G_CALLBACK(gtk_event_handler_),
+  gtk_window_set_resizable(GTK_WINDOW(window_), true);
+  gtk_window_set_title(GTK_WINDOW(window_), title_.c_str());
+  gtk_window_set_default_size(GTK_WINDOW(window_), width_, height_);
+  // Drawing area is where we will attach our vulkan/gl context
+  drawing_area_ = gtk_drawing_area_new();
+  // Don't allow resizing the window below this
+  gtk_widget_set_size_request(drawing_area_, 640, 480);
+  // tick callback is for the refresh rate of the window
+  gtk_widget_add_tick_callback(drawing_area_, draw_callback,
+                               reinterpret_cast<gpointer>(this), nullptr);
+  // Attach our event handler to both the main window (for keystrokes) and the
+  // drawing area (for mouse input, resize event, etc)
+  g_signal_connect(G_OBJECT(drawing_area_), "event",
+                   G_CALLBACK(gtk_event_handler),
                    reinterpret_cast<gpointer>(this));
-
+  g_signal_connect(G_OBJECT(window_), "event", G_CALLBACK(gtk_event_handler),
+                   reinterpret_cast<gpointer>(this));
+  // When the window manager kills the window (ie, the user hits X)
+  g_signal_connect(G_OBJECT(window_), "destroy", G_CALLBACK(close_callback),
+                   reinterpret_cast<gpointer>(this));
   GdkDisplay* gdk_display = gtk_widget_get_display(window_);
   assert(GDK_IS_X11_DISPLAY(gdk_display));
   connection_ = XGetXCBConnection(gdk_x11_display_get_xdisplay(gdk_display));
+  // Enable only keyboard events (so no mouse) for the top window
+  gtk_widget_set_events(window_, GDK_KEY_PRESS | GDK_KEY_RELEASE);
+  // Enable all events for the drawing area
+  gtk_widget_add_events(drawing_area_, GDK_ALL_EVENTS_MASK);
+  // Place the drawing area in a container (which later will hold the menu)
+  // then let it fill the whole area
+  box_ = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_box_pack_end(GTK_BOX(box_), drawing_area_, TRUE, TRUE, 0);
+  gtk_container_add(GTK_CONTAINER(window_), box_);
+  gtk_widget_show_all(window_);
 }
 
 bool GTKWindow::OnCreate() {
@@ -129,7 +178,6 @@ void GTKWindow::ToggleFullscreen(bool fullscreen) {
   }
 
   fullscreen_ = fullscreen;
-
   if (fullscreen) {
     gtk_window_fullscreen(GTK_WINDOW(window_));
   } else {
@@ -146,7 +194,6 @@ void GTKWindow::set_bordered(bool enabled) {
     // Don't screw with the borders if we're fullscreen.
     return;
   }
-
   gtk_window_set_decorated(GTK_WINDOW(window_), enabled);
 }
 
@@ -168,7 +215,7 @@ void GTKWindow::set_focus(bool value) {
     if (value) {
       gtk_window_activate_focus(GTK_WINDOW(window_));
     } else {
-      // TODO(dougvj) Check to see if we need to do something here to unset
+      // TODO(dougvj) Check to see if we need to do somethign here to unset
       // the focus.
     }
   } else {
@@ -177,31 +224,26 @@ void GTKWindow::set_focus(bool value) {
 }
 
 void GTKWindow::Resize(int32_t width, int32_t height) {
+  width_ = width;
+  height_ = height;
   gtk_window_resize(GTK_WINDOW(window_), width, height);
 }
 
 void GTKWindow::Resize(int32_t left, int32_t top, int32_t right,
                        int32_t bottom) {
-  // TODO(dougvj) Verify that this is the desired behavior from this call
+  int32_t width = right - left;
+  int32_t height = bottom - top;
+  width_ = width;
+  height_ = height;
   gtk_window_move(GTK_WINDOW(window_), left, top);
-  gtk_window_resize(GTK_WINDOW(window_), left - right, top - bottom);
+  gtk_window_resize(GTK_WINDOW(window_), width, height);
 }
 
-void GTKWindow::OnResize(UIEvent* e) {
-  int32_t width;
-  int32_t height;
-  gtk_window_get_size(GTK_WINDOW(window_), &width, &height);
-  if (width != width_ || height != height_) {
-    width_ = width;
-    height_ = height;
-    Layout();
-  }
-  super::OnResize(e);
-}
+void GTKWindow::OnResize(UIEvent* e) { super::OnResize(e); }
 
 void GTKWindow::Invalidate() {
+  //  gtk_widget_queue_draw(drawing_area_);
   super::Invalidate();
-  // TODO(dougvj) I am not sure what this is supposed to do
 }
 
 void GTKWindow::Close() {
@@ -215,14 +257,15 @@ void GTKWindow::Close() {
 
 void GTKWindow::OnMainMenuChange() {
   // We need to store the old handle for detachment
-  static GtkWidget* box = nullptr;
+  static int count = 0;
   auto main_menu = reinterpret_cast<GTKMenuItem*>(main_menu_.get());
-  if (main_menu && !is_fullscreen()) {
-    if (box) gtk_widget_destroy(box);
-    GtkWidget* menu = main_menu->handle();
-    box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-    gtk_box_pack_start(GTK_BOX(box), menu, FALSE, FALSE, 3);
-    gtk_container_add(GTK_CONTAINER(window_), box);
+  if (main_menu && main_menu->handle()) {
+    if (!is_fullscreen()) {
+      gtk_box_pack_start(GTK_BOX(box_), main_menu->handle(), FALSE, FALSE, 0);
+      gtk_widget_show_all(window_);
+    } else {
+      gtk_container_remove(GTK_CONTAINER(box_), main_menu->handle());
+    }
   }
 }
 
@@ -240,9 +283,22 @@ bool GTKWindow::HandleWindowOwnerChange(GdkEventOwnerChange* event) {
   return false;
 }
 
+bool GTKWindow::HandleWindowPaint() {
+  auto e = UIEvent(this);
+  OnPaint(&e);
+  return true;
+}
+
 bool GTKWindow::HandleWindowResize(GdkEventConfigure* event) {
   if (event->type == GDK_CONFIGURE) {
+    int32_t width = event->width;
+    int32_t height = event->height;
     auto e = UIEvent(this);
+    if (width != width_ || height != height_) {
+      width_ = width;
+      height_ = height;
+      Layout();
+    }
     OnResize(&e);
     return true;
   }
@@ -368,8 +424,9 @@ bool GTKWindow::HandleKeyboard(GdkEventKey* event) {
     case GDK_KEY_RELEASE:
       OnKeyUp(&e);
       break;
-    // TODO(dougvj) GDK doesn't have a KEY CHAR event, so we will have to
-    // figure out its equivalent here to call  OnKeyChar(&e);
+   // TODO(dougvj) GDK doesn't have a KEY CHAR event, so we will have to
+   // figure out its equivalent here to call  OnKeyChar(&e);
+   // most likely some subset of hardware keycodes triggers it
     default:
       return false;
   }
@@ -383,23 +440,35 @@ std::unique_ptr<ui::MenuItem> MenuItem::Create(Type type,
   return std::make_unique<GTKMenuItem>(type, text, hotkey, callback);
 }
 
-static void _menu_activate_callback(GtkWidget* menu, gpointer data) {
-  auto fn = reinterpret_cast<FnWrapper*>(data);
-  fn->Call();
-  delete fn;
+static void _menu_activate_callback(GtkWidget* gtk_menu, gpointer data) {
+  GTKMenuItem* menu = reinterpret_cast<GTKMenuItem*>(data);
+  menu->Activate();
+}
+
+void GTKMenuItem::Activate() {
+  try {
+    callback_();
+  } catch (const std::bad_function_call& e) {
+    // Ignore
+  }
 }
 
 GTKMenuItem::GTKMenuItem(Type type, const std::string& text,
                          const std::string& hotkey,
                          std::function<void()> callback)
     : MenuItem(type, text, hotkey, std::move(callback)) {
+  std::string label = text;
+  // TODO(dougvj) Would we ever need to escape underscores?
+  // Replace & with _ for gtk to see the memonic
+  std::replace(label.begin(), label.end(), '&', '_');
+  const gchar* gtk_label = reinterpret_cast<const gchar*>(label.c_str());
   switch (type) {
     case MenuItem::Type::kNormal:
     default:
       menu_ = gtk_menu_bar_new();
       break;
     case MenuItem::Type::kPopup:
-      menu_ = gtk_menu_item_new_with_label((gchar*)text.c_str());
+      menu_ = gtk_menu_item_new_with_mnemonic(gtk_label);
       break;
     case MenuItem::Type::kSeparator:
       menu_ = gtk_separator_menu_item_new();
@@ -409,12 +478,12 @@ GTKMenuItem::GTKMenuItem(Type type, const std::string& text,
       if (!hotkey.empty()) {
         full_name += "\t" + hotkey;
       }
-      menu_ = gtk_menu_item_new_with_label((gchar*)full_name.c_str());
+      menu_ = gtk_menu_item_new_with_mnemonic(gtk_label);
       break;
   }
   if (GTK_IS_MENU_ITEM(menu_))
     g_signal_connect(menu_, "activate", G_CALLBACK(_menu_activate_callback),
-                     (gpointer) new FnWrapper(callback));
+                     (gpointer)this);
 }
 
 GTKMenuItem::~GTKMenuItem() {
@@ -462,4 +531,5 @@ void GTKMenuItem::OnChildRemoved(MenuItem* generic_child_item) {
 }
 
 }  // namespace ui
+
 }  // namespace xe

--- a/src/xenia/ui/window_gtk.cc
+++ b/src/xenia/ui/window_gtk.cc
@@ -149,8 +149,6 @@ void GTKWindow::OnDestroy() { super::OnDestroy(); }
 void GTKWindow::OnClose() {
   if (!closing_ && window_) {
     closing_ = true;
-    gtk_widget_destroy(window_);
-    window_ = nullptr;
   }
   super::OnClose();
 }
@@ -224,19 +222,23 @@ void GTKWindow::set_focus(bool value) {
 }
 
 void GTKWindow::Resize(int32_t width, int32_t height) {
-  width_ = width;
-  height_ = height;
+  if (is_fullscreen()) {
+    // Cannot resize while in fullscreen.
+    return;
+  }
   gtk_window_resize(GTK_WINDOW(window_), width, height);
+  super::Resize(width, height);
 }
 
 void GTKWindow::Resize(int32_t left, int32_t top, int32_t right,
                        int32_t bottom) {
-  int32_t width = right - left;
-  int32_t height = bottom - top;
-  width_ = width;
-  height_ = height;
+  if (is_fullscreen()) {
+    // Cannot resize while in fullscreen.
+    return;
+  }
   gtk_window_move(GTK_WINDOW(window_), left, top);
-  gtk_window_resize(GTK_WINDOW(window_), width, height);
+  gtk_window_resize(GTK_WINDOW(window_), right - left, bottom - top);
+  super::Resize(left, top, right, bottom);
 }
 
 void GTKWindow::OnResize(UIEvent* e) { super::OnResize(e); }
@@ -251,8 +253,9 @@ void GTKWindow::Close() {
     return;
   }
   closing_ = true;
-  Close();
   OnClose();
+  gtk_widget_destroy(window_);
+  window_ = nullptr;
 }
 
 void GTKWindow::OnMainMenuChange() {

--- a/src/xenia/ui/window_gtk.cc
+++ b/src/xenia/ui/window_gtk.cc
@@ -9,6 +9,8 @@
 
 #include <string>
 
+#include <X11/Xlib-xcb.h>
+
 #include "xenia/base/assert.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/platform_linux.h"
@@ -82,6 +84,10 @@ void GTKWindow::Create() {
                    NULL);
   g_signal_connect(G_OBJECT(window_), "event", G_CALLBACK(gtk_event_handler_),
                    reinterpret_cast<gpointer>(this));
+
+  GdkDisplay* gdk_display = gtk_widget_get_display(window_);
+  assert(GDK_IS_X11_DISPLAY(gdk_display));
+  connection_ = XGetXCBConnection(gdk_x11_display_get_xdisplay(gdk_display));
 }
 
 bool GTKWindow::OnCreate() {

--- a/src/xenia/ui/window_gtk.h
+++ b/src/xenia/ui/window_gtk.h
@@ -15,6 +15,7 @@
 
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
+#include <xcb/xcb.h>
 
 #include "xenia/base/platform_linux.h"
 #include "xenia/ui/menu_item.h"
@@ -31,7 +32,7 @@ class GTKWindow : public Window {
   ~GTKWindow() override;
 
   NativePlatformHandle native_platform_handle() const override {
-    return nullptr;
+    return connection_;
   }
   NativeWindowHandle native_handle() const override { return window_; }
 
@@ -74,6 +75,7 @@ class GTKWindow : public Window {
  private:
   void Create();
   GtkWidget* window_;
+  xcb_connection_t* connection_;
 
   friend void gtk_event_handler_(GtkWidget*, GdkEvent*, gpointer);
   bool HandleMouse(GdkEventAny* event);

--- a/src/xenia/ui/window_gtk.h
+++ b/src/xenia/ui/window_gtk.h
@@ -34,7 +34,8 @@ class GTKWindow : public Window {
   NativePlatformHandle native_platform_handle() const override {
     return connection_;
   }
-  NativeWindowHandle native_handle() const override { return drawing_area_; }
+  NativeWindowHandle native_handle() const override { return window_; }
+  GtkWidget* native_window_handle() const { return drawing_area_; }
 
   void EnableMainMenu() override {}
   void DisableMainMenu() override {}

--- a/src/xenia/ui/window_gtk.h
+++ b/src/xenia/ui/window_gtk.h
@@ -34,7 +34,7 @@ class GTKWindow : public Window {
   NativePlatformHandle native_platform_handle() const override {
     return connection_;
   }
-  NativeWindowHandle native_handle() const override { return window_; }
+  NativeWindowHandle native_handle() const override { return drawing_area_; }
 
   void EnableMainMenu() override {}
   void DisableMainMenu() override {}
@@ -74,16 +74,23 @@ class GTKWindow : public Window {
 
  private:
   void Create();
-  GtkWidget* window_;
+  GtkWidget* window_ = nullptr;
+  GtkWidget* box_ = nullptr;
+  GtkWidget* drawing_area_ = nullptr;
   xcb_connection_t* connection_;
 
-  friend void gtk_event_handler_(GtkWidget*, GdkEvent*, gpointer);
+  // C Callback shims for GTK
+  friend gboolean gtk_event_handler(GtkWidget*, GdkEvent*, gpointer);
+  friend gboolean close_callback(GtkWidget*, gpointer);
+  friend gboolean draw_callback(GtkWidget*, GdkFrameClock*, gpointer);
+
   bool HandleMouse(GdkEventAny* event);
   bool HandleKeyboard(GdkEventKey* event);
   bool HandleWindowResize(GdkEventConfigure* event);
   bool HandleWindowFocus(GdkEventFocus* event);
   bool HandleWindowVisibility(GdkEventVisibility* event);
   bool HandleWindowOwnerChange(GdkEventOwnerChange* event);
+  bool HandleWindowPaint();
 
   bool closing_ = false;
   bool fullscreen_ = false;
@@ -97,6 +104,7 @@ class GTKMenuItem : public MenuItem {
 
   GtkWidget* handle() { return menu_; }
   using MenuItem::OnSelected;
+  void Activate();
 
   void EnableMenuItem(Window& window) override {}
   void DisableMenuItem(Window& window) override {}

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -707,7 +707,7 @@ bool Win32Window::HandleMouse(UINT message, WPARAM wParam, LPARAM lParam) {
 
 bool Win32Window::HandleKeyboard(UINT message, WPARAM wParam, LPARAM lParam) {
   auto e = KeyEvent(
-      this, VirtualKey(wParam), lParam & 0xFFFF0000, !!(lParam & 0x2),
+      this, VirtualKey(wParam), lParam & 0xFFFF, !!(lParam & 0x400000000),
       !!(GetKeyState(VK_SHIFT) & 0x80), !!(GetKeyState(VK_CONTROL) & 0x80),
       !!(GetKeyState(VK_MENU) & 0x80), !!(GetKeyState(VK_LWIN) & 0x80));
   switch (message) {

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -447,6 +447,7 @@ void Win32Window::Close() {
   closing_ = true;
   OnClose();
   DestroyWindow(hwnd_);
+  hwnd_ = 0;
 }
 
 void Win32Window::OnMainMenuChange() {


### PR DESCRIPTION
- Fix GTK abstractions on linux
- Fix Vulkan init support on linux
- Miscellaneous fixes for linux build/support
- Abstract the keyboard events so that nothing relies on hardcoded windows key codes. 

xenia-ui-window-vulkan-demo compiles and runs. 

xenia-app compiles, runs briefly and crashes with an assert as there is still missing threading functionality, however the GTK window is created correctly.

![xenia-ui-window-vulkan-demo](https://user-images.githubusercontent.com/6045454/34911560-3e8e49a0-f88a-11e7-8419-c8a71b025abf.png)
