### PR TITLE
Flush the logger before exiting on a fatal error

### DIFF
--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -325,7 +325,7 @@ void FatalError(const char* fmt, ...) {
                 MB_OK | MB_ICONERROR | MB_APPLMODAL | MB_SETFOREGROUND);
   }
 #endif  // WIN32
-
+  ShutdownLogging();
   exit(1);
 }
 


### PR DESCRIPTION
We manually call the logger destructor when a fatal error occurs, this fixes the error not showing up in the log file when a fatal error is triggered