### PR TITLE
[xenia-build] Make vswhere.exe output in UTF-8

### DIFF
--- a/xenia-build
+++ b/xenia-build
@@ -96,7 +96,7 @@ def import_vs_environment():
     install_path = None
     env_tool_args = None
 
-    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -format json', shell=False, universal_newlines=True)
+    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -format json -utf8', shell=False, universal_newlines=True)
     if vswhere:
         vswhere = json.loads(vswhere)
     if vswhere and len(vswhere) > 0:


### PR DESCRIPTION
This PR modifies xenia-build to pass an additional `-utf8` parameter to `vswhere.exe`. This fixes `xb` command on systems where a JSON file procuded by this tool contains regional characters. Well formed JSON files are supposed to be in UTF-8, and on top of that Python also expects encoding to be UTF-8, it seems.

This fixes my particular case, where `"description"` field contained strings in Polish (even though both my Windows and VS are in English...) and regional diacritics could not be parsed:

```
H:\dev\emulators\xenia>xb setup
Traceback (most recent call last):
  File "xenia-build", line 1366, in <module>
    main()
  File "xenia-build", line 47, in main
    vs_version = import_vs_environment()
  File "xenia-build", line 99, in import_vs_environment
    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -format json', shell=False, universal_newlines=True)
  File "C:\Users\X\AppData\Local\Programs\Python\Python36\lib\subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "C:\Users\X\AppData\Local\Programs\Python\Python36\lib\subprocess.py", line 405, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "C:\Users\X\AppData\Local\Programs\Python\Python36\lib\subprocess.py", line 830, in communicate
    stdout = self.stdout.read()
  File "C:\Users\X\AppData\Local\Programs\Python\Python36\lib\encodings\cp1250.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x88 in position 673: character maps to <undefined>
```

Reference for `vswhere.exe` behaviour with and without this switch:
https://github.com/Microsoft/vswhere/wiki/Encoding