### PR TITLE
[GPU] Depth bias support

### DIFF
--- a/src/xenia/gpu/vulkan/pipeline_cache.h
+++ b/src/xenia/gpu/vulkan/pipeline_cache.h
@@ -228,6 +228,7 @@ class PipelineCache {
     uint32_t pa_sc_screen_scissor_tl;
     uint32_t pa_sc_screen_scissor_br;
     uint32_t pa_sc_viz_query;
+    uint32_t pa_su_poly_offset_enable;
     uint32_t multi_prim_ib_reset_index;
 
     UpdateRasterizationStateRegisters() { Reset(); }
@@ -275,6 +276,9 @@ class PipelineCache {
 
     uint32_t rb_surface_info;
     uint32_t pa_su_sc_vtx_cntl;
+    // Bias is in Vulkan units because depth format may potentially effect it.
+    float pa_su_poly_offset_scale;
+    float pa_su_poly_offset_offset;
     uint32_t pa_cl_vte_cntl;
     float pa_cl_vport_xoffset;
     float pa_cl_vport_yoffset;


### PR DESCRIPTION
Fixes Z fighting of decals in various games including the Call of Duty series, and possibly shadow acne in some games also.

Since the registers contain offset values for both polygon sides, the actual value is chosen based on the culled side (if none are culled, then choosing the side that has any offset, if both have, using the front). However, I doubt different values for different sides are even exposed via D3D at all, but who knows what games do.

I'm not sure what we should prefer — enable depth offset in all Vulkan pipelines, or toggle based on the actual state. However, it's usually enabled for a small portion of drawn surfaces, and those surfaces already have their own pipelines generally, so I think the second option, implemented here, is better.