### PR TITLE
[CPU] Fix XexModule::FindSaveRest not finding functions properly

### DIFF
--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -67,7 +67,7 @@ class XexModule : public xe::cpu::Module {
       desc.value =
           xe::byte_swap(xex_security_info()->page_descriptors[i].value);
 
-      total_size += desc.size * heap->page_size();
+      total_size += desc.page_count * heap->page_size();
     }
     return total_size;
   }

--- a/src/xenia/kernel/user_module.cc
+++ b/src/xenia/kernel/user_module.cc
@@ -679,12 +679,13 @@ void UserModule::Dump() {
     const uint32_t page_size =
         xex_module()->base_address() < 0x90000000 ? 64 * 1024 : 4 * 1024;
     uint32_t start_address = xex_module()->base_address() + (page * page_size);
-    uint32_t end_address = start_address + (page_descriptor.size * page_size);
+    uint32_t end_address =
+        start_address + (page_descriptor.page_count * page_size);
 
     sb.AppendFormat("  %3u %s %3u pages    %.8X - %.8X (%d bytes)\n", page,
-                    type, page_descriptor.size, start_address, end_address,
-                    page_descriptor.size * page_size);
-    page += page_descriptor.size;
+                    type, page_descriptor.page_count, start_address,
+                    end_address, page_descriptor.page_count * page_size);
+    page += page_descriptor.page_count;
   }
 
   // Print out imports.

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -514,8 +514,8 @@ struct xex2_header {
 struct xex2_page_descriptor {
   union {
     struct {
-      uint32_t info : 4;
-      uint32_t size : 28;
+      xex2_section_type info : 4;
+      uint32_t page_count : 28;
     };
     xe::be<uint32_t> value;  // 0x0
   };


### PR DESCRIPTION
Oops - forgot to byteswap the xex2_page_descriptor struct when it's used in FindSaveRest, this was causing it to not find any save/rest functions, which would make Skate 3 crash on boot, and ODST crash before the menu is shown. (both worked fine pre-xexp merge)

Also fixed up the xex2_page_descriptor struct to be more descriptive (which is why other files had to be modified besides just xex_module.cc)

Tested Skate 3 with the fix and it now loads up fine, ODST seems to load to the menu now too (but since it doesn't draw anything in VK I could only tell by the sound)