### PR TITLE
Linux memory Fixes

### DIFF
--- a/src/xenia/base/memory.h
+++ b/src/xenia/base/memory.h
@@ -101,7 +101,8 @@ typedef void* FileMappingHandle;
 FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
                                           size_t length, PageAccess access,
                                           bool commit);
-void CloseFileMappingHandle(FileMappingHandle handle);
+void CloseFileMappingHandle(FileMappingHandle handle,
+                            const std::filesystem::path& path);
 void* MapFileView(FileMappingHandle handle, void* base_address, size_t length,
                   PageAccess access, size_t file_offset);
 bool UnmapFileView(FileMappingHandle handle, void* base_address, size_t length);

--- a/src/xenia/base/memory_posix.cc
+++ b/src/xenia/base/memory_posix.cc
@@ -88,7 +88,8 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
   }
 
   oflag |= O_CREAT;
-  int ret = shm_open(path.c_str(), oflag, 0777);
+  auto full_path = "/" / path;
+  int ret = shm_open(full_path.c_str(), oflag, 0777);
   if (ret > 0) {
     ftruncate64(ret, length);
   }

--- a/src/xenia/base/memory_posix.cc
+++ b/src/xenia/base/memory_posix.cc
@@ -97,8 +97,10 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
   return ret <= 0 ? nullptr : reinterpret_cast<FileMappingHandle>(ret);
 }
 
-void CloseFileMappingHandle(FileMappingHandle handle) {
-  close(static_cast<int>(reinterpret_cast<int64_t>(handle)));
+void CloseFileMappingHandle(FileMappingHandle handle,
+                            const std::filesystem::path& path) {
+  auto full_path = "/" / path;
+  shm_unlink(full_path.c_str());
 }
 
 void* MapFileView(FileMappingHandle handle, void* base_address, size_t length,

--- a/src/xenia/base/memory_win.cc
+++ b/src/xenia/base/memory_win.cc
@@ -147,9 +147,10 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
                                           bool commit) {
   DWORD protect =
       ToWin32ProtectFlags(access) | (commit ? SEC_COMMIT : SEC_RESERVE);
+  auto full_path = "Local" / path;
   return CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, protect,
                             static_cast<DWORD>(length >> 32),
-                            static_cast<DWORD>(length), path.c_str());
+                            static_cast<DWORD>(length), full_path.c_str());
 }
 
 void CloseFileMappingHandle(FileMappingHandle handle) { CloseHandle(handle); }

--- a/src/xenia/base/memory_win.cc
+++ b/src/xenia/base/memory_win.cc
@@ -153,7 +153,10 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
                             static_cast<DWORD>(length), full_path.c_str());
 }
 
