### PR TITLE
[GPU] Add texture signedness enumeration

### DIFF
--- a/src/xenia/gpu/xenos.h
+++ b/src/xenia/gpu/xenos.h
@@ -63,6 +63,17 @@ enum class ClampMode : uint32_t {
   kMirrorClampToBorder = 7,
 };
 
+// TEX_FORMAT_COMP, known as GPUSIGN on the Xbox 360.
+enum class TextureSign : uint32_t {
+  kUnsigned = 0,
+  // Two's complement texture data.
+  kSigned = 1,
+  // 2*color-1 - http://xboxforums.create.msdn.com/forums/t/107374.aspx
+  kUnsignedBiased = 2,
+  // Linearized when sampled.
+  kGamma = 3,
+};
+
 enum class TextureFilter : uint32_t {
   kPoint = 0,
   kLinear = 1,


### PR DESCRIPTION
A small documentation update — actually handling those would be much more complicated. Adds the possible values of sign_x/y/z/w in texture fetch constants.

`UnsignedBiased` should be very easy to handle in shaders, `Gamma` can be handled in shaders too, but `Signed` would require two image descriptors to be bound and sampled — one for the UNORM/UINT view of the texture and another for the SNORM/SINT one — because there are formats like `D3DFMT_X8L8V8U8` that contain both signed and unsigned data.