### PR TITLE
[UI] Set User Language

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -25,6 +25,8 @@
 #include "xenia/ui/imgui_dialog.h"
 #include "xenia/ui/imgui_drawer.h"
 
+uint32_t userlang = 1; // Default as English
+
 namespace xe {
 namespace app {
 
@@ -35,6 +37,7 @@ using xe::ui::UIEvent;
 using xe::ui::FileDropEvent;
 
 const std::wstring kBaseTitle = L"xenia";
+    std::wstring userlangs = L"[UserLang-English]";
 
 EmulatorWindow::EmulatorWindow(Emulator* emulator)
     : emulator_(emulator),
@@ -226,6 +229,36 @@ bool EmulatorWindow::Initialize() {
   }
   main_menu->AddChild(std::move(gpu_menu));
 
+  // User Language menu
+  auto ulang_menu = MenuItem::Create(MenuItem::Type::kPopup, L"&User Language");
+  {
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&English",
+			  std::bind(&EmulatorWindow::UserlangEnglish, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&Japanese",
+			  std::bind(&EmulatorWindow::UserlangJapanese, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&German",
+			  std::bind(&EmulatorWindow::UserlangGerman, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&French",
+			  std::bind(&EmulatorWindow::UserlangFrench, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&Spanish",
+			  std::bind(&EmulatorWindow::UserlangSpanish, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&Italian",
+			  std::bind(&EmulatorWindow::UserlangItalian, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&Korean",
+			  std::bind(&EmulatorWindow::UserlangKorean, this)));
+	  ulang_menu->AddChild(
+		  MenuItem::Create(MenuItem::Type::kString, L"&Chinese",
+			  std::bind(&EmulatorWindow::UserlangChinese, this)));	  
+  }
+  main_menu->AddChild(std::move(ulang_menu));
+
   // Window menu.
   auto window_menu = MenuItem::Create(MenuItem::Type::kPopup, L"&Window");
   {
@@ -344,6 +377,47 @@ void EmulatorWindow::CpuTimeScalarSetDouble() {
   UpdateTitle();
 }
 
+void EmulatorWindow::UserlangEnglish() {
+	userlang = 1;
+	userlangs = L"/UserLang-English";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangJapanese() {
+	userlang = 2;
+	userlangs = L"/UserLang-Japanese";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangGerman() {
+	userlang = 3;
+	userlangs = L"/UserLang-German";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangFrench() {
+	userlang = 4;
+	userlangs = L"/UserLang-French";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangSpanish() {
+	userlang = 5;
+	userlangs = L"/UserLang-Spanish";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangItalian() {
+	userlang = 6;
+	userlangs = L"/UserLang-Italian";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangKorean() {
+	userlang = 7;
+	userlangs = L"/UserLang-Korean";
+	UpdateTitle();
+}
+void EmulatorWindow::UserlangChinese() {
+	userlang = 8;
+	userlangs = L"/UserLang-Chinese";
+	UpdateTitle();
+}
+
 void EmulatorWindow::CpuBreakIntoDebugger() {
   if (!FLAGS_debug) {
     xe::ui::ImGuiDialog::ShowMessageBox(window_.get(), "Xenia Debugger",
@@ -393,7 +467,8 @@ void EmulatorWindow::UpdateTitle() {
   if (Clock::guest_time_scalar() != 1.0) {
     title += xe::format_string(L" (@%.2fx)", Clock::guest_time_scalar());
   }
-
+    title += userlangs;
+    
   window_->set_title(title);
 }
 

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -17,6 +17,7 @@
 #include "xenia/ui/menu_item.h"
 #include "xenia/ui/window.h"
 #include "xenia/xbox.h"
+extern uint32_t userlang;
 
 namespace xe {
 class Emulator;
@@ -54,6 +55,14 @@ class EmulatorWindow {
   void GpuTraceFrame();
   void GpuClearCaches();
   void ShowHelpWebsite();
+  void UserlangEnglish();  
+  void UserlangJapanese();
+  void UserlangGerman();
+  void UserlangFrench();
+  void UserlangSpanish();
+  void UserlangItalian();
+  void UserlangKorean();
+  void UserlangChinese();
 
   Emulator* emulator_;
   std::unique_ptr<ui::Loop> loop_;

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
@@ -15,6 +15,7 @@
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/util/xex2.h"
 #include "xenia/kernel/xboxkrnl/xboxkrnl_private.h"
+#include "xenia/app/emulator_window.h" // for user language UI
 
 namespace xe {
 namespace kernel {
@@ -58,7 +59,7 @@ X_STATUS xeExGetXConfigSetting(uint16_t category, uint16_t setting,
           break;
         case 0x0009:  // XCONFIG_USER_LANGUAGE
           setting_size = 4;
-          value = 0x00000001;  // English
+          value = userlang;  // 1 - English as default
           break;
         case 0x000A:  // XCONFIG_USER_VIDEO_FLAGS
           setting_size = 4;


### PR DESCRIPTION
Works at English as default, but can choose any language from list (works for multi-lingual games, example Sonic 2006)
![xenia_ui_features_snapshot](https://user-images.githubusercontent.com/19775644/37877335-59078962-3062-11e8-89ca-b12bf139ee74.jpg)
