### PR TITLE
[CPU] Bring back saturation in D3DCOLOR vpkd3d128

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -626,6 +626,7 @@ static const vec128_t xmm_consts[] = {
     vec128i(0x01000302u, 0x05040706u, 0x09080B0Au, 0x0D0C0F0Eu),
     /* XMMPermuteControl15    */ vec128b(15),
     /* XMMPermuteByteMask     */ vec128b(0x1F),
+    /* XMMPackD3DCOLORSat     */ vec128i(0x404000FFu),
     /* XMMPackD3DCOLOR        */
     vec128i(0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0x0C000408u),
     /* XMMUnpackD3DCOLOR      */

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -64,6 +64,7 @@ enum XmmConst {
   XMMByteOrderMask,
   XMMPermuteControl15,
   XMMPermuteByteMask,
+  XMMPackD3DCOLORSat,
   XMMPackD3DCOLOR,
   XMMUnpackD3DCOLOR,
   XMMPackFLOAT16_2,


### PR DESCRIPTION
Fix for d61aff438923fb81fd875c9a5fb99a2d423e7cf9 that caused tests to fail.