### PR TITLE
Add a check to see if divisor is -1 in integer division

### DIFF
--- a/src/xenia/cpu/testing/div_test.cc
+++ b/src/xenia/cpu/testing/div_test.cc
@@ -1,0 +1,170 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2014 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/cpu/testing/util.h"
+
+#include <cfloat>
+
+using namespace xe::cpu::hir;
+using namespace xe::cpu;
+using namespace xe::cpu::testing;
+using xe::cpu::ppc::PPCContext;
+
+TEST_CASE("DIV_I8", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreGPR(b, 3,
+             b.ZeroExtend(b.Div(b.Truncate(LoadGPR(b, 4), INT8_TYPE),
+                                b.Truncate(LoadGPR(b, 5), INT8_TYPE)),
+                          INT64_TYPE));
+    b.Return();
+  });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = INT8_MIN;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 0);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 15;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 15 / -1);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 30;
+        ctx->r[5] = 7;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 30 / 7);
+      });
+}
+
+TEST_CASE("DIV_I16", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreGPR(b, 3,
+             b.ZeroExtend(b.Div(b.Truncate(LoadGPR(b, 4), INT16_TYPE),
+                                b.Truncate(LoadGPR(b, 5), INT16_TYPE)),
+                          INT64_TYPE));
+    b.Return();
+  });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = INT16_MIN;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int16_t>(ctx->r[3]);
+        REQUIRE(result == 0);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 15;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 15 / -1);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 30;
+        ctx->r[5] = 7;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 30 / 7);
+      });
+}
+
+TEST_CASE("DIV_I32", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreGPR(b, 3,
+             b.ZeroExtend(b.Div(b.Truncate(LoadGPR(b, 4), INT32_TYPE),
+                                b.Truncate(LoadGPR(b, 5), INT32_TYPE)),
+                          INT64_TYPE));
+    b.Return();
+  });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = INT32_MIN;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int32_t>(ctx->r[3]);
+        REQUIRE(result == 0);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 15;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 15 / -1);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 30;
+        ctx->r[5] = 7;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 30 / 7);
+      });
+}
+
+TEST_CASE("DIV_I64", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreGPR(b, 3, b.Div(LoadGPR(b, 4), LoadGPR(b, 5)));
+    b.Return();
+  });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = INT64_MIN;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = ctx->r[3];
+        REQUIRE(result == 0);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 15;
+        ctx->r[5] = -1;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 15 / -1);
+      });
+
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->r[4] = 30;
+        ctx->r[5] = 7;
+      },
+      [](PPCContext* ctx) {
+        auto result = static_cast<int8_t>(ctx->r[3]);
+        REQUIRE(result == 30 / 7);
+      });
+}


### PR DESCRIPTION
Resolve #1085

1) In that case use neg on the register containing the dividend.

This avoids an x86 CPU exception when dividend is INT_MIN or similar and
divisor is -1

The result will be wrong in that last case and still equal to INT_MIN as
the true result == INT_MAX + 1 would require an additional bit to store

For PPC, the behavior is apparently undefined in that case, so hopefully
x360 game devs were not relying on such values

2) Code now returns 0 to comply with results from RPCS3 when encountering
INT_MIN / -1 case

3) Corrected code after testing with cpu-tests.

Oddity with Xbyak handling of imm: in source code, imm have to be 32 bits
when using 16 bits registers (potential bug in opRM_I ) for the cmp op.

64 bits imm are not usable with cmp (see intel ref manual), used intermediate register
for DIV_I64

Stopped using CodeGenerator:T_SHORT, as default T_AUTO already tries to use
T_SHORT

4) Code clean-up based on better understanding of Xbyak