### PR TITLE
don't dereference null pointers in SetThreadName

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_debug.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_debug.cc
@@ -42,6 +42,12 @@ void RtlRaiseException(pointer_t<X_EXCEPTION_RECORD> record) {
         reinterpret_cast<X_THREADNAME_INFO*>(&record->exception_information[0]);
 
     assert_true(thread_info->type == 0x1000);
+
+    if (!thread_info->name_ptr) {
+      XELOGD("SetThreadName called with null name_ptr");
+      return;
+    }
+
     auto name =
         kernel_memory()->TranslateVirtual<const char*>(thread_info->name_ptr);
 


### PR DESCRIPTION
Some games pass nullptrs in to SetThreadName, causing crashes. Dark Souls 2 goes from crashing on startup to ingame with this change.