### PR TITLE
[GPU] Fix cubemap sampling

### DIFF
--- a/src/xenia/gpu/glsl_shader_translator.cc
+++ b/src/xenia/gpu/glsl_shader_translator.cc
@@ -149,6 +149,7 @@ struct VertexData {
   +rz          GL_TEXTURE_CUBE_MAP_POSITIVE_Z_EXT=4   +rx    -ry   rz
   -rz          GL_TEXTURE_CUBE_MAP_NEGATIVE_Z_EXT=5   -rx    -ry   rz
   */
+  // FIXME(Triang3l): This is totally incorrect - fixed in SPIR-V but not here!
   EmitSource(R"(
 vec4 cube(vec4 src0, vec4 src1) {
   vec3 src = vec3(src1.y, src1.x, src1.z);

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -87,9 +87,12 @@ class SpirvShaderTranslator : public ShaderTranslator {
 
  private:
   spv::Function* CreateCubeFunction();
+  spv::Function* CreateCubeUndoFunction();
 
   void ProcessVectorAluInstruction(const ParsedAluInstruction& instr);
   void ProcessScalarAluInstruction(const ParsedAluInstruction& instr);
+
+  spv::Id ConvertTextureCoordinates(spv::Id src, TextureDimension dimension);
 
   spv::Id BitfieldExtract(spv::Id result_type, spv::Id base, bool is_signed,
                           uint32_t offset, uint32_t count);
@@ -130,6 +133,7 @@ class SpirvShaderTranslator : public ShaderTranslator {
   // Generated function
   spv::Function* translated_main_ = nullptr;
   spv::Function* cube_function_ = nullptr;
+  spv::Function* cube_undo_function_ = nullptr;
 
   // Types.
   spv::Id float_type_ = 0, bool_type_ = 0, int_type_ = 0, uint_type_ = 0;


### PR DESCRIPTION
`tfetchCube` doesn't actually sample a cubemap by its 3D coordinates on the Xbox 360, instead, the fetch is split into four instructions: `cube`, normalizing the texture coordinates on the side via `rcp` and `mad`, and `tfetchCube` that samples the texture like a 2D array texture.

The behavior of `cube` has also been changed to make cubemaps with the clamp wrap mode work — tested on skies in Call of Duty 4, also removed the division from `cube` as it's done by the `rcp` and `mad` that follow `cube`. Also changed greater-than comparisons to greater-or-equal so if the three coordinates are exactly the same, the result won't be undefined.