### PR TITLE
Fix Linux Build Errors By Adding Virtual Destructors to Abstract Classes

### DIFF
--- a/src/xenia/cpu/stack_walker.h
+++ b/src/xenia/cpu/stack_walker.h
@@ -92,6 +92,8 @@ class StackWalker {
   // populated.
   virtual bool ResolveStack(uint64_t* frame_host_pcs, StackFrame* frames,
                             size_t frame_count) = 0;
+
+  virtual ~StackWalker() = default;
 };
 
 }  // namespace cpu

--- a/src/xenia/kernel/xam/app_manager.h
+++ b/src/xenia/kernel/xam/app_manager.h
@@ -35,6 +35,8 @@ class App {
   virtual X_RESULT DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
                                        uint32_t buffer_length) = 0;
 
+  virtual ~App() = default;
+
  protected:
   App(KernelState* kernel_state, uint32_t app_id);
 


### PR DESCRIPTION
Made xe::kernel::App and xe::cpu::StackWalker destructors virtual, since they are abstract classes.
This fixes build the following build errors on Linux:
```
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unique_ptr.h:78:2: error: delete called on
      'xe::kernel::xam::App' that is abstract but has non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unique_ptr.h:78:2: error: delete called on
      'xe::cpu::StackWalker' that is abstract but has non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^ 
```