### PR TITLE
[Test] Fix build_bin_path for case sensitive FS

### DIFF
--- a/xenia-build
+++ b/xenia-build
@@ -389,7 +389,7 @@ def get_build_bin_path(args):
         platform = 'windows'
     else:
         platform = 'linux'
-    return os.path.join(self_path, 'build', 'bin', platform, args['config'])
+    return os.path.join(self_path, 'build', 'bin', platform.capitalize(), args['config'].capitalize())
 
 
 def discover_commands(subparsers):


### PR DESCRIPTION
Match xenia-build and premake configuration and platform capitalization with
only first letter capitalized in filesystem (Debug, Checked, Released, Linux,
Windows, etc).
Fix xenia-build test command on linux systems.

The issue in question arises because `get_bin()` returns `None` if it cannot find the file in question and it searches for ".../build/bin/linux/debug/xenia-cpu-ppc-tests" instead of ".../build/bin/Linux/Debug/xenia-cpu-ppc-tests'" with capitals on both "Debug" and "Linux"
```
 ./xenia-build test
Testing...

Traceback (most recent call last):
  File "./xenia-build", line 1351, in <module>
    main()
  File "./xenia-build", line 81, in main
    return_code = command.execute(args, pass_args, os.getcwd())
  File "./xenia-build", line 794, in execute
    if not has_bin(test_executable):
  File "./xenia-build", line 149, in has_bin
    bin_path = get_bin(binary)
  File "./xenia-build", line 166, in get_bin
    exe_file = os.path.join(path, binary)
  File "/usr/lib/python3.6/posixpath.py", line 92, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.6/genericpath.py", line 149, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'NoneType
```