-void CloseFileMappingHandle(FileMappingHandle handle) { CloseHandle(handle); }
+void CloseFileMappingHandle(FileMappingHandle handle,
+                            const std::filesystem::path& path) {
+  CloseHandle(handle);
+}
 
 void* MapFileView(FileMappingHandle handle, void* base_address, size_t length,
                   PageAccess access, size_t file_offset) {

--- a/src/xenia/base/testing/memory_test.cc
+++ b/src/xenia/base/testing/memory_test.cc
@@ -418,7 +418,7 @@ TEST_CASE("copy_and_swap_16_in_32_unaligned", "Copy and Swap") {
 }
 
 TEST_CASE("create_and_close_file_mapping", "Virtual Memory Mapping") {
-  auto path = fmt::format("Local\\xenia_test_{}", Clock::QueryHostTickCount());
+  auto path = fmt::format("xenia_test_{}", Clock::QueryHostTickCount());
   auto memory = xe::memory::CreateFileMappingHandle(
       path, 0x100, xe::memory::PageAccess::kReadWrite, true);
   REQUIRE(memory);
@@ -426,7 +426,7 @@ TEST_CASE("create_and_close_file_mapping", "Virtual Memory Mapping") {
 }
 
 TEST_CASE("map_view", "Virtual Memory Mapping") {
-  auto path = fmt::format("Local\\xenia_test_{}", Clock::QueryHostTickCount());
+  auto path = fmt::format("xenia_test_{}", Clock::QueryHostTickCount());
   const size_t length = 0x100;
   auto memory = xe::memory::CreateFileMappingHandle(
       path, length, xe::memory::PageAccess::kReadWrite, true);
@@ -444,7 +444,7 @@ TEST_CASE("map_view", "Virtual Memory Mapping") {
 
 TEST_CASE("read_write_view", "Virtual Memory Mapping") {
   const size_t length = 0x100;
-  auto path = fmt::format("Local\\xenia_test_{}", Clock::QueryHostTickCount());
+  auto path = fmt::format("xenia_test_{}", Clock::QueryHostTickCount());
   auto memory = xe::memory::CreateFileMappingHandle(
       path, length, xe::memory::PageAccess::kReadWrite, true);
   REQUIRE(memory);

--- a/src/xenia/base/testing/memory_test.cc
+++ b/src/xenia/base/testing/memory_test.cc
@@ -10,6 +10,9 @@
 #include "xenia/base/memory.h"
 
 #include "third_party/catch/include/catch.hpp"
+#include "third_party/fmt/include/fmt/format.h"
+
+#include "xenia/base/clock.h"
 
 namespace xe {
 namespace base {
@@ -412,6 +415,58 @@ TEST_CASE("copy_and_swap_16_in_32_aligned", "Copy and Swap") {
 TEST_CASE("copy_and_swap_16_in_32_unaligned", "Copy and Swap") {
   // TODO(bwrsandman): test once properly understood.
   REQUIRE(true == true);
+}
+
+TEST_CASE("create_and_close_file_mapping", "Virtual Memory Mapping") {
+  auto path = fmt::format("Local\\xenia_test_{}", Clock::QueryHostTickCount());
+  auto memory = xe::memory::CreateFileMappingHandle(
+      path, 0x100, xe::memory::PageAccess::kReadWrite, true);
+  REQUIRE(memory);
+  xe::memory::CloseFileMappingHandle(memory);
+}
+
+TEST_CASE("map_view", "Virtual Memory Mapping") {
+  auto path = fmt::format("Local\\xenia_test_{}", Clock::QueryHostTickCount());
+  const size_t length = 0x100;
+  auto memory = xe::memory::CreateFileMappingHandle(
+      path, length, xe::memory::PageAccess::kReadWrite, true);
+  REQUIRE(memory);
+
+  uintptr_t address = 0x100000000;
+  auto view =
+      xe::memory::MapFileView(memory, reinterpret_cast<void*>(address), length,
+                              xe::memory::PageAccess::kReadWrite, 0);
+  REQUIRE(reinterpret_cast<uintptr_t>(view) == address);
+
+  xe::memory::UnmapFileView(memory, reinterpret_cast<void*>(address), length);
+  xe::memory::CloseFileMappingHandle(memory);
+}
+
+TEST_CASE("read_write_view", "Virtual Memory Mapping") {
+  const size_t length = 0x100;
+  auto path = fmt::format("Local\\xenia_test_{}", Clock::QueryHostTickCount());
+  auto memory = xe::memory::CreateFileMappingHandle(
+      path, length, xe::memory::PageAccess::kReadWrite, true);
+  REQUIRE(memory);
+
+  uintptr_t address = 0x100000000;
+  auto view =
+      xe::memory::MapFileView(memory, reinterpret_cast<void*>(address), length,
+                              xe::memory::PageAccess::kReadWrite, 0);
+  REQUIRE(reinterpret_cast<uintptr_t>(view) == address);
+
+  for (uint32_t i = 0; i < length; i += sizeof(uint8_t)) {
+    auto p_value = reinterpret_cast<uint8_t*>(address + i);
+    *p_value = i;
+  }
+  for (uint32_t i = 0; i < length; i += sizeof(uint8_t)) {
+    auto p_value = reinterpret_cast<uint8_t*>(address + i);
+    uint8_t value = *p_value;
+    REQUIRE(value == i);
+  }
+
+  xe::memory::UnmapFileView(memory, reinterpret_cast<void*>(address), length);
+  xe::memory::CloseFileMappingHandle(memory);
 }
 
 }  // namespace test

--- a/src/xenia/base/testing/memory_test.cc
+++ b/src/xenia/base/testing/memory_test.cc
@@ -422,7 +422,7 @@ TEST_CASE("create_and_close_file_mapping", "Virtual Memory Mapping") {
   auto memory = xe::memory::CreateFileMappingHandle(
       path, 0x100, xe::memory::PageAccess::kReadWrite, true);
   REQUIRE(memory);
-  xe::memory::CloseFileMappingHandle(memory);
+  xe::memory::CloseFileMappingHandle(memory, path);
 }
 
 TEST_CASE("map_view", "Virtual Memory Mapping") {
@@ -439,7 +439,7 @@ TEST_CASE("map_view", "Virtual Memory Mapping") {
   REQUIRE(reinterpret_cast<uintptr_t>(view) == address);
 
   xe::memory::UnmapFileView(memory, reinterpret_cast<void*>(address), length);
-  xe::memory::CloseFileMappingHandle(memory);
+  xe::memory::CloseFileMappingHandle(memory, path);
 }
 
 TEST_CASE("read_write_view", "Virtual Memory Mapping") {
@@ -466,7 +466,7 @@ TEST_CASE("read_write_view", "Virtual Memory Mapping") {
   }
 
   xe::memory::UnmapFileView(memory, reinterpret_cast<void*>(address), length);
-  xe::memory::CloseFileMappingHandle(memory);
+  xe::memory::CloseFileMappingHandle(memory, path);
 }
 
 }  // namespace test

--- a/src/xenia/cpu/backend/x64/x64_code_cache.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.cc
@@ -43,7 +43,7 @@ X64CodeCache::~X64CodeCache() {
   if (mapping_) {
     xe::memory::UnmapFileView(mapping_, generated_code_base_,
                               kGeneratedCodeSize);
-    xe::memory::CloseFileMappingHandle(mapping_);
+    xe::memory::CloseFileMappingHandle(mapping_, file_name_);
     mapping_ = nullptr;
   }
 }

--- a/src/xenia/cpu/backend/x64/x64_code_cache.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.cc
@@ -63,8 +63,7 @@ bool X64CodeCache::Initialize() {
   }
 
   // Create mmap file. This allows us to share the code cache with the debugger.
-  file_name_ =
-      fmt::format("Local\\xenia_code_cache_{}", Clock::QueryHostTickCount());
+  file_name_ = fmt::format("xenia_code_cache_{}", Clock::QueryHostTickCount());
   mapping_ = xe::memory::CreateFileMappingHandle(
       file_name_, kGeneratedCodeSize, xe::memory::PageAccess::kExecuteReadWrite,
       false);

--- a/src/xenia/kernel/util/shim_utils.h
+++ b/src/xenia/kernel/util/shim_utils.h
@@ -148,7 +148,7 @@ class Param {
 
  protected:
   Param() : ordinal_(-1) {}
-  explicit Param(Init& init) : ordinal_(--init.ordinal) {}
+  explicit Param(Init& init) : ordinal_(init.ordinal++) {}
 
   template <typename V>
   void LoadValue(Init& init, V* out_value) {
@@ -519,10 +519,13 @@ xe::cpu::Export* RegisterExport(R (*fn)(Ps&...), const char* name,
       ++export_entry->function_data.call_count;
       Param::Init init = {
           ppc_context,
-          sizeof...(Ps),
           0,
       };
-      auto params = std::make_tuple<Ps...>(Ps(init)...);
+      // Using braces initializer instead of make_tuple because braces
+      // enforce execution order across compilers.
+      // The make_tuple order is undefined per the C++ standard and
+      // cause inconsitencies between msvc and clang.
+      std::tuple<Ps...> params = {Ps(init)...};
       if (export_entry->tags & xe::cpu::ExportTag::kLog &&
           (!(export_entry->tags & xe::cpu::ExportTag::kHighFrequency) ||
            cvars::log_high_frequency_kernel_calls)) {
@@ -554,9 +557,13 @@ xe::cpu::Export* RegisterExport(void (*fn)(Ps&...), const char* name,
       ++export_entry->function_data.call_count;
       Param::Init init = {
           ppc_context,
-          sizeof...(Ps),
+          0,
       };
-      auto params = std::make_tuple<Ps...>(Ps(init)...);
+      // Using braces initializer instead of make_tuple because braces
+      // enforce execution order across compilers.
+      // The make_tuple order is undefined per the C++ standard and
+      // cause inconsitencies between msvc and clang.
+      std::tuple<Ps...> params = {Ps(init)...};
       if (export_entry->tags & xe::cpu::ExportTag::kLog &&
           (!(export_entry->tags & xe::cpu::ExportTag::kHighFrequency) ||
            cvars::log_high_frequency_kernel_calls)) {

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -115,7 +115,7 @@ Memory::~Memory() {
   // Unmap all views and close mapping.
   if (mapping_) {
     UnmapViews();
-    xe::memory::CloseFileMappingHandle(mapping_);
+    xe::memory::CloseFileMappingHandle(mapping_, file_name_);
     mapping_base_ = nullptr;
     mapping_ = nullptr;
   }

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -125,8 +125,7 @@ Memory::~Memory() {
 }
 
 bool Memory::Initialize() {
-  file_name_ =
-      fmt::format("Local\\xenia_memory_{}", Clock::QueryHostTickCount());
+  file_name_ = fmt::format("xenia_memory_{}", Clock::QueryHostTickCount());
 
   // Create main page file-backed mapping. This is all reserved but
   // uncommitted (so it shouldn't expand page file).


### PR DESCRIPTION
Here are various memory implementation Fixes for Xenia to run on Linux.
As of this draft, they go as far as getting something on screen, but they do go farther in the initialization.

### Changes
* Cherry picked some improvements from @uytvbn from another unmerged PR
* Moved some Windows specific code about Virtual File Mappings to the win implementation and added Linux/Posix specific code to the posix implementation
* Fixed a leak of shared memory handles on Linux
* Added a few tests
* Fixed a subtle compiler issue in kernel which was causing guest-to-host args to compile out of order on clang. 
<details><summary>Small example</summary>
<p>
The following code does the same thing as `RegisterExport` in `src/xenia/kernel/util/shim_utils.h` but clearly shows the issue with compiler inconsistency of parameter resolution.

| compiler | output | |
|-----------|--------|---|
| g++ | A(9, 0), B(8, 1), C(7, 2), D(6, 3), E(5, 4), F(4, 5), G(3, 6), H(2, 7), I(1, 8), J(0, 9) ||
| clang++ | A(0, 0), B(1, 1), C(2, 2), D(3, 3), E(4, 4), F(5, 5), G(6, 6), H(7, 7), I(8, 8), J(9, 9) ||
| msvc | A(9, 0), B(8, 1), C(7, 2), D(6, 3), E(5, 4), F(4, 5), G(3, 6), H(2, 7), I(1, 8), J(0, 9) ||

```c++
#include <tuple>
#include <sstream>
#include <iostream>

template <size_t I = 0, typename... Ps>
typename std::enable_if<I == sizeof...(Ps)>::type append_param(
        std::ostringstream& ss, const std::tuple<Ps...>&) {}
template <size_t I = 0, typename... Ps>
typename std::enable_if<I < sizeof...(Ps)>::type append_param(
        std::ostringstream& ss, const std::tuple<Ps...>& params) {
    if (I) {
        ss << ", ";
    }
    auto param = std::get<I>(params);
    ss << param.name << "(" << param.order << ", " << I << ")";
    append_param<I + 1>(ss, params);
}

template <typename... Ps>
void tuple_order(Ps&...) {
    int order = 0;

    // Prior: order changes between clang and (msvc + gcc)
    auto params = std::make_tuple<Ps...>(Ps(order)...);
    // Fix: using braces enforces order and forces all to be like clang
    //std::tuple<Ps...> params = {Ps(order)...};

    std::ostringstream ss;
    append_param(ss, params);
    std::cout << ss.str() << std::endl;
}

#define NAMED_STRUCT(NAME) \
struct NAME { \
    NAME() : order(-1) {} \
    explicit NAME(int& order) : order(order++) {} \
    const char* name = #NAME; \
    int order; \
}

NAMED_STRUCT(A);
NAMED_STRUCT(B);
NAMED_STRUCT(C);
NAMED_STRUCT(D);
NAMED_STRUCT(E);
NAMED_STRUCT(F);
NAMED_STRUCT(G);
NAMED_STRUCT(H);
NAMED_STRUCT(I);
NAMED_STRUCT(J);

int main(int argc, char* argv[]) {
    A a;
    B b;
    C c;
    D d;
    E e;
    F f;
    G g;
    H h;
    I i;
    J j;
    tuple_order(a, b, c, d, e, f, g, h, i, j);
    return 0;
}
```

</p>
</details>


<details><summary>Log</summary>
<p>
Here is the difference in the log from trying to load RDR. This was run using the other branches from my PRs (linux_threads, linux_cpu, linux_misc and this one).

Prior would run this far before crashing due to trying to access non-read page in `0x100000004`:
```
i> 00002A7C Build: linux / 90f81652b34d681ed66598fb8a14b02247ccfbaf on Jul 11 2019
i> 00002A7C Content root: /home/sandy/.local/share/Xenia
d> 00002A7C Stack walker unimplemented on posix
i> 00002A7C Initializing Vulkan 1.1.0...
i> 00002A7C Found 18 global layers:
i> 00002A7C - VK_LAYER_RENDERDOC_Capture (spec: 1.1.73, impl: 0.0.4)
i> 00002A7C   Debugging capture layer for RenderDoc
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_utils (0.0.1)
i> 00002A7C - VK_LAYER_NV_nomad_release_public_2019_3_1 (spec: 1.1.71, impl: 0.0.1)
i> 00002A7C   NVIDIA Nsight Graphics interception layer
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_utils (0.0.1)
i> 00002A7C - VK_LAYER_VALVE_steam_fossilize_64 (spec: 1.1.73, impl: 0.0.1)
i> 00002A7C   Steam Pipeline Caching Layer
i> 00002A7C - VK_LAYER_VALVE_steam_overlay_64 (spec: 1.1.73, impl: 0.0.1)
i> 00002A7C   Steam Overlay Layer
i> 00002A7C - VK_LAYER_VALVE_steam_overlay_32 (spec: 1.1.73, impl: 0.0.1)
i> 00002A7C   Steam Overlay Layer
i> 00002A7C - VK_LAYER_VALVE_steam_fossilize_32 (spec: 1.1.73, impl: 0.0.1)
i> 00002A7C   Steam Pipeline Caching Layer
i> 00002A7C - VK_LAYER_LUNARG_vktrace (spec: 1.1.97, impl: 0.0.1)
i> 00002A7C   Vktrace tracing library
i> 00002A7C - VK_LAYER_LUNARG_screenshot (spec: 1.1.97, impl: 0.0.1)
i> 00002A7C   LunarG image capture layer
i> 00002A7C - VK_LAYER_LUNARG_device_simulation (spec: 1.1.97, impl: 0.0.1)
i> 00002A7C   LunarG device simulation layer
i> 00002A7C - VK_LAYER_LUNARG_api_dump (spec: 1.1.97, impl: 0.0.2)
i> 00002A7C   LunarG debug layer
i> 00002A7C - VK_LAYER_LUNARG_monitor (spec: 1.1.97, impl: 0.0.1)
i> 00002A7C   Execution Monitoring Layer
i> 00002A7C - VK_LAYER_LUNARG_standard_validation (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   LunarG Standard Validation
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_report (0.0.6)
i> 00002A7C - VK_LAYER_GOOGLE_threading (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   Google Validation Layer
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_report (0.0.6)
i> 00002A7C - VK_LAYER_LUNARG_object_tracker (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   LunarG Validation Layer
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_report (0.0.6)
i> 00002A7C - VK_LAYER_LUNARG_core_validation (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   LunarG Validation Layer
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_report (0.0.6)
i> 00002A7C - VK_LAYER_GOOGLE_unique_objects (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   Google Validation Layer
i> 00002A7C - VK_LAYER_LUNARG_parameter_validation (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   LunarG Validation Layer
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_report (0.0.6)
i> 00002A7C - VK_LAYER_KHRONOS_validation (spec: 1.1.112, impl: 0.0.1)
i> 00002A7C   LunarG Validation Layer
i> 00002A7C   1 extensions:
i> 00002A7C   - VK_EXT_debug_report (0.0.6)
i> 00002A7C Found 16 global extensions:
i> 00002A7C - VK_KHR_device_group_creation (0.0.1)
i> 00002A7C - VK_KHR_display (0.0.21)
i> 00002A7C - VK_KHR_external_fence_capabilities (0.0.1)
i> 00002A7C - VK_KHR_external_memory_capabilities (0.0.1)
i> 00002A7C - VK_KHR_external_semaphore_capabilities (0.0.1)
i> 00002A7C - VK_KHR_get_display_properties2 (0.0.1)
i> 00002A7C - VK_KHR_get_physical_device_properties2 (0.0.1)
i> 00002A7C - VK_KHR_get_surface_capabilities2 (0.0.1)
i> 00002A7C - VK_KHR_surface (0.0.25)
i> 00002A7C - VK_KHR_xcb_surface (0.0.6)
i> 00002A7C - VK_KHR_xlib_surface (0.0.6)
i> 00002A7C - VK_EXT_acquire_xlib_display (0.0.1)
i> 00002A7C - VK_EXT_debug_report (0.0.9)
i> 00002A7C - VK_EXT_debug_utils (0.0.1)
i> 00002A7C - VK_EXT_direct_mode_display (0.0.1)
i> 00002A7C - VK_EXT_display_surface_counter (0.0.1)
i> 00002A7C Verifying layers and extensions...
i> 00002A7C - optional extension VK_EXT_debug_marker not found
i> 00002A7C - enabling extension VK_KHR_surface (0.0.25)
i> 00002A7C - enabling extension VK_KHR_xcb_surface (0.0.6)
i> 00002A7C Initializing application instance...
i> 00002A7C Debug validation layer not installed; ignoring
i> 00002A7C Found 1 physical devices:
i> 00002A7C - Device 0:
i> 00002A7C   apiVersion     = 1.1.99
i> 00002A7C   driverVersion  = 430.104.0
i> 00002A7C   vendorId       = 0x10de
i> 00002A7C   deviceId       = 0x1ba1
i> 00002A7C   deviceType     = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
i> 00002A7C   deviceName     = GeForce GTX 1070 with Max-Q Design
i> 00002A7C   Memory Heaps:
i> 00002A7C   - Heap 0: 8589934592 bytes
i> 00002A7C     - Type 7:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
i> 00002A7C     - Type 8:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
i> 00002A7C   - Heap 1: 12492112896 bytes
i> 00002A7C     - Type 0:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 1:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 2:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 3:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 4:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 5:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 6:
i> 00002A7C       VK_MEMORY_PROPERTY_DEVICE_ONLY
i> 00002A7C     - Type 9:
i> 00002A7C       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
i> 00002A7C       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
i> 00002A7C     - Type 10:
i> 00002A7C       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
i> 00002A7C       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
i> 00002A7C       VK_MEMORY_PROPERTY_HOST_CACHED_BIT
i> 00002A7C   Queue Families:
i> 00002A7C   - Queue 0:
i> 00002A7C     queueFlags         = graphics, compute, transfer, sparse, 
i> 00002A7C     queueCount         = 16
i> 00002A7C     timestampValidBits = 64
i> 00002A7C   - Queue 1:
i> 00002A7C     queueFlags         = transfer, 
i> 00002A7C     queueCount         = 2
i> 00002A7C     timestampValidBits = 64
i> 00002A7C   - Queue 2:
i> 00002A7C     queueFlags         = compute, 
i> 00002A7C     queueCount         = 8
i> 00002A7C     timestampValidBits = 64
i> 00002A7C   Layers:
i> 00002A7C   Extensions:
i> 00002A7C   - VK_KHR_8bit_storage (0.0.1)
i> 00002A7C   - VK_KHR_16bit_storage (0.0.1)
i> 00002A7C   - VK_KHR_bind_memory2 (0.0.1)
i> 00002A7C   - VK_KHR_create_renderpass2 (0.0.1)
i> 00002A7C   - VK_KHR_dedicated_allocation (0.0.3)
i> 00002A7C   - VK_KHR_depth_stencil_resolve (0.0.1)
i> 00002A7C   - VK_KHR_descriptor_update_template (0.0.1)
i> 00002A7C   - VK_KHR_device_group (0.0.3)
i> 00002A7C   - VK_KHR_draw_indirect_count (0.0.1)
i> 00002A7C   - VK_KHR_driver_properties (0.0.1)
i> 00002A7C   - VK_KHR_external_fence (0.0.1)
i> 00002A7C   - VK_KHR_external_fence_fd (0.0.1)
i> 00002A7C   - VK_KHR_external_memory (0.0.1)
i> 00002A7C   - VK_KHR_external_memory_fd (0.0.1)
i> 00002A7C   - VK_KHR_external_semaphore (0.0.1)
i> 00002A7C   - VK_KHR_external_semaphore_fd (0.0.1)
i> 00002A7C   - VK_KHR_get_memory_requirements2 (0.0.1)
i> 00002A7C   - VK_KHR_image_format_list (0.0.1)
i> 00002A7C   - VK_KHR_maintenance1 (0.0.2)
i> 00002A7C   - VK_KHR_maintenance2 (0.0.1)
i> 00002A7C   - VK_KHR_maintenance3 (0.0.1)
i> 00002A7C   - VK_KHR_multiview (0.0.1)
i> 00002A7C   - VK_KHR_push_descriptor (0.0.2)
i> 00002A7C   - VK_KHR_relaxed_block_layout (0.0.1)
i> 00002A7C   - VK_KHR_sampler_mirror_clamp_to_edge (0.0.1)
i> 00002A7C   - VK_KHR_sampler_ycbcr_conversion (0.0.1)
i> 00002A7C   - VK_KHR_shader_atomic_int64 (0.0.1)
i> 00002A7C   - VK_KHR_shader_draw_parameters (0.0.1)
i> 00002A7C   - VK_KHR_shader_float16_int8 (0.0.1)
i> 00002A7C   - VK_KHR_shader_float_controls (0.0.1)
i> 00002A7C   - VK_KHR_storage_buffer_storage_class (0.0.1)
i> 00002A7C   - VK_KHR_swapchain (0.0.70)
i> 00002A7C   - VK_KHR_swapchain_mutable_format (0.0.1)
i> 00002A7C   - VK_KHR_variable_pointers (0.0.1)
i> 00002A7C   - VK_KHR_vulkan_memory_model (0.0.3)
i> 00002A7C   - VK_EXT_blend_operation_advanced (0.0.2)
i> 00002A7C   - VK_EXT_buffer_device_address (0.0.2)
i> 00002A7C   - VK_EXT_conditional_rendering (0.0.1)
i> 00002A7C   - VK_EXT_conservative_rasterization (0.0.1)
i> 00002A7C   - VK_EXT_depth_clip_enable (0.0.1)
i> 00002A7C   - VK_EXT_depth_range_unrestricted (0.0.1)
i> 00002A7C   - VK_EXT_descriptor_indexing (0.0.2)
i> 00002A7C   - VK_EXT_discard_rectangles (0.0.1)
i> 00002A7C   - VK_EXT_display_control (0.0.1)
i> 00002A7C   - VK_EXT_global_priority (0.0.2)
i> 00002A7C   - VK_EXT_host_query_reset (0.0.1)
i> 00002A7C   - VK_EXT_inline_uniform_block (0.0.1)
i> 00002A7C   - VK_EXT_memory_budget (0.0.1)
i> 00002A7C   - VK_EXT_pci_bus_info (0.0.2)
i> 00002A7C   - VK_EXT_post_depth_coverage (0.0.1)
i> 00002A7C   - VK_EXT_sample_locations (0.0.1)
i> 00002A7C   - VK_EXT_sampler_filter_minmax (0.0.1)
i> 00002A7C   - VK_EXT_scalar_block_layout (0.0.1)
i> 00002A7C   - VK_EXT_shader_subgroup_ballot (0.0.1)
i> 00002A7C   - VK_EXT_shader_subgroup_vote (0.0.1)
i> 00002A7C   - VK_EXT_shader_viewport_index_layer (0.0.1)
i> 00002A7C   - VK_EXT_transform_feedback (0.0.1)
i> 00002A7C   - VK_EXT_vertex_attribute_divisor (0.0.3)
i> 00002A7C   - VK_NV_clip_space_w_scaling (0.0.1)
i> 00002A7C   - VK_NV_dedicated_allocation (0.0.1)
i> 00002A7C   - VK_NV_dedicated_allocation_image_aliasing (0.0.1)
i> 00002A7C   - VK_NV_device_diagnostic_checkpoints (0.0.2)
i> 00002A7C   - VK_NV_fill_rectangle (0.0.1)
i> 00002A7C   - VK_NV_fragment_coverage_to_color (0.0.1)
i> 00002A7C   - VK_NV_framebuffer_mixed_samples (0.0.1)
i> 00002A7C   - VK_NV_geometry_shader_passthrough (0.0.1)
i> 00002A7C   - VK_NV_sample_mask_override_coverage (0.0.1)
i> 00002A7C   - VK_NV_shader_subgroup_partitioned (0.0.1)
i> 00002A7C   - VK_NV_viewport_array2 (0.0.1)
i> 00002A7C   - VK_NV_viewport_swizzle (0.0.1)
i> 00002A7C   - VK_NVX_device_generated_commands (0.0.3)
i> 00002A7C   - VK_NVX_multiview_per_view_attributes (0.0.1)
i> 00002A7C   - VK_NV_ray_tracing (0.0.3)
i> 00002A7C RenderDoc support requested but it is not attached
i> 00002A7C Instance initialized successfully!
i> 00002A7C - optional extension VK_AMD_shader_info not found
i> 00002A7C - optional extension VK_EXT_debug_marker not found
i> 00002A7C - enabling extension VK_KHR_sampler_mirror_clamp_to_edge (0.0.1)
i> 00002A7C - enabling extension VK_KHR_swapchain (0.0.70)
i> 00002A7C Device initialized successfully!
i> 00002A80 Creating swap chain:
i> 00002A80   minImageCount    = 3
i> 00002A80   imageFormat      = VK_FORMAT_B8G8R8A8_UNORM
i> 00002A80   imageExtent      = 1280 x 984
i> 00002A80   preTransform     = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR
i> 00002A80   imageArrayLayers = 1
i> 00002A80   presentMode      = VK_PRESENT_MODE_IMMEDIATE_KHR
i> 00002A80   clipped          = true
i> 00002A80   imageColorSpace  = VK_COLORSPACE_SRGB_NONLINEAR_KHR
i> 00002A80   imageUsageFlags  = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
i> 00002A80   imageSharingMode = VK_SHARING_MODE_EXCLUSIVE
i> 00002A80   queueFamilyCount = 0
i> 00002A80 Swap chain initialized successfully!
w> 00002A80 Unable to load japanese font; jp characters will be boxes
i> 00002A7C Added handle:00000004 for N2xe6kernel7XObjectE
i> 00002A7C XThread00000004 (1) Stack: 40010000-40030000
i> 00002A7C Added handle:00000008 for N2xe6kernel7XObjectE
K> 00000004 XThread::Execute thid 1 (handle=00000004, 'GPU Commands (00000004)', native=E4AA7700, <host>)
i> 00002A7C XThread00000008 (2) Stack: 40050000-40070000
K> 00000008 XThread::Execute thid 2 (handle=00000008, 'GPU VSync (00000008)', native=E3A26700, <host>)
i> 00002A7C Added handle:0000000C for N2xe6kernel7XObjectE
i> 00002A7C XThread0000000C (3) Stack: 40090000-400B0000
i> 00002A7C Added handle:00000010 for N2xe6kernel7XObjectE
K> 0000000C XThread::Execute thid 3 (handle=0000000C, 'XMA Decoder (0000000C)', native=E1FA4700, <host>)
i> 00002A7C XThread00000010 (4) Stack: 400D0000-400F0000
i> 00002A7C Added handle:00000014 for N2xe6kernel7XObjectE
K> 00000010 XThread::Execute thid 4 (handle=00000010, 'Audio Worker (00000010)', native=B97FE700, <host>)
i> 00002A7C Added handle:00000018 for N2xe6kernel7XObjectE
i> 00002A7C Added handle:0000001C for N2xe6kernel7XObjectE
d> 00002A80 Registered symbolic link: game: => \Device\Cdrom0
d> 00002A80 Registered symbolic link: d: => \Device\Cdrom0
F> 00002A80 DiscImageDevice::ResolvePath(\GameInfo.bin)
i> 00002A80 Launching module game:\default.xex
i> 00002A80 Added handle:00000020 for N2xe6kernel7XObjectE
F> 00002A80 DiscImageDevice::ResolvePath(\default.xex)
F> 00002A80 DiscImageDevice::ResolvePath(\default.xexp)
C> 00002A80 WARNING: imported a variable with no value: ExThreadObjectType
i> 00002A80 Module \Device\Cdrom0\default.xex:
    Module Flags: 00000001
Security Header:
     Image Flags: 00000008
    Load Address: 82000000
      Image Size: 01290000
    Export Table: 00000000
Optional Header Count: 15
  XEX_HEADER_RESOURCE_INFO:
    5454082B 831E0000-83288136, 688438b
  XEX_HEADER_FILE_FORMAT_INFO (TODO):
  XEX_HEADER_ENTRY_POINT: 823DAE58
  XEX_HEADER_IMAGE_BASE_ADDRESS: 82000000
  XEX_HEADER_IMPORT_LIBRARIES:
    xam.xex - 198 imports
      Version: 0.0.9328.32
      Min Version: 0.0.8955.32
    xboxkrnl.exe - 314 imports
      Version: 0.0.9328.32
      Min Version: 0.0.8955.32
  XEX_HEADER_CHECKSUM_TIMESTAMP (TODO):
  XEX_HEADER_ORIGINAL_PE_NAME: rdr2_xenon_final.exe
  XEX_HEADER_STATIC_LIBRARIES:
    XAPILIB  : 2.0.9328.9
    XBOXKRNL : 2.0.9328.0
    LIBCMT   : 2.0.9328.0
    XAPOBA   : 2.0.9328.4
    XAUDIO2  : 2.0.9328.4
    XMP      : 2.0.9328.0
    XHV2     : 2.0.9328.0
    XONLINE  : 2.0.9328.0
    XPARTY   : 2.0.9328.0
    D3D9     : 2.0.9328.0
    XGRAPHC  : 2.0.9328.0
    XMCORE   : 2.0.9328.0
  XEX_HEADER_TLS_INFO:
          Slot Count: 64
    Raw Data Address: 831D5400
           Data Size: 668
       Raw Data Size: 668
  XEX_HEADER_DEFAULT_STACK_SIZE: 262144
  XEX_HEADER_SYSTEM_FLAGS: 00000200
  XEX_HEADER_EXECUTION_INFO:
       Media ID: 2AAB34E2
       Title ID: 5454082B
    Savegame ID: 5454082B
    Disc Number / Total: 1 / 1
  XEX_HEADER_GAME_RATINGS (TODO):
  XEX_HEADER_LAN_KEY: 0A 92 0F 63 58 B5 FA C4 EA 6A 31 7D 46 3A F1 08
  XEX_HEADER_XBOX360_LOGO (TODO):
Sections:
    0 RODATA    1 pages    82000000 - 82010000 (65536 bytes)
    1 RODATA    1 pages    82010000 - 82020000 (65536 bytes)
    2 RODATA    1 pages    82020000 - 82030000 (65536 bytes)
    3 RODATA    1 pages    82030000 - 82040000 (65536 bytes)
    4 RODATA    1 pages    82040000 - 82050000 (65536 bytes)
    5 RODATA    1 pages    82050000 - 82060000 (65536 bytes)
    6 RODATA    1 pages    82060000 - 82070000 (65536 bytes)
    7 RODATA    1 pages    82070000 - 82080000 (65536 bytes)
    8 RODATA    1 pages    82080000 - 82090000 (65536 bytes)
    9 RODATA    1 pages    82090000 - 820A0000 (65536 bytes)
   10 RODATA    1 pages    820A0000 - 820B0000 (65536 bytes)
   11 RODATA    1 pages    820B0000 - 820C0000 (65536 bytes)
   12 RODATA    1 pages    820C0000 - 820D0000 (65536 bytes)
   13 RODATA    1 pages    820D0000 - 820E0000 (65536 bytes)
   14 RODATA    1 pages    820E0000 - 820F0000 (65536 bytes)
   15 RODATA    1 pages    820F0000 - 82100000 (65536 bytes)
   16 RODATA    1 pages    82100000 - 82110000 (65536 bytes)
   17 RODATA    1 pages    82110000 - 82120000 (65536 bytes)
   18 RODATA    1 pages    82120000 - 82130000 (65536 bytes)
   19 RODATA    1 pages    82130000 - 82140000 (65536 bytes)
   20 RODATA    1 pages    82140000 - 82150000 (65536 bytes)
   21 RODATA    1 pages    82150000 - 82160000 (65536 bytes)
   22 RODATA    1 pages    82160000 - 82170000 (65536 bytes)
   23 RODATA    1 pages    82170000 - 82180000 (65536 bytes)
   24 RODATA    1 pages    82180000 - 82190000 (65536 bytes)
   25 RODATA    1 pages    82190000 - 821A0000 (65536 bytes)
   26 RODATA    1 pages    821A0000 - 821B0000 (65536 bytes)
   27 RODATA    1 pages    821B0000 - 821C0000 (65536 bytes)
   28 RODATA    1 pages    821C0000 - 821D0000 (65536 bytes)
   29 RODATA    1 pages    821D0000 - 821E0000 (65536 bytes)
   30 RODATA    1 pages    821E0000 - 821F0000 (65536 bytes)
   31 RODATA    1 pages    821F0000 - 82200000 (65536 bytes)
   32 RODATA    1 pages    82200000 - 82210000 (65536 bytes)
   33 CODE      1 pages    82210000 - 82220000 (65536 bytes)
   34 CODE      1 pages    82220000 - 82230000 (65536 bytes)
   35 CODE      1 pages    82230000 - 82240000 (65536 bytes)
   36 CODE      1 pages    82240000 - 82250000 (65536 bytes)
   37 CODE      1 pages    82250000 - 82260000 (65536 bytes)
   38 CODE      1 pages    82260000 - 82270000 (65536 bytes)
   39 CODE      1 pages    82270000 - 82280000 (65536 bytes)
   40 CODE      1 pages    82280000 - 82290000 (65536 bytes)
   41 CODE      1 pages    82290000 - 822A0000 (65536 bytes)
   42 CODE      1 pages    822A0000 - 822B0000 (65536 bytes)
   43 CODE      1 pages    822B0000 - 822C0000 (65536 bytes)
   44 CODE      1 pages    822C0000 - 822D0000 (65536 bytes)
   45 CODE      1 pages    822D0000 - 822E0000 (65536 bytes)
   46 CODE      1 pages    822E0000 - 822F0000 (65536 bytes)
   47 CODE      1 pages    822F0000 - 82300000 (65536 bytes)
   48 CODE      1 pages    82300000 - 82310000 (65536 bytes)
   49 CODE      1 pages    82310000 - 82320000 (65536 bytes)
   50 CODE      1 pages    82320000 - 82330000 (65536 bytes)
   51 CODE      1 pages    82330000 - 82340000 (65536 bytes)
   52 CODE      1 pages    82340000 - 82350000 (65536 bytes)
   53 CODE      1 pages    82350000 - 82360000 (65536 bytes)
   54 CODE      1 pages    82360000 - 82370000 (65536 bytes)
   55 CODE      1 pages    82370000 - 82380000 (65536 bytes)
   56 CODE      1 pages    82380000 - 82390000 (65536 bytes)
   57 CODE      1 pages    82390000 - 823A0000 (65536 bytes)
   58 CODE      1 pages    823A0000 - 823B0000 (65536 bytes)
   59 CODE      1 pages    823B0000 - 823C0000 (65536 bytes)
   60 CODE      1 pages    823C0000 - 823D0000 (65536 bytes)
   61 CODE      1 pages    823D0000 - 823E0000 (65536 bytes)
   62 CODE      1 pages    823E0000 - 823F0000 (65536 bytes)
   63 CODE      1 pages    823F0000 - 82400000 (65536 bytes)
   64 CODE      1 pages    82400000 - 82410000 (65536 bytes)
   65 CODE      1 pages    82410000 - 82420000 (65536 bytes)
   66 CODE      1 pages    82420000 - 82430000 (65536 bytes)
   67 CODE      1 pages    82430000 - 82440000 (65536 bytes)
   68 CODE      1 pages    82440000 - 82450000 (65536 bytes)
   69 CODE      1 pages    82450000 - 82460000 (65536 bytes)
   70 CODE      1 pages    82460000 - 82470000 (65536 bytes)
   71 CODE      1 pages    82470000 - 82480000 (65536 bytes)
   72 CODE      1 pages    82480000 - 82490000 (65536 bytes)
   73 CODE      1 pages    82490000 - 824A0000 (65536 bytes)
   74 CODE      1 pages    824A0000 - 824B0000 (65536 bytes)
   75 CODE      1 pages    824B0000 - 824C0000 (65536 bytes)
   76 CODE      1 pages    824C0000 - 824D0000 (65536 bytes)
   77 CODE      1 pages    824D0000 - 824E0000 (65536 bytes)
   78 CODE      1 pages    824E0000 - 824F0000 (65536 bytes)
   79 CODE      1 pages    824F0000 - 82500000 (65536 bytes)
   80 CODE      1 pages    82500000 - 82510000 (65536 bytes)
   81 CODE      1 pages    82510000 - 82520000 (65536 bytes)
   82 CODE      1 pages    82520000 - 82530000 (65536 bytes)
   83 CODE      1 pages    82530000 - 82540000 (65536 bytes)
   84 CODE      1 pages    82540000 - 82550000 (65536 bytes)
   85 CODE      1 pages    82550000 - 82560000 (65536 bytes)
   86 CODE      1 pages    82560000 - 82570000 (65536 bytes)
   87 CODE      1 pages    82570000 - 82580000 (65536 bytes)
   88 CODE      1 pages    82580000 - 82590000 (65536 bytes)
   89 CODE      1 pages    82590000 - 825A0000 (65536 bytes)
   90 CODE      1 pages    825A0000 - 825B0000 (65536 bytes)
   91 CODE      1 pages    825B0000 - 825C0000 (65536 bytes)
   92 CODE      1 pages    825C0000 - 825D0000 (65536 bytes)
   93 CODE      1 pages    825D0000 - 825E0000 (65536 bytes)
   94 CODE      1 pages    825E0000 - 825F0000 (65536 bytes)
   95 CODE      1 pages    825F0000 - 82600000 (65536 bytes)
   96 CODE      1 pages    82600000 - 82610000 (65536 bytes)
   97 CODE      1 pages    82610000 - 82620000 (65536 bytes)
   98 CODE      1 pages    82620000 - 82630000 (65536 bytes)
   99 CODE      1 pages    82630000 - 82640000 (65536 bytes)
  100 CODE      1 pages    82640000 - 82650000 (65536 bytes)
  101 CODE      1 pages    82650000 - 82660000 (65536 bytes)
  102 CODE      1 pages    82660000 - 82670000 (65536 bytes)
  103 CODE      1 pages    82670000 - 82680000 (65536 bytes)
  104 CODE      1 pages    82680000 - 82690000 (65536 bytes)
  105 CODE      1 pages    82690000 - 826A0000 (65536 bytes)
  106 CODE      1 pages    826A0000 - 826B0000 (65536 bytes)
  107 CODE      1 pages    826B0000 - 826C0000 (65536 bytes)
  108 CODE      1 pages    826C0000 - 826D0000 (65536 bytes)
  109 CODE      1 pages    826D0000 - 826E0000 (65536 bytes)
  110 CODE      1 pages    826E0000 - 826F0000 (65536 bytes)
  111 CODE      1 pages    826F0000 - 82700000 (65536 bytes)
  112 CODE      1 pages    82700000 - 82710000 (65536 bytes)
  113 CODE      1 pages    82710000 - 82720000 (65536 bytes)
  114 CODE      1 pages    82720000 - 82730000 (65536 bytes)
  115 CODE      1 pages    82730000 - 82740000 (65536 bytes)
  116 CODE      1 pages    82740000 - 82750000 (65536 bytes)
  117 CODE      1 pages    82750000 - 82760000 (65536 bytes)
  118 CODE      1 pages    82760000 - 82770000 (65536 bytes)
  119 CODE      1 pages    82770000 - 82780000 (65536 bytes)
  120 CODE      1 pages    82780000 - 82790000 (65536 bytes)
  121 CODE      1 pages    82790000 - 827A0000 (65536 bytes)
  122 CODE      1 pages    827A0000 - 827B0000 (65536 bytes)
  123 CODE      1 pages    827B0000 - 827C0000 (65536 bytes)
  124 CODE      1 pages    827C0000 - 827D0000 (65536 bytes)
  125 CODE      1 pages    827D0000 - 827E0000 (65536 bytes)
  126 CODE      1 pages    827E0000 - 827F0000 (65536 bytes)
  127 CODE      1 pages    827F0000 - 82800000 (65536 bytes)
  128 CODE      1 pages    82800000 - 82810000 (65536 bytes)
  129 CODE      1 pages    82810000 - 82820000 (65536 bytes)
  130 CODE      1 pages    82820000 - 82830000 (65536 bytes)
  131 CODE      1 pages    82830000 - 82840000 (65536 bytes)
  132 CODE      1 pages    82840000 - 82850000 (65536 bytes)
  133 CODE      1 pages    82850000 - 82860000 (65536 bytes)
  134 CODE      1 pages    82860000 - 82870000 (65536 bytes)
  135 CODE      1 pages    82870000 - 82880000 (65536 bytes)
  136 CODE      1 pages    82880000 - 82890000 (65536 bytes)
  137 CODE      1 pages    82890000 - 828A0000 (65536 bytes)
  138 CODE      1 pages    828A0000 - 828B0000 (65536 bytes)
  139 CODE      1 pages    828B0000 - 828C0000 (65536 bytes)
  140 CODE      1 pages    828C0000 - 828D0000 (65536 bytes)
  141 CODE      1 pages    828D0000 - 828E0000 (65536 bytes)
  142 CODE      1 pages    828E0000 - 828F0000 (65536 bytes)
  143 CODE      1 pages    828F0000 - 82900000 (65536 bytes)
  144 CODE      1 pages    82900000 - 82910000 (65536 bytes)
  145 CODE      1 pages    82910000 - 82920000 (65536 bytes)
  146 CODE      1 pages    82920000 - 82930000 (65536 bytes)
  147 CODE      1 pages    82930000 - 82940000 (65536 bytes)
  148 CODE      1 pages    82940000 - 82950000 (65536 bytes)
  149 CODE      1 pages    82950000 - 82960000 (65536 bytes)
  150 CODE      1 pages    82960000 - 82970000 (65536 bytes)
  151 CODE      1 pages    82970000 - 82980000 (65536 bytes)
  152 CODE      1 pages    82980000 - 82990000 (65536 bytes)
  153 CODE      1 pages    82990000 - 829A0000 (65536 bytes)
  154 CODE      1 pages    829A0000 - 829B0000 (65536 bytes)
  155 CODE      1 pages    829B0000 - 829C0000 (65536 bytes)
  156 CODE      1 pages    829C0000 - 829D0000 (65536 bytes)
  157 CODE      1 pages    829D0000 - 829E0000 (65536 bytes)
  158 CODE      1 pages    829E0000 - 829F0000 (65536 bytes)
  159 CODE      1 pages    829F0000 - 82A00000 (65536 bytes)
  160 CODE      1 pages    82A00000 - 82A10000 (65536 bytes)
  161 CODE      1 pages    82A10000 - 82A20000 (65536 bytes)
  162 CODE      1 pages    82A20000 - 82A30000 (65536 bytes)
  163 CODE      1 pages    82A30000 - 82A40000 (65536 bytes)
  164 CODE      1 pages    82A40000 - 82A50000 (65536 bytes)
  165 CODE      1 pages    82A50000 - 82A60000 (65536 bytes)
  166 CODE      1 pages    82A60000 - 82A70000 (65536 bytes)
  167 CODE      1 pages    82A70000 - 82A80000 (65536 bytes)
  168 CODE      1 pages    82A80000 - 82A90000 (65536 bytes)
  169 CODE      1 pages    82A90000 - 82AA0000 (65536 bytes)
  170 CODE      1 pages    82AA0000 - 82AB0000 (65536 bytes)
  171 CODE      1 pages    82AB0000 - 82AC0000 (65536 bytes)
  172 CODE      1 pages    82AC0000 - 82AD0000 (65536 bytes)
  173 CODE      1 pages    82AD0000 - 82AE0000 (65536 bytes)
  174 CODE      1 pages    82AE0000 - 82AF0000 (65536 bytes)
  175 CODE      1 pages    82AF0000 - 82B00000 (65536 bytes)
  176 CODE      1 pages    82B00000 - 82B10000 (65536 bytes)
  177 CODE      1 pages    82B10000 - 82B20000 (65536 bytes)
  178 CODE      1 pages    82B20000 - 82B30000 (65536 bytes)
  179 CODE      1 pages    82B30000 - 82B40000 (65536 bytes)
  180 CODE      1 pages    82B40000 - 82B50000 (65536 bytes)
  181 CODE      1 pages    82B50000 - 82B60000 (65536 bytes)
  182 CODE      1 pages    82B60000 - 82B70000 (65536 bytes)
  183 CODE      1 pages    82B70000 - 82B80000 (65536 bytes)
  184 CODE      1 pages    82B80000 - 82B90000 (65536 bytes)
  185 CODE      1 pages    82B90000 - 82BA0000 (65536 bytes)
  186 CODE      1 pages    82BA0000 - 82BB0000 (65536 bytes)
  187 CODE      1 pages    82BB0000 - 82BC0000 (65536 bytes)
  188 CODE      1 pages    82BC0000 - 82BD0000 (65536 bytes)
  189 CODE      1 pages    82BD0000 - 82BE0000 (65536 bytes)
  190 CODE      1 pages    82BE0000 - 82BF0000 (65536 bytes)
  191 CODE      1 pages    82BF0000 - 82C00000 (65536 bytes)
  192 CODE      1 pages    82C00000 - 82C10000 (65536 bytes)
  193 CODE      1 pages    82C10000 - 82C20000 (65536 bytes)
  194 CODE      1 pages    82C20000 - 82C30000 (65536 bytes)
  195 CODE      1 pages    82C30000 - 82C40000 (65536 bytes)
  196 CODE      1 pages    82C40000 - 82C50000 (65536 bytes)
  197 CODE      1 pages    82C50000 - 82C60000 (65536 bytes)
  198 CODE      1 pages    82C60000 - 82C70000 (65536 bytes)
  199 CODE      1 pages    82C70000 - 82C80000 (65536 bytes)
  200 CODE      1 pages    82C80000 - 82C90000 (65536 bytes)
  201 CODE      1 pages    82C90000 - 82CA0000 (65536 bytes)
  202 CODE      1 pages    82CA0000 - 82CB0000 (65536 bytes)
  203 CODE      1 pages    82CB0000 - 82CC0000 (65536 bytes)
  204 CODE      1 pages    82CC0000 - 82CD0000 (65536 bytes)
  205 CODE      1 pages    82CD0000 - 82CE0000 (65536 bytes)
  206 CODE      1 pages    82CE0000 - 82CF0000 (65536 bytes)
  207 CODE      1 pages    82CF0000 - 82D00000 (65536 bytes)
  208 CODE      1 pages    82D00000 - 82D10000 (65536 bytes)
  209 CODE      1 pages    82D10000 - 82D20000 (65536 bytes)
  210 CODE      1 pages    82D20000 - 82D30000 (65536 bytes)
  211 CODE      1 pages    82D30000 - 82D40000 (65536 bytes)
  212 CODE      1 pages    82D40000 - 82D50000 (65536 bytes)
  213 CODE      1 pages    82D50000 - 82D60000 (65536 bytes)
  214 CODE      1 pages    82D60000 - 82D70000 (65536 bytes)
  215 CODE      1 pages    82D70000 - 82D80000 (65536 bytes)
  216 CODE      1 pages    82D80000 - 82D90000 (65536 bytes)
  217 CODE      1 pages    82D90000 - 82DA0000 (65536 bytes)
  218 CODE      1 pages    82DA0000 - 82DB0000 (65536 bytes)
  219 CODE      1 pages    82DB0000 - 82DC0000 (65536 bytes)
  220 CODE      1 pages    82DC0000 - 82DD0000 (65536 bytes)
  221 CODE      1 pages    82DD0000 - 82DE0000 (65536 bytes)
  222 CODE      1 pages    82DE0000 - 82DF0000 (65536 bytes)
  223 CODE      1 pages    82DF0000 - 82E00000 (65536 bytes)
  224 CODE      1 pages    82E00000 - 82E10000 (65536 bytes)
  225 CODE      1 pages    82E10000 - 82E20000 (65536 bytes)
  226 CODE      1 pages    82E20000 - 82E30000 (65536 bytes)
  227 CODE      1 pages    82E30000 - 82E40000 (65536 bytes)
  228 CODE      1 pages    82E40000 - 82E50000 (65536 bytes)
  229 CODE      1 pages    82E50000 - 82E60000 (65536 bytes)
  230 CODE      1 pages    82E60000 - 82E70000 (65536 bytes)
  231 CODE      1 pages    82E70000 - 82E80000 (65536 bytes)
  232 CODE      1 pages    82E80000 - 82E90000 (65536 bytes)
  233 CODE      1 pages    82E90000 - 82EA0000 (65536 bytes)
  234 CODE      1 pages    82EA0000 - 82EB0000 (65536 bytes)
  235 CODE      1 pages    82EB0000 - 82EC0000 (65536 bytes)
  236 CODE      1 pages    82EC0000 - 82ED0000 (65536 bytes)
  237 CODE      1 pages    82ED0000 - 82EE0000 (65536 bytes)
  238 CODE      1 pages    82EE0000 - 82EF0000 (65536 bytes)
  239 CODE      1 pages    82EF0000 - 82F00000 (65536 bytes)
  240 CODE      1 pages    82F00000 - 82F10000 (65536 bytes)
  241 CODE      1 pages    82F10000 - 82F20000 (65536 bytes)
  242 CODE      1 pages    82F20000 - 82F30000 (65536 bytes)
  243 CODE      1 pages    82F30000 - 82F40000 (65536 bytes)
  244 RWDATA    1 pages    82F40000 - 82F50000 (65536 bytes)
  245 RWDATA    1 pages    82F50000 - 82F60000 (65536 bytes)
  246 RWDATA    1 pages    82F60000 - 82F70000 (65536 bytes)
  247 RWDATA    1 pages    82F70000 - 82F80000 (65536 bytes)
  248 RWDATA    1 pages    82F80000 - 82F90000 (65536 bytes)
  249 RWDATA    1 pages    82F90000 - 82FA0000 (65536 bytes)
  250 RWDATA    1 pages    82FA0000 - 82FB0000 (65536 bytes)
  251 RWDATA    1 pages    82FB0000 - 82FC0000 (65536 bytes)
  252 RWDATA    1 pages    82FC0000 - 82FD0000 (65536 bytes)
  253 RWDATA    1 pages    82FD0000 - 82FE0000 (65536 bytes)
  254 RWDATA    1 pages    82FE0000 - 82FF0000 (65536 bytes)
  255 RWDATA    1 pages    82FF0000 - 83000000 (65536 bytes)
  256 RWDATA    1 pages    83000000 - 83010000 (65536 bytes)
  257 RWDATA    1 pages    83010000 - 83020000 (65536 bytes)
  258 RWDATA    1 pages    83020000 - 83030000 (65536 bytes)
  259 RWDATA    1 pages    83030000 - 83040000 (65536 bytes)
  260 RWDATA    1 pages    83040000 - 83050000 (65536 bytes)
  261 RWDATA    1 pages    83050000 - 83060000 (65536 bytes)
  262 RWDATA    1 pages    83060000 - 83070000 (65536 bytes)
  263 RWDATA    1 pages    83070000 - 83080000 (65536 bytes)
  264 RWDATA    1 pages    83080000 - 83090000 (65536 bytes)
  265 RWDATA    1 pages    83090000 - 830A0000 (65536 bytes)
  266 RWDATA    1 pages    830A0000 - 830B0000 (65536 bytes)
  267 RWDATA    1 pages    830B0000 - 830C0000 (65536 bytes)
  268 RWDATA    1 pages    830C0000 - 830D0000 (65536 bytes)
  269 RWDATA    1 pages    830D0000 - 830E0000 (65536 bytes)
  270 RWDATA    1 pages    830E0000 - 830F0000 (65536 bytes)
  271 RWDATA    1 pages    830F0000 - 83100000 (65536 bytes)
  272 RWDATA    1 pages    83100000 - 83110000 (65536 bytes)
  273 RWDATA    1 pages    83110000 - 83120000 (65536 bytes)
  274 RWDATA    1 pages    83120000 - 83130000 (65536 bytes)
  275 RWDATA    1 pages    83130000 - 83140000 (65536 bytes)
  276 RWDATA    1 pages    83140000 - 83150000 (65536 bytes)
  277 RWDATA    1 pages    83150000 - 83160000 (65536 bytes)
  278 RWDATA    1 pages    83160000 - 83170000 (65536 bytes)
  279 RWDATA    1 pages    83170000 - 83180000 (65536 bytes)
  280 RWDATA    1 pages    83180000 - 83190000 (65536 bytes)
  281 RWDATA    1 pages    83190000 - 831A0000 (65536 bytes)
  282 RWDATA    1 pages    831A0000 - 831B0000 (65536 bytes)
  283 RWDATA    1 pages    831B0000 - 831C0000 (65536 bytes)
  284 RWDATA    1 pages    831C0000 - 831D0000 (65536 bytes)
  285 RWDATA    1 pages    831D0000 - 831E0000 (65536 bytes)
  286 RODATA    1 pages    831E0000 - 831F0000 (65536 bytes)
  287 RODATA    1 pages    831F0000 - 83200000 (65536 bytes)
  288 RODATA    1 pages    83200000 - 83210000 (65536 bytes)
  289 RODATA    1 pages    83210000 - 83220000 (65536 bytes)
  290 RODATA    1 pages    83220000 - 83230000 (65536 bytes)
  291 RODATA    1 pages    83230000 - 83240000 (65536 bytes)
  292 RODATA    1 pages    83240000 - 83250000 (65536 bytes)
  293 RODATA    1 pages    83250000 - 83260000 (65536 bytes)
  294 RODATA    1 pages    83260000 - 83270000 (65536 bytes)
  295 RODATA    1 pages    83270000 - 83280000 (65536 bytes)
  296 RODATA    1 pages    83280000 - 83290000 (65536 bytes)
Imports:
 xam - 99 imports
   Version: 0.0.9328.32
   Min Version: 0.0.8955.32

         Total:   99
         Known:  100% (99 known, 0 unknown)
   Implemented:   76% (76 implemented, 23 unimplemented)

   F 82000600 82F266E4 2DC ( 732) !! XamShowMessageBoxUIEx
   F 82000604 82F266F4 3CD ( 973)    XGetLanguage
   F 82000608 82F26704 3CB ( 971)    XGetAVPack
   F 8200060C 82F26714 1A9 ( 425)    XamLoaderTerminateTitle
   F 82000610 82F26E44 280 ( 640)    XamGetExecutionId
   F 82000614 82F26614 198 ( 408)    XamInputGetKeystrokeEx
   F 82000618 82F266A4 192 ( 402)    XamInputSetState
   F 8200061C 82F26E34 191 ( 401)    XamInputGetState
   F 82000620 82F26E24 190 ( 400)    XamInputGetCapabilities
   F 82000624 82F26E14 1AF ( 431) !! XamTaskSchedule
   F 82000628 82F26E04 1B1 ( 433) !! XamTaskCloseHandle
   F 8200062C 82F26DF4 1B3 ( 435) !! XamTaskShouldExit
   F 82000630 82F26DE4 1A4 ( 420)    XamLoaderLaunchTitle
   F 82000634 82F26DD4 250 ( 592)    XamEnumerate
   F 82000638 82F26DC4 2EE ( 750)    XamUserCreateAchievementEnumerator
   F 8200063C 82F26DB4 2F7 ( 759) !! XamUserCreateStatsEnumerator
   F 82000640 82F26DA4 20E ( 526)    XamUserGetName
   F 82000644 82F26D94 227 ( 551)    XamUserGetSigninInfo
   F 82000648 82F26D84 2CE ( 718) !! XamShowFriendRequestUI
   F 8200064C 82F26D74 2CB ( 715)    XamShowDeviceSelectorUI
   F 82000650 82F26D64 2C7 ( 711) !! XamShowMarketplaceUI
   F 82000654 82F26D54 2C6 ( 710) !! XamShowPlayerReviewUI
   F 82000658 82F26D44 2D5 ( 725) !! XamShowGamerCardUIForXUID
   F 8200065C 82F26D34 2C1 ( 705)    XamShowKeyboardUI
   F 82000660 82F26D24 2BF ( 703) !! XamShowFriendsUI
   F 82000664 82F26D14 2BC ( 700)    XamShowSigninUI
   F 82000668 82F268A4 1A8 ( 424)    XamLoaderGetLaunchData
   F 8200066C 82F268B4 3CC ( 972)    XGetGameRegion
   F 82000670 82F268C4 28C ( 652)    XNotifyPositionUI
   F 82000674 82F26694 28B ( 651)    XNotifyGetNext
   F 82000678 82F26664 3D1 ( 977)    XGetVideoMode
   F 8200067C 82F268D4 1A6 ( 422)    XamLoaderSetLaunchData
   F 82000680 82F268E4 24E ( 590)    XamCreateEnumeratorHandle
   F 82000684 82F268F4 1FC ( 508)    XMsgStartIORequestEx
   F 82000688 82F26904 1F7 ( 503)    XMsgStartIORequest
   F 8200068C 82F26914 282 ( 642)    XamGetSystemVersion
   F 82000690 82F26924 1F4 ( 500)    XMsgInProcessCall
   F 82000694 82F26934 24F ( 591)    XamGetPrivateEnumStructureFromHandle
   F 82000698 82F26944 28A ( 650)    XamNotifyCreateListener
   F 8200069C 82F26954 212 ( 530)    XamUserCheckPrivilege
   F 820006A0 82F26964 219 ( 537)    XamUserReadProfileSettings
   F 820006A4 82F26974 210 ( 528)    XamUserGetSigninState
   F 820006A8 82F26984 30D ( 781)    XamVoiceHeadsetPresent
   F 820006AC 82F26994 30F ( 783)    XamVoiceClose
   F 820006B0 82F269A4 1F8 ( 504)    XMsgCancelIORequest
   F 820006B4 82F269B4 30E ( 782) !! XamVoiceSubmitPacket
   F 820006B8 82F269C4 30C ( 780)    XamVoiceCreate
   F 820006BC 82F269D4 213 ( 531)    XamUserAreUsersFriends
   F 820006C0 82F269E4 317 ( 791)    XamSessionRefObjByHandle
   F 820006C4 82F269F4 316 ( 790)    XamSessionCreateHandle
   F 820006C8 82F26A04 001 (   1)    NetDll_WSAStartup
   F 820006CC 82F26A14 002 (   2)    NetDll_WSACleanup
   F 820006D0 82F26A24 003 (   3)    NetDll_socket
   F 820006D4 82F26A34 004 (   4)    NetDll_closesocket
   F 820006D8 82F26A44 005 (   5)    NetDll_shutdown
   F 820006DC 82F26A54 006 (   6)    NetDll_ioctlsocket
   F 820006E0 82F26A64 007 (   7)    NetDll_setsockopt
   F 820006E4 82F26A74 009 (   9) !! NetDll_getsockname
   F 820006E8 82F26A84 00B (  11)    NetDll_bind
   F 820006EC 82F26A94 00C (  12)    NetDll_connect
   F 820006F0 82F26AA4 00D (  13)    NetDll_listen
   F 820006F4 82F26AB4 00E (  14)    NetDll_accept
   F 820006F8 82F26AC4 00F (  15)    NetDll_select
   F 820006FC 82F26AD4 012 (  18)    NetDll_recv
   F 82000700 82F26AE4 014 (  20)    NetDll_recvfrom
   F 82000704 82F26AF4 016 (  22)    NetDll_send
   F 82000708 82F26B04 018 (  24)    NetDll_sendto
   F 8200070C 82F26B14 01A (  26)    NetDll_inet_addr
   F 82000710 82F26B24 01B (  27)    NetDll_WSAGetLastError
   F 82000714 82F26B34 022 (  34) !! NetDll___WSAFDIsSet
   F 82000718 82F26B44 136 ( 310) !! XNetLogonGetTitleID
   F 8200071C 82F26B54 1EC ( 492)    XamFree
   F 82000720 82F26B64 1EA ( 490)    XamAlloc
   F 82000724 82F26B74 033 (  51)    NetDll_XNetStartup
   F 82000728 82F26B84 034 (  52)    NetDll_XNetCleanup
   F 8200072C 82F26B94 037 (  55) !! NetDll_XNetRegisterKey
   F 82000730 82F26BA4 038 (  56) !! NetDll_XNetUnregisterKey
   F 82000734 82F26BB4 039 (  57)    NetDll_XNetXnAddrToInAddr
   F 82000738 82F26BC4 03A (  58) !! NetDll_XNetServerToInAddr
   F 8200073C 82F26BD4 03F (  63) !! NetDll_XNetUnregisterInAddr
   F 82000740 82F26BE4 041 (  65) !! NetDll_XNetConnect
   F 82000744 82F26BF4 042 (  66) !! NetDll_XNetGetConnectStatus
   F 82000748 82F26C04 043 (  67)    NetDll_XNetDnsLookup
   F 8200074C 82F26C14 044 (  68)    NetDll_XNetDnsRelease
   F 82000750 82F26C24 045 (  69)    NetDll_XNetQosListen
   F 82000754 82F26C34 046 (  70) !! NetDll_XNetQosLookup
   F 82000758 82F26C44 048 (  72) !! NetDll_XNetQosRelease
   F 8200075C 82F26C54 049 (  73)    NetDll_XNetGetTitleXnAddr
   F 82000760 82F26C64 04B (  75)    NetDll_XNetGetEthernetLinkStatus
   F 82000764 82F26C74 04E (  78)    NetDll_XNetGetOpt
   F 82000768 82F26C84 135 ( 309) !! XNetLogonGetMachineID
   F 8200076C 82F26C94 20A ( 522)    XamUserGetXUID
   F 82000770 82F26CA4 259 ( 601)    XamContentCreateEx
   F 82000774 82F26CB4 25A ( 602)    XamContentClose
   F 82000778 82F26CC4 262 ( 610)    XamContentGetCreator
   F 8200077C 82F26CD4 266 ( 614)    XamContentGetLicenseMask
   F 82000780 82F26CE4 25C ( 604)    XamContentCreateEnumerator
   F 82000784 82F26CF4 265 ( 613)    XamContentGetDeviceState
   F 82000788 82F26D04 25E ( 606)    XamContentGetDeviceData

 xboxkrnl - 163 imports
   Version: 0.0.9328.32
   Min Version: 0.0.8955.32

         Total:  163
         Known:  100% (163 known, 0 unknown)
   Implemented:   87% (142 implemented, 21 unimplemented)

   F 82000790 82F265F4 0FD ( 253)    NtWaitForSingleObjectEx
   F 82000794 82F26894 136 ( 310)    RtlRaiseException
   F 82000798 82F26884 12E ( 302)    RtlInitializeCriticalSection
   F 8200079C 82F26874 11B ( 283)    RtlCompareMemoryUlong
   F 820007A0 82F26634 066 ( 102)    KeGetCurrentProcessType
   F 820007A4 82F26864 053 (  83)    KeBugCheckEx
   F 820007A8 82F26854 126 ( 294)    RtlFillMemoryUlong
   V 820007AC          156 ( 342)    XboxHardwareInfo
   F 820007B0 82F26844 135 ( 309)    RtlNtStatusToDosError
   F 820007B4 82F26834 028 (  40)    HalReturnToFirmware
   V 820007B8          193 ( 403)    XexExecutableModuleHandle
   F 820007BC 82F26824 12B ( 299)    RtlImageXexHeaderField
   F 820007C0 82F26644 125 ( 293)    RtlEnterCriticalSection
   F 820007C4 82F26814 130 ( 304)    RtlLeaveCriticalSection
   V 820007C8          1AE ( 430)    ExLoadedCommandLine
   V 820007CC          059 (  89)    KeDebugMonitorData
   F 820007D0 82F26804 097 ( 151)    KeSetAffinityThread
   F 820007D4 82F267F4 09C ( 156)    KeSetDisableBoostThread
   F 820007D8 82F267E4 081 ( 129)    KeQueryBasePriorityThread
   V 820007DC          01B (  27) !! ExThreadObjectType
   F 820007E0 82F267D4 110 ( 272)    ObReferenceObjectByHandle
   F 820007E4 82F267C4 099 ( 153)    KeSetBasePriorityThread
   F 820007E8 82F267B4 105 ( 261)    ObDereferenceObject
   F 820007EC 82F267A4 0DC ( 220)    NtFreeVirtualMemory
   F 820007F0 82F26794 0CC ( 204)    NtAllocateVirtualMemory
   F 820007F4 82F26784 1A5 ( 421) !! __C_specific_handler
   F 820007F8 82F26774 003 (   3)    DbgPrint
   F 820007FC 82F26764 194 ( 404)    XexCheckExecutablePrivilege
   F 82000800 82F26754 010 (  16)    ExGetXConfigSetting
   F 82000804 82F26744 0D1 ( 209)    NtCreateEvent
   F 82000808 82F26734 0CF ( 207)    NtClose
   F 8200080C 82F266B4 0C6 ( 198)    MmQueryStatistics
   F 82000810 82F26724 0EE ( 238)    NtQueryVirtualMemory
   F 82000814 82F26E54 12F ( 303)    RtlInitializeCriticalSectionAndSpinCount
   F 82000818 82F26684 141 ( 321)    RtlTryEnterCriticalSection
   F 8200081C 82F26E64 052 (  82)    KeBugCheck
   F 82000820 82F26E74 152 ( 338)    KeTlsAlloc
   F 82000824 82F26E84 154 ( 340)    KeTlsGetValue
   F 82000828 82F26E94 155 ( 341)    KeTlsSetValue
   F 8200082C 82F26EA4 153 ( 339)    KeTlsFree
   F 82000830 82F26EB4 147 ( 327) !! RtlUnwind
   F 82000834 82F26EC4 1F8 ( 504)    XAudioGetVoiceCategoryVolume
   F 82000838 82F26ED4 0BE ( 190)    MmGetPhysicalAddress
   F 8200083C 82F26EE4 0C2 ( 194)    MmMapIoSpace
   F 82000840 82F26EF4 224 ( 548)    XMACreateContext
   F 82000844 82F26F04 226 ( 550)    XMAReleaseContext
   F 82000848 82F26F14 083 ( 131)    KeQueryPerformanceFrequency
   F 8200084C 82F26F24 09D ( 157)    KeSetEvent
   F 82000850 82F26F34 0B0 ( 176)    KeWaitForSingleObject
   F 82000854 82F26F44 0AF ( 175)    KeWaitForMultipleObjects
   F 82000858 82F26F54 1F5 ( 501)    XAudioSubmitRenderDriverFrame
   F 8200085C 82F26F64 1F4 ( 500)    XAudioUnregisterRenderDriverClient
   F 82000860 82F26F74 07D ( 125)    KeLeaveCriticalRegion
   F 82000864 82F26F84 015 (  21)    ExRegisterTitleTerminateNotification
   F 82000868 82F26F94 05F (  95)    KeEnterCriticalRegion
   F 8200086C 82F26FA4 1F3 ( 499)    XAudioRegisterRenderDriverClient
   F 82000870 82F26FB4 1FF ( 511)    XAudioGetSpeakerConfig
   F 82000874 82F26624 0B4 ( 180)    KfReleaseSpinLock
   F 82000878 82F266C4 0B1 ( 177)    KfAcquireSpinLock
   F 8200087C 82F26FC4 197 ( 407)    XexGetProcedureAddress
   F 82000880 82F26FD4 195 ( 405)    XexGetModuleHandle
   V 82000884          266 ( 614)    KeCertMonitorData
   V 82000888          1BE ( 446)    VdGlobalDevice
   V 8200088C          1BF ( 447)    VdGlobalXamDevice
   F 82000890 82F26FE4 0BD ( 189)    MmFreePhysicalMemory
   F 82000894 82F26FF4 1C7 ( 455)    VdPersistDisplay
   F 82000898 82F27004 25B ( 603)    VdSwap
   F 8200089C 82F27014 1BD ( 445)    VdGetSystemCommandBuffer
   F 820008A0 82F27024 13B ( 315)    sprintf
   F 820008A4 82F27034 0C4 ( 196)    MmQueryAddressProtect
   F 820008A8 82F27044 1B4 ( 436)    VdEnableDisableClockGating
   F 820008AC 82F27054 089 ( 137)    KeReleaseSpinLockFromRaisedIrql
   F 820008B0 82F27064 04D (  77)    KeAcquireSpinLockAtRaisedIrql
   F 820008B4 82F27074 1DF ( 479)    KiApcNormalRoutineNop
   F 820008B8 82F27084 1B6 ( 438)    VdEnableRingBufferRPtrWriteBack
   F 820008BC 82F27094 1C3 ( 451)    VdInitializeRingBuffer
   F 820008C0 82F270A4 1D9 ( 473)    VdSetSystemCommandBufferGpuIdentifierAddress
   F 820008C4 82F270B4 1B9 ( 441)    VdGetCurrentDisplayGamma
   F 820008C8 82F270C4 14D ( 333)    _vsnprintf
   V 820008CC          158 ( 344)    XboxKrnlVersion
   F 820008D0 82F270D4 1DC ( 476)    VdShutdownEngines
   F 820008D4 82F270E4 1CA ( 458)    VdQueryVideoMode
   F 820008D8 82F270F4 1BA ( 442)    VdGetCurrentDisplayInformation
   F 820008DC 82F27104 1D3 ( 467)    VdSetDisplayMode
   F 820008E0 82F27114 1D5 ( 469)    VdSetGraphicsInterruptCallback
   F 820008E4 82F27124 1C2 ( 450)    VdInitializeEngines
   F 820008E8 82F27134 1C6 ( 454)    VdIsHSIOTrainingSucceeded
   F 820008EC 82F27144 1C9 ( 457)    VdQueryVideoFlags
   F 820008F0 82F27154 1B1 ( 433)    VdCallGraphicsNotificationRoutines
   V 820008F4          1C0 ( 448)    VdGpuClockInMHz
   F 820008F8 82F27164 1C5 ( 453)    VdInitializeScalerCommandBuffer
   F 820008FC 82F27174 269 ( 617)    VdRetrainEDRAM
   F 82000900 82F27184 26A ( 618)    VdRetrainEDRAMWorker
   V 82000904          1C1 ( 449)    VdHSIOCalibrationLock
   F 82000908 82F27194 0BA ( 186)    MmAllocatePhysicalMemoryEx
   F 8200090C 82F271A4 104 ( 260)    ObDeleteSymbolicLink
   F 82000910 82F271B4 103 ( 259)    ObCreateSymbolicLink
   F 82000914 82F271C4 12C ( 300)    RtlInitAnsiString
   F 82000918 82F271D4 06B ( 107)    KeLockL2
   F 8200091C 82F271E4 06C ( 108)    KeUnlockL2
   F 82000920 82F271F4 08F ( 143)    KeResetEvent
   F 82000924 82F27204 06F ( 111)    KeInitializeDpc
   F 82000928 82F27214 0DF ( 223)    NtOpenFile
   F 8200092C 82F27224 0D2 ( 210)    NtCreateFile
   V 82000930          0AD ( 173)    KeTimeStampBundle
   F 82000934 82F27234 0D5 ( 213)    NtCreateSemaphore
   F 82000938 82F26654 0F3 ( 243)    NtReleaseSemaphore
   F 8200093C 82F26604 0FE ( 254)    NtWaitForMultipleObjectsEx
   F 82000940 82F27244 0C5 ( 197)    MmQueryAllocationSize
   F 82000944 82F27254 0F6 ( 246)    NtSetEvent
   F 82000948 82F27264 0D4 ( 212)    NtCreateMutant
   F 8200094C 82F26674 0F2 ( 242)    NtReleaseMutant
   F 82000950 82F27274 0F5 ( 245)    NtResumeThread
   F 82000954 82F27284 019 (  25)    ExTerminateThread
   F 82000958 82F27294 25A ( 602) !! StfsControlDevice
   F 8200095C 82F272A4 259 ( 601) !! StfsCreateDevice
   F 82000960 82F272B4 0EF ( 239)    NtQueryVolumeInformationFile
   F 82000964 82F272C4 257 ( 599) !! XeKeysConsoleSignatureVerification
   F 82000968 82F272D4 192 ( 402)    XeCryptSha
   F 8200096C 82F272E4 0FF ( 255)    NtWriteFile
   F 82000970 82F272F4 0F0 ( 240)    NtReadFile
   F 82000974 82F27304 256 ( 598) !! XeKeysConsolePrivateKeySign
   F 82000978 82F27314 13A ( 314)    _snprintf
   F 8200097C 82F27324 0DB ( 219)    NtFlushBuffersFile
   F 82000980 82F27334 03B (  59) !! IoDismountVolume
   F 82000984 82F27344 0F7 ( 247)    NtSetInformationFile
   F 82000988 82F27354 0E8 ( 232)    NtQueryInformationFile
   F 8200098C 82F27364 0E7 ( 231)    NtQueryFullAttributesFile
   F 82000990 82F27374 140 ( 320)    RtlTimeToTimeFields
   F 82000994 82F27384 084 ( 132)    KeQuerySystemTime
   F 82000998 82F27394 001 (   1)    DbgBreakPoint
   F 8200099C 82F273A4 133 ( 307)    RtlMultiByteToUnicodeN
   F 820009A0 82F273B4 127 ( 295)    RtlFreeAnsiString
   F 820009A4 82F273C4 142 ( 322)    RtlUnicodeStringToAnsiString
   F 820009A8 82F273D4 12D ( 301)    RtlInitUnicodeString
   F 820009AC 82F273E4 0CE ( 206)    NtClearEvent
   F 820009B0 82F273F4 0CD ( 205)    NtCancelTimer
   F 820009B4 82F27404 0FA ( 250)    NtSetTimerEx
   F 820009B8 82F27414 0D7 ( 215)    NtCreateTimer
   F 820009BC 82F27424 0DA ( 218)    NtDuplicateObject
   F 820009C0 82F27434 00D (  13)    ExCreateThread
   F 820009C4 82F27444 143 ( 323)    RtlUnicodeToMultiByteN
   F 820009C8 82F27454 1A1 ( 417)    XexUnloadImage
   F 820009CC 82F27464 199 ( 409)    XexLoadImage
   F 820009D0 82F27474 0E4 ( 228)    NtQueryDirectoryFile
   F 820009D4 82F27484 0F1 ( 241) !! NtReadFileScatter
   F 820009D8 82F266D4 05A (  90)    KeDelayExecutionThread
   F 820009DC 82F27494 041 (  65) !! IoInvalidDeviceRequest
   F 820009E0 82F274A4 10F ( 271) !! ObReferenceObject
   F 820009E4 82F274B4 037 (  55) !! IoCreateDevice
   F 820009E8 82F274C4 039 (  57) !! IoDeleteDevice
   F 820009EC 82F274D4 00B (  11)    ExAllocatePoolTypeWithTag
   F 820009F0 82F274E4 00F (  15)    ExFreePool
   F 820009F4 82F274F4 11D ( 285)    RtlCompareStringN
   F 820009F8 82F27504 13F ( 319)    RtlTimeFieldsToTime
   F 820009FC 82F27514 035 (  53) !! IoCompleteRequest
   F 82000A00 82F27524 149 ( 329) !! RtlUpcaseUnicodeChar
   F 82000A04 82F27534 109 ( 265) !! ObIsTitleObject
   F 82000A08 82F27544 034 (  52) !! IoCheckShareAccess
   F 82000A0C 82F27554 047 (  71) !! IoSetShareAccess
   F 82000A10 82F27564 045 (  69) !! IoRemoveShareAccess
   F 82000A14 82F27574 03C (  60) !! IoDismountVolumeByFileHandle
   F 82000A18 82F27584 0D9 ( 217) !! NtDeviceIoControlFile

i> 00002A80 Added handle:00000024 for N2xe6kernel7XObjectE
i> 00002A80 XThread00000024 (5) Stack: 40110000-40130000
i> 00002A80 KernelState: Launching module...
i> 00002A80 Added handle:00000028 for N2xe6kernel7XObjectE
K> 00000024 XThread::Execute thid 5 (handle=00000024, 'Kernel Dispatch (00000024)', native=AB7FE700, <host>)
i> 00002A80 XThread00000028 (6) Stack: 40150000-40190000
K> 00000028 XThread::Execute thid 6 (handle=00000028, 'Main XThread (00000028)', native=9AFFD700)
```

After the fix, the above lines are the same but the following lines show how far the emulator goes before crashing:
```
d> 00000028 RtlImageXexHeaderField(00030000, 00020401)
d> 00000028 NtAllocateVirtualMemory(4018FB90(00000000), 4018FC84(00100000), 60002000, 00000004, 00000000)
d> 00000028 NtAllocateVirtualMemory = 401A0000
d> 00000028 NtAllocateVirtualMemory(4018FB94(401A0000), 4018FC8C(00010000), 60001000, 00000004, 00000000)
d> 00000028 NtAllocateVirtualMemory = 401A0000
d> 00000028 RtlInitializeCriticalSection(401A0618)
d> 00000028 XexCheckExecutablePrivilege(0000000A)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B8670, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B868C, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B86A8, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B86C4, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B86E0, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B86FC, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B8718, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B8734, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B8750, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B876C, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B8788, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B87A4, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B87C0, 00000FA0)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(831B87DC, 00000FA0)
d> 00000028 KeTlsAlloc()
d> 00000028 KeTlsSetValue(00000000, 401A06A0)
d> 00000028 MmAllocatePhysicalMemoryEx(00000000, 04200000, 20000004, 00000000, FFFFFFFF, 00000000)
d> 00000028 MmAllocatePhysicalMemoryEx = BBAA0000
d> 00000028 MmQueryStatistics(4018FB30)
d> 00000028 MmAllocatePhysicalMemoryEx(00000000, 0003EF22, 20000004, 00000000, FFFFFFFF, 00000000)
d> 00000028 MmAllocatePhysicalMemoryEx = BBA60000
d> 00000028 MmAllocatePhysicalMemoryEx(00000000, 14FB7000, 20000004, 00000000, FFFFFFFF, 00000000)
d> 00000028 MmAllocatePhysicalMemoryEx = A6AA0000
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83039C2C, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83039C4C, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(830413AC, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83041AD0, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83041B54, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83041B74, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83044A70, 000003E8)
d> 00000028 RtlInitializeCriticalSectionAndSpinCount(83081CF8, 000003E8)
```

</p>
</details>