### PR TITLE
[Kernel] Fixes for _snwprintf and xmp_app

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
@@ -925,7 +925,7 @@ SHIM_CALL _snwprintf_shim(PPCContext* ppc_context, KernelState* kernel_state) {
   StackArgList args(ppc_context, 3);
   WideStringFormatData data(format);
 
-  int32_t count = format_core(ppc_context, data, args, false);
+  int32_t count = format_core(ppc_context, data, args, true);
   if (count < 0) {
     if (buffer_count > 0) {
       buffer[0] = '\0';  // write a null, just to be safe


### PR DESCRIPTION
This fixes _snwprintf not having format_core's wide param as true, without this dash.xex was failing to create proper locator strings, but with the fix the strings were being made fine, so I think this is how _snwprintf was meant to work. It might still be worth checking any other titles that use it though.

Also adds some null pointer checks to the handlers inside xmp_app.cc, 1888 dash.xex was calling them without the pointers being set which resulted in a crash, this could be due to 1888 dash/xam using different XMP structs.. hopefully not, but for now this stops the crashing at least.