### PR TITLE
[CPU] Fix some compressed XEXs trying to decompress past the actual image size, causing errors

### DIFF
--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -831,7 +831,6 @@ int XexModule::ReadImageCompressed(const void* xex_addr, size_t xex_length) {
   uint8_t* compress_buffer = NULL;
   const uint8_t* p = NULL;
   uint8_t* d = NULL;
-  uint32_t uncompressed_size = 0;
   sha1::SHA1 s;
 
   // Decrypt (if needed).
@@ -895,8 +894,6 @@ int XexModule::ReadImageCompressed(const void* xex_addr, size_t xex_length) {
       memcpy(d, p, chunk_size);
       p += chunk_size;
       d += chunk_size;
-
-      uncompressed_size += 0x8000;
     }
 
     p = pnext;
@@ -904,6 +901,8 @@ int XexModule::ReadImageCompressed(const void* xex_addr, size_t xex_length) {
   }
 
   if (!result_code) {
+    uint32_t uncompressed_size = image_size();
+
     // Allocate in-place the XEX memory.
     bool alloc_result =
         memory()


### PR DESCRIPTION
The recent XexModule code I committed uses a guessed size for the decompressed image, and passes that guessed size to the LZX decompressor, but the older xex2.cc code would use a calculated size based on the XEX sections for the actual LZX decompression, and only used the guessed size to allocate enough memory for it (and since the guessed size was always bigger than the calculated size this worked out fine)

This PR changes XexModule to use the calculated size for both instead, this fixes problems with some compressed XEX's that would have a larger guessed-size than the actual calculated size, which when passed to the LZX decompressor would make it throw an error when it was expecting more compressed data than was available...

All the compressed XEX's I've tested with it now work fine again (eg. 1888's dash.xex, which failed to load prior to this fix)
I think using XEX sections to calculate the decompressed size rather than guessing it is probably the most proper way, so I don't think any officially-released XEXs should have problems with this code.