### PR TITLE
[Core] Treat .exe files as XEX

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -228,7 +228,7 @@ X_STATUS Emulator::LaunchPath(std::wstring path) {
   auto extension = path.substr(last_dot);
   std::transform(extension.begin(), extension.end(), extension.begin(),
                  tolower);
-  if (extension == L".xex" || extension == L".elf") {
+  if (extension == L".xex" || extension == L".elf" || extension == L".exe") {
     // Treat as a naked xex file.
     return LaunchXexFile(path);
   } else {


### PR DESCRIPTION
Call of Duty 4 and World at War alphas have .exe files like CoD3SP.exe and CoD3SP_profile.exe alongside default.xex that are actually XEX files.