### PR TITLE
Add debug symbols when building Debug on linux

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -68,6 +68,11 @@ filter({"configurations:Debug", "platforms:Windows"})
     "/NODEFAULTLIB:MSVCRTD",
   })
 
+filter({"configurations:Debug", "platforms:Linux"})
+  buildoptions({
+    "-g",
+  })
+
 filter("configurations:Release")
   runtime("Release")
   defines({


### PR DESCRIPTION
The premake config doesn't include the debug symbols on linux in the debug config this adds them.

Commit cherry-picked from #1076.