### PR TITLE
[Base] Remove hacky fix for missing codecvt on linux

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -154,7 +154,7 @@ int xenia_main(const std::vector<std::wstring>& args) {
 #if defined(XE_PLATFORM_WIN32)
       content_root = xe::join_paths(content_root, L"Xenia");
 #elif defined(XE_PLATFORM_LINUX)
-      content_root = xe::join_paths(content_root, L".xenia");
+      content_root = xe::join_paths(content_root, L"Xenia");
 #else
 #warning Unhandled platform for content root.
       content_root = xe::join_paths(content_root, L"Xenia");

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -12,29 +12,58 @@
 #include "xenia/base/logging.h"
 #include "xenia/base/string.h"
 
+#include <assert.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <ftw.h>
+#include <libgen.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <iostream>
 
 namespace xe {
 namespace filesystem {
 
 std::wstring GetExecutablePath() {
-  assert_always();  // IMPLEMENT ME.
-  return std::wstring();
+  char buff[FILENAME_MAX] = "";
+  readlink("/proc/self/exe", buff, FILENAME_MAX);
+  std::string s(buff);
+  return to_wstring(s);
 }
 
 std::wstring GetExecutableFolder() {
-  assert_always();  // IMPLEMENT ME.
-  return std::wstring();
+  auto path = GetExecutablePath();
+  return xe::find_base_path(path);
 }
 
 std::wstring GetUserFolder() {
-  assert_always();  // IMPLEMENT ME.
-  return std::wstring();
+  // get preferred data home
+  char* dataHome = std::getenv("XDG_DATA_HOME");
+
+  // if XDG_DATA_HOME not set, fallback to HOME directory
+  if (dataHome == NULL) {
+    dataHome = std::getenv("HOME");
+  } else {
+    std::string home(dataHome);
+    return to_wstring(home);
+  }
+
+  // if HOME not set, fall back to this
+  if (dataHome == NULL) {
+    struct passwd pw1;
+    struct passwd* pw;
+    char buf[4096];  // could potentionally lower this
+    getpwuid_r(getuid(), &pw1, buf, sizeof(buf), &pw);
+    assert(&pw1 == pw);  // sanity check
+    dataHome = pw->pw_dir;
+  }
+
+  std::string home(dataHome);
+  return to_wstring(home + "/.local/share");
 }
 
 bool PathExists(const std::wstring& path) {

--- a/src/xenia/base/string.cc
+++ b/src/xenia/base/string.cc
@@ -9,12 +9,28 @@
 
 #include "xenia/base/string.h"
 
-// TODO(benvanik): when GCC finally gets codecvt, use that.
-#if XE_PLATFORM_LINUX
+// codecvt existence check
+#ifdef __clang__
+// using clang
+#if (__clang_major__ < 4)  // 3.3 has it but I think we need at least 4 anyway
+// insufficient clang version
 #define NO_CODECVT 1
 #else
 #include <codecvt>
-#endif  // XE_PLATFORM_LINUX
+#endif
+#elif defined(__GNUC__) || defined(__GNUG__)
+// using gcc
+#if (__GNUC__ < 5)
+// insufficient clang version
+#define NO_CODECVT 1
+#else
+#include <codecvt>
+#endif
+#elif defined( \
+    _MSC_VER)  // since the windows 10 sdk is required, this shouldn't be an
+// issue
+#include <codecvt>
+#endif
 
 #include <cctype>
 #include <cstring>

--- a/src/xenia/base/string.cc
+++ b/src/xenia/base/string.cc
@@ -26,9 +26,8 @@
 #else
 #include <codecvt>
 #endif
-#elif defined( \
-    _MSC_VER)  // since the windows 10 sdk is required, this shouldn't be an
-// issue
+// since the windows 10 sdk is required, this shouldn't be an issue
+#elif defined(_MSC_VER)
 #include <codecvt>
 #endif
 


### PR DESCRIPTION
per #399 , these lines were only required because codecvt was missing in GCC. That has since been fixed per https://stackoverflow.com/questions/15615136/is-codecvt-not-a-std-header 