### PR TITLE
[Kernel] Remove item limit from enumerators, fixes #1255

### DIFF
--- a/src/xenia/kernel/xenumerator.cc
+++ b/src/xenia/kernel/xenumerator.cc
@@ -12,10 +12,10 @@
 namespace xe {
 namespace kernel {
 
-XEnumerator::XEnumerator(KernelState* kernel_state, size_t item_capacity,
+XEnumerator::XEnumerator(KernelState* kernel_state, size_t items_per_enumerate,
                          size_t item_size)
     : XObject(kernel_state, kTypeEnumerator),
-      item_capacity_(item_capacity),
+      items_per_enumerate_(items_per_enumerate),
       item_size_(item_size) {}
 
 XEnumerator::~XEnumerator() = default;

--- a/src/xenia/kernel/xenumerator.h
+++ b/src/xenia/kernel/xenumerator.h
@@ -23,7 +23,7 @@ class XEnumerator : public XObject {
  public:
   static const Type kType = kTypeEnumerator;
 
-  XEnumerator(KernelState* kernel_state, size_t item_capacity,
+  XEnumerator(KernelState* kernel_state, size_t items_per_enumerate,
               size_t item_size);
   virtual ~XEnumerator();
 
@@ -34,30 +34,28 @@ class XEnumerator : public XObject {
   virtual bool WriteItem(uint8_t* buffer) = 0;
 
   size_t item_size() const { return item_size_; }
+  size_t items_per_enumerate() const { return items_per_enumerate_; }
   size_t current_item() const { return current_item_; }
 
  protected:
-  size_t item_capacity_ = 0;
+  size_t items_per_enumerate_ = 0;
   size_t item_size_ = 0;
   size_t current_item_ = 0;
 };
 
 class XStaticEnumerator : public XEnumerator {
  public:
-  XStaticEnumerator(KernelState* kernel_state, size_t item_capacity,
+  XStaticEnumerator(KernelState* kernel_state, size_t items_per_enumerate,
                     size_t item_size)
-      : XEnumerator(kernel_state, item_capacity, item_size), item_count_(0) {
-    buffer_.resize(item_capacity_ * item_size_);
-  }
+      : XEnumerator(kernel_state, items_per_enumerate, item_size),
+        item_count_(0) {}
 
   uint32_t item_count() const override { return item_count_; }
 
   uint8_t* AppendItem() {
-    if (item_count_ + 1 > item_capacity_) {
-      return nullptr;
-    }
-    auto ptr = const_cast<uint8_t*>(buffer_.data() + item_count_ * item_size_);
-    ++item_count_;
+    buffer_.resize(++item_count_ * item_size_);
+    auto ptr =
+        const_cast<uint8_t*>(buffer_.data() + (item_count_ - 1) * item_size_);
     return ptr;
   }
 


### PR DESCRIPTION
Like said in #1255, it seems the limit passed to XamContentCreateEnumerator is actually a limit on how many results XamEnumerate should return per call, not a limit on the number of enumeration items in total.

These changes will fix Sonic Unleashed not loading more than 1 DLC (it passes 1 as the limit, but then loops over XamEnumerate to load in each DLC one at a time), and likely many other games.

Other enumerators like XamContentCreateDeviceEnumerator also seem to work the same way on 360, so hopefully they should also work fine once added to Xenia.