### PR TITLE
[Part 2] Update and move documentation from website to GitHub Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 <h1 align="center">Xenia - Xbox 360 Emulator</h1>
 
 Xenia is an experimental emulator for the Xbox 360. For more information, see the
-[main xenia website](https://xenia.jp/).
+[main Xenia wiki](https://github.com/xenia-project/xenia/wiki).
 
 **Interested in supporting the core contributors?** Visit
 [Xenia Project on Patreon](https://www.patreon.com/xenia_project).
 
 Come chat with us about **emulator-related topics** on [Discord](https://discord.gg/Q9mxZf9).
 For developer chat join `#dev` but stay on topic. Lurking is not only fine, but encouraged!
-Please check the [frequently asked questions](https://xenia.jp/faq/) page before
-asking questions. We've got jobs/lives/etc, so don't expect instant answers.
+Please check the [FAQ](https://github.com/xenia-project/xenia/wiki/FAQ) page before asking questions.
+We've got jobs/lives/etc, so don't expect instant answers.
 
 Discussing illegal activities will get you banned.
 
@@ -41,29 +41,7 @@ legally purchased devices and games and information made public on the internet
 
 ## Quickstart
 
-With Windows 8+, Python 3.4+, and [Visual Studio 2017 or 2019](https://www.visualstudio.com/downloads/) and the Windows SDKs installed:
-
-    > git clone https://github.com/xenia-project/xenia.git
-    > cd xenia
-    > xb setup
-
-    # Pull latest changes, rebase, and update submodules and premake:
-    > xb pull
-
-    # Build on command line:
-    > xb build
-
-    # Run premake and open Visual Studio (run the 'xenia-app' project):
-    > xb devenv
-
-    # Run premake to update the sln/vcproj's:
-    > xb premake
-
-    # Format code to the style guide:
-    > xb format
-
-When fetching updates use `xb pull` to automatically fetch everything and
-run premake for project files/etc.
+See the [Quickstart](https://github.com/xenia-project/xenia/wiki/Quickstart) page.
 
 ## Building
 
@@ -91,8 +69,4 @@ something.
 
 ## FAQ
 
-For more see the main [frequently asked questions](https://xenia.jp/faq/) page.
-
-### Can I get an exe?
-
-[Latest master revision at AppVeyor](https://ci.appveyor.com/api/projects/benvanik/xenia/artifacts/xenia-master.zip?branch=master&job=Configuration%3A%20Release&pr=false)
+See the [frequently asked questions](https://github.com/xenia-project/xenia/wiki/FAQ) page.

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,22 +2,73 @@
 
 You must have a 64-bit machine for building and running the project. Always
 run your system updater before building and make sure you have the latest
-video drivers for your card.
+drivers.
 
 ## Setup
 
 ### Windows
 
-* Windows 8 or later
-* [Visual Studio 2017 or Visual Studio 2019](https://www.visualstudio.com/downloads/)
+* Windows 7 or later
+* [Visual Studio 2019 or Visual Studio 2017](https://www.visualstudio.com/downloads/)
 * [Python 3.4+](https://www.python.org/downloads/)
-* You may also need the [Windows 8.1 SDK](https://msdn.microsoft.com/en-us/windows/desktop/bg162891)
-  * (for VS2017 just click the Windows 8.1 SDK option in the Individual Components section in the Visual Studio Installer)
+  * Ensure Python is in PATH.
+* Windows 10 SDK
 
-Ensure Python is in your PATH.
+```
+git clone https://github.com/xenia-project/xenia.git
+cd xenia
+xb setup
 
-I recommend using [Cmder](https://cmder.net/) for git and command
-line usage.
+# Build on command line (add --config=release for release):
+xb build
+
+
+# Pull latest changes, rebase, update submodules, and run premake:
+xb pull
+
+# Run premake and open Visual Studio (run the 'xenia-app' project):
+xb devenv
+
+# Run premake to update the sln/vcproj's:
+xb premake
+
+# Format code to the style guide:
+xb format
+```
+<!--
+# Remove intermediate files and build outputs (doesn't work on Linux):
+xb clean
+
+# Check for lint errors with clang-format:
+xb lint
+
+# Run the style checker on all code:
+xb style
+
+# Remove all build/ output and do a hard git reset:
+xb nuke
+
+# Runs the clang-tidy checker on all code:
+xb tidy
+
+
+## Testing:
+
+# Generate tests:
+xb gentests
+
+# Run tests:
+xb test
+
+# Run GPU tests:
+xb gputest
+
+
+## Other:
+
+# Generate SPIR-V binaries and header files:
+xb genspirv
+-->
 
 #### Debugging
 
@@ -43,8 +94,7 @@ swappable right now.
 [CodeLite](https://codelite.org) is the IDE of choice and `xb premake` will spit
 out files for that. Make also works via `xb build`.
 
-To get the latest Clang on an ubuntu system:
-
+To get the latest Clang on an Ubuntu system:
 ```
 sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
 curl -sSL "http://llvm.org/apt/llvm-snapshot.gpg.key" | sudo -E apt-key add -
@@ -53,39 +103,34 @@ sudo -E apt-get -yq update &>> ~/apt-get-update.log
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-4.0 clang-format-4.0
 ```
 
-You will also need some development libraries. To get them on an ubuntu system:
+You will also need some development libraries. To get them on an Ubuntu system:
 ```
 sudo apt-get install libgtk-3-dev libpthread-stubs0-dev liblz4-dev libglew-dev libx11-dev libvulkan-dev libc++-dev libc++abi-dev
 ```
 
-In addition, you will need the latest OpenGL libraries and drivers for your hardware. Intel and the open source
-drivers are not supported as they do not yet support OpenGL 4.5.
+In addition, you will need the latest Vulkan libraries and drivers for your hardware.
 
 #### Linux NVIDIA Vulkan Drivers
 
 You'll need to install the latest NVIDIA drivers to enable Vulkan support on Linux.
 
 First, remove all existing NVIDIA drivers:
-
 ```
 sudo apt-get purge nvidia*
 ```
 
 Add the graphics-drivers PPA to your system:
-
 ```
 sudo add-apt-repository ppa:graphics-drivers
 sudo apt update
 ```
 
 Install the NVIDIA drivers (newer ones may be released after 387; check online):
-
 ```
 sudo apt install nvidia-387
 ```
 
-Either reboot the computer, or inject the NVIDIA drivers:
-
+Either restart the computer, or inject the NVIDIA drivers:
 ```
 sudo rmmod nouveau
 sudo modprobe nvidia


### PR DESCRIPTION
Part 2 of #1391.

README.md changes:
* Replaces website with wiki link since it's not relevant anymore.
* Make Quickstart into an actual Quickstart and move building+xb instructions to building.md
building.md changes:
* Update/remove outdated information.