### PR TITLE
Actually fix building.md

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -9,11 +9,11 @@ video drivers for your card.
 ### Windows
 
 * Windows 8 or later
-* Visual Studio 2015 or Visual Studio 2017
-* [Python 2.7](https://www.python.org/downloads/release/python-2713/)
-* If you are on Windows 8, you will also need the [Windows 8.1 SDK](http://msdn.microsoft.com/en-us/windows/desktop/bg162891)
+* Visual Studio 2015 or Visual Studio 2017 (for VS2017 you will need the Windows Universal CRT SDK)
+* [Python 3.4+](https://www.python.org/downloads/)
+* You will also need the [Windows 8.1 SDK](http://msdn.microsoft.com/en-us/windows/desktop/bg162891)(for VS2017 just click the Windows 8.1 SDK option in the Individual Components section in the Visual Studio Installer)
 
-Ensure Python is in your PATH (`C:\Python27\`).
+Ensure Python is in your PATH.
 
 I recommend using [Cmder](http://cmder.net/) for git and command
 line usage.

--- a/docs/building.md
+++ b/docs/building.md
@@ -9,9 +9,11 @@ video drivers for your card.
 ### Windows
 
 * Windows 8 or later
-* Visual Studio 2015 or Visual Studio 2017 (for VS2017 you will need the Windows Universal CRT SDK)
+* Visual Studio 2015 or Visual Studio 2017 
+  * (for VS2017 you will need the Windows Universal CRT SDK)
 * [Python 3.4+](https://www.python.org/downloads/)
-* You will also need the [Windows 8.1 SDK](http://msdn.microsoft.com/en-us/windows/desktop/bg162891)(for VS2017 just click the Windows 8.1 SDK option in the Individual Components section in the Visual Studio Installer)
+* You will also need the [Windows 8.1 SDK](http://msdn.microsoft.com/en-us/windows/desktop/bg162891) 
+  * (for VS2017 just click the Windows 8.1 SDK option in the Individual Components section in the Visual Studio Installer)
 
 Ensure Python is in your PATH.
 


### PR DESCRIPTION
VS2015 comes with the Windows Universal CRT SDK by default however VS2017 needs to have it manually added.
The Windows 8.1 SDK is required when building on both Windows 8.X and 10.
Python 3.4+ is now required to run the setup scripts.