### PR TITLE
Make sure the audio system is initialized when starting a file from the command line

### DIFF
--- a/src/xenia/apu/xaudio2/xaudio2_audio_driver.cc
+++ b/src/xenia/apu/xaudio2/xaudio2_audio_driver.cc
@@ -110,6 +110,10 @@ bool XAudio2AudioDriver::Initialize() {
   config.LogFileline = TRUE;
   audio_->SetDebugConfiguration(&config);
 
+  // Make sure the audio is initilized
+  hr = audio_->StartEngine();
+  CoInitialize(nullptr);
+
   hr = audio_->CreateMasteringVoice(&mastering_voice_);
   if (FAILED(hr)) {
     XELOGE("CreateMasteringVoice failed with %.8X", hr);


### PR DESCRIPTION
When calling CreateMasteringVoice in xaudio2, this can crash when the windows comsystem is not initialized.

This will always happen when a game file is passed as an command parameter to the emulator.

Calling CoInitialize fixes this behaviour.