### PR TITLE
Persist title-specific profile content

### DIFF
--- a/src/xenia/kernel/xam/content_manager.cc
+++ b/src/xenia/kernel/xam/content_manager.cc
@@ -23,6 +23,8 @@ namespace xam {
 
 static const wchar_t* kThumbnailFileName = L"__thumbnail.png";
 
+static const wchar_t* kGameUserContentDirName = L"profile";
+
 static int content_device_id_ = 0;
 
 ContentPackage::ContentPackage(KernelState* kernel_state, std::string root_name,
@@ -250,6 +252,20 @@ X_RESULT ContentManager::DeleteContent(const XCONTENT_DATA& data) {
   } else {
     return X_ERROR_FILE_NOT_FOUND;
   }
+}
+
+std::wstring ContentManager::ResolveGameUserContentPath() {
+  wchar_t title_id[9] = L"00000000";
+  std::swprintf(title_id, 9, L"%.8X", kernel_state_->title_id());
+  auto user_name = xe::to_wstring(kernel_state_->user_profile()->name());
+
+  // Per-game per-profile data location:
+  // content_root/title_id/profile/user_name
+  auto package_root = xe::join_paths(
+      root_path_,
+      xe::join_paths(title_id,
+                     xe::join_paths(kGameUserContentDirName, user_name)));
+  return package_root + xe::kWPathSeparator;
 }
 
 }  // namespace xam

--- a/src/xenia/kernel/xam/content_manager.h
+++ b/src/xenia/kernel/xam/content_manager.h
@@ -84,6 +84,7 @@ class ContentManager {
   X_RESULT SetContentThumbnail(const XCONTENT_DATA& data,
                                std::vector<uint8_t> buffer);
   X_RESULT DeleteContent(const XCONTENT_DATA& data);
+  std::wstring ResolveGameUserContentPath();
 
  private:
   std::wstring ResolvePackageRoot(uint32_t content_type);

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -7,6 +7,10 @@
  ******************************************************************************
  */
 
+#include <sstream>
+
+#include "xenia/kernel/kernel_state.h"
+#include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/user_profile.h"
 
 namespace xe {
@@ -87,6 +91,10 @@ void UserProfile::AddSetting(std::unique_ptr<Setting> setting) {
   Setting* previous_setting = setting.get();
   std::swap(settings_[setting->setting_id], previous_setting);
 
+  if (setting->is_set && setting->is_title_specific()) {
+    SaveSetting(setting.get());
+  }
+
   if (previous_setting) {
     // replace: swap out the old setting from the owning list
     for (auto vec_it = setting_list_.begin(); vec_it != setting_list_.end();
@@ -107,7 +115,58 @@ UserProfile::Setting* UserProfile::GetSetting(uint32_t setting_id) {
   if (it == settings_.end()) {
     return nullptr;
   }
-  return it->second;
+  UserProfile::Setting* setting = it->second;
+  if (setting->is_title_specific()) {
+    // If what we have loaded in memory isn't for the title that is running
+    // right now, then load it from disk.
+    if (kernel_state()->title_id() != setting->loaded_title_id) {
+      LoadSetting(setting);
+    }
+  }
+  return setting;
+}
+
+void UserProfile::LoadSetting(UserProfile::Setting* setting) {
+  if (setting->is_title_specific()) {
+    auto content_dir =
+        kernel_state()->content_manager()->ResolveGameUserContentPath();
+    auto setting_id = xe::format_string(L"%.8X", setting->setting_id);
+    auto file_path = xe::join_paths(content_dir, setting_id);
+    auto file = xe::filesystem::OpenFile(file_path, "rb");
+    if (file) {
+      fseek(file, 0, SEEK_END);
+      uint32_t input_file_size = static_cast<uint32_t>(ftell(file));
+      fseek(file, 0, SEEK_SET);
+
+      std::vector<uint8_t> serialized_data(input_file_size);
+      fread(serialized_data.data(), 1, serialized_data.size(), file);
+      fclose(file);
+      setting->Deserialize(serialized_data);
+      setting->loaded_title_id = kernel_state()->title_id();
+    }
+  } else {
+    // Unsupported for now.  Other settings aren't per-game and need to be
+    // stored some other way.
+    XELOGW("Attempting to load unsupported profile setting from disk");
+  }
+}
+
+void UserProfile::SaveSetting(UserProfile::Setting* setting) {
+  if (setting->is_title_specific()) {
+    auto serialized_setting = setting->Serialize();
+    auto content_dir =
+        kernel_state()->content_manager()->ResolveGameUserContentPath();
+    xe::filesystem::CreateFolder(content_dir);
+    auto setting_id = xe::format_string(L"%.8X", setting->setting_id);
+    auto file_path = xe::join_paths(content_dir, setting_id);
+    auto file = xe::filesystem::OpenFile(file_path, "wb");
+    fwrite(serialized_setting.data(), 1, serialized_setting.size(), file);
+    fclose(file);
+  } else {
+    // Unsupported for now.  Other settings aren't per-game and need to be
+    // stored some other way.
+    XELOGW("Attempting to save unsupported profile setting to disk");
+  }
 }
 
 }  // namespace xam

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -290,6 +290,7 @@ dword_result_t XamUserWriteProfileSettings(
         static_cast<xam::UserProfile::Setting::Type>(settings_data.type);
 
     switch (settingType) {
+      case UserProfile::Setting::Type::CONTENT:
       case UserProfile::Setting::Type::BINARY: {
         uint8_t* settings_data_ptr = kernel_state()->memory()->TranslateVirtual(
             settings_data.binary.ptr);


### PR DESCRIPTION
Save and load title-specific profile content to disk in the content folder for that title.  Allows saving settings for many games and saving games for games that store saved games there, such as BattleBlock Theater.