### PR TITLE
Implement additional fast paths for VECTOR_SHL_V128 (INT8_TYPE), ADD_I8, ADD_I16, ADD_I32, ADD_I64, SUB_I8, SUB_I16, SUB_I32, SUB_I64, MUL_I32, MUL_I64, DIV_I32, DIV_I64.

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -715,17 +715,20 @@ struct VECTOR_SHL_V128
       for (unsigned j = 1; j < 16; ++j) {
         if (i.src2.constant().u8[j] != n) {
           all = false;
-
           break;
         }
       }
       if (all) {
-        vec128_t bleh;
+        // we build a mask to eliminate the bits that will be shifted out of the
+        // bytes so that they do not enter the adjacent bytes
+        vec128_t shiftout_mask; 
 
         uint8_t mask = ~(uint8_t)(((uint16_t)0x100) >> n);
 
-        for (unsigned i = 0; i < 16; ++i) bleh.u8[i] = mask;
-        e.LoadConstantXmm(e.xmm0, bleh);
+        for (unsigned i = 0; i < 16; ++i) {
+          shiftout_mask.u8[i] = mask;
+        }
+        e.LoadConstantXmm(e.xmm0, shiftout_mask);
         e.vpand(e.xmm0, e.xmm0, i.src1);
         e.vpsllw(i.dest, e.xmm0, n);
         return;

--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -708,7 +708,6 @@ struct VECTOR_SHL_V128
 
   static void EmitInt8(X64Emitter& e, const EmitArgType& i) {
     // TODO(benvanik): native version (with shift magic).
-
     if (i.src2.is_constant) {
       unsigned char n = i.src2.constant().u8[0];
       bool all = true;
@@ -721,10 +720,8 @@ struct VECTOR_SHL_V128
       if (all) {
         // we build a mask to eliminate the bits that will be shifted out of the
         // bytes so that they do not enter the adjacent bytes
-        vec128_t shiftout_mask; 
-
         uint8_t mask = ~(uint8_t)(((uint16_t)0x100) >> n);
-
+        vec128_t shiftout_mask;
         for (unsigned i = 0; i < 16; ++i) {
           shiftout_mask.u8[i] = mask;
         }
@@ -742,7 +739,6 @@ struct VECTOR_SHL_V128
     }
     e.lea(e.GetNativeParam(0), e.StashXmm(0, i.src1));
     e.CallNativeSafe(reinterpret_cast<void*>(EmulateVectorShl<uint8_t>));
-
     e.vmovaps(i.dest, e.xmm0);
   }
 

--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -708,6 +708,29 @@ struct VECTOR_SHL_V128
 
   static void EmitInt8(X64Emitter& e, const EmitArgType& i) {
     // TODO(benvanik): native version (with shift magic).
+
+    if (i.src2.is_constant) {
+      unsigned char n = i.src2.constant().u8[0];
+      bool all = true;
+      for (unsigned j = 1; j < 16; ++j) {
+        if (i.src2.constant().u8[j] != n) {
+          all = false;
+
+          break;
+        }
+      }
+      if (all) {
+        vec128_t bleh;
+
+        uint8_t mask = ~(uint8_t)(((uint16_t)0x100) >> n);
+
+        for (unsigned i = 0; i < 16; ++i) bleh.u8[i] = mask;
+        e.LoadConstantXmm(e.xmm0, bleh);
+        e.vpand(e.xmm0, e.xmm0, i.src1);
+        e.vpsllw(i.dest, e.xmm0, n);
+        return;
+      }
+    }
     if (i.src2.is_constant) {
       e.LoadConstantXmm(e.xmm0, i.src2.constant());
       e.lea(e.GetNativeParam(1), e.StashXmm(1, e.xmm0));
@@ -716,6 +739,7 @@ struct VECTOR_SHL_V128
     }
     e.lea(e.GetNativeParam(0), e.StashXmm(0, i.src1));
     e.CallNativeSafe(reinterpret_cast<void*>(EmulateVectorShl<uint8_t>));
+
     e.vmovaps(i.dest, e.xmm0);
   }
 

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1886,7 +1886,6 @@ struct DIV_I16 : Sequence<DIV_I16, I<OPCODE_DIV, I16Op, I16Op, I16Op>> {
         e.idiv(i.src2);
       }
     }
-
     e.L(skip);
     e.outLocalLabel();
     e.mov(i.dest, e.ax);
@@ -1902,7 +1901,6 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
       e.mov(e.ecx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
         auto div_shift_info = magicu<unsigned>(i.src2.value->constant.u32);
-        // todo: handle the add flag.
         e.mov(i.dest, i.src1);
         if (e.IsFeatureEnabled(kX64EmitAVX2)) {
           e.mov(e.edx, div_shift_info.M);
@@ -1912,14 +1910,12 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
           e.mul(i.dest);
           e.mov(i.dest, e.edx);
         }
-
         if (div_shift_info.a) {
           // pg 228, hackers delight, 2nd edition. add initial input to product,
           // result may carry we need to handle this carry, treat result as 33
           // bits with carry as bit 33
           e.add(i.dest, i.src1);
           e.rcr(i.dest, 1);
-    
         }
         if (div_shift_info.s != 0) {
           e.shr(i.dest, div_shift_info.s);
@@ -1954,7 +1950,6 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
         e.idiv(i.src2);
       }
     }
-
     e.L(skip);
     e.outLocalLabel();
     e.mov(i.dest, e.eax);
@@ -1970,16 +1965,14 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
       e.mov(e.rcx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
         auto div_shift_info = magicu<uint64_t>(i.src2.value->constant.u32);
-        // todo: handle addflag
-
         if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-        e.mov(e.rdx, div_shift_info.M);
-        e.mov(i.dest, i.src1);
-        e.mulx(i.dest, i.dest, i.dest);
+          e.mov(e.rdx, div_shift_info.M);
+          e.mov(i.dest, i.src1);
+          e.mulx(i.dest, i.dest, i.dest);
         } else {
-        e.mov(e.rax, div_shift_info.M);
-        e.mul(i.src1);
-        e.mov(i.dest, e.rdx);
+          e.mov(e.rax, div_shift_info.M);
+          e.mul(i.src1);
+          e.mov(i.dest, e.rdx);
         }
         if (div_shift_info.a) {
           // pg 228, hackers delight, 2nd edition. add initial input to product,
@@ -1987,13 +1980,11 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
           // bits with carry as bit 65
           e.add(i.dest, i.src1);
           e.rcr(i.dest, 1);
-		}
+        }
         if (div_shift_info.s) {
           e.shr(i.dest, div_shift_info.s);
         }
         return;
-
-
       } else {
         e.mov(e.rax, i.src1);
         e.cqo();  // rdx:rax = sign-extend rax

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1470,17 +1470,14 @@ struct MUL_I64 : Sequence<MUL_I64, I<OPCODE_MUL, I64Op, I64Op, I64Op>> {
     if (i.src2.is_constant) {
       if (i.src2.value->constant.u64 == 3) {
         e.lea(i.dest, e.ptr[i.src1.reg() * 2 + i.src1.reg()]);
-        // exit(0);
         return;
       }
       if (i.src2.value->constant.u64 == 5) {
         e.lea(i.dest, e.ptr[i.src1.reg() * 4 + i.src1.reg()]);
-        // exit(0);
         return;
       }
       if (i.src2.value->constant.u64 == 9) {
         e.lea(i.dest, e.ptr[i.src1.reg() * 8 + i.src1.reg()]);
-        // exit(0);
         return;
       }
     }

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1902,29 +1902,29 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
       e.mov(e.ecx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
         auto div_shift_info = magicu<unsigned>(i.src2.value->constant.u32);
-		//todo: handle the add flag. 
-        if (!div_shift_info.a) {
-          e.mov(i.dest, i.src1);
-          if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-            e.mov(e.edx, div_shift_info.M);
-            e.mulx(i.dest, i.dest, i.dest);
-          } else {
-            e.mov(e.eax, div_shift_info.M);
-            e.mul(i.dest);
-            e.mov(i.dest, e.edx);
-          }
-          if (div_shift_info.s != 0) {
-            e.shr(i.dest, div_shift_info.s);
-          }
-
-          return;
+        // todo: handle the add flag.
+        e.mov(i.dest, i.src1);
+        if (e.IsFeatureEnabled(kX64EmitAVX2)) {
+          e.mov(e.edx, div_shift_info.M);
+          e.mulx(i.dest, i.dest, i.dest);
         } else {
-          e.mov(e.eax, i.src1);
-          // Zero upper bits.
-          e.xor_(e.edx, e.edx);
-          e.div(e.ecx);
+          e.mov(e.eax, div_shift_info.M);
+          e.mul(i.dest);
+          e.mov(i.dest, e.edx);
         }
 
+        if (div_shift_info.a) {
+          // pg 228, hackers delight, 2nd edition. add initial input to product,
+          // result may carry we need to handle this carry, treat result as 33
+          // bits with carry as bit 33
+          e.add(i.dest, i.src1);
+          e.rcr(i.dest, 1);
+    
+        }
+        if (div_shift_info.s != 0) {
+          e.shr(i.dest, div_shift_info.s);
+        }
+        return;
       } else {
         e.mov(e.eax, i.src1);
         e.cdq();  // edx:eax = sign-extend eax
@@ -1970,25 +1970,30 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
       e.mov(e.rcx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
         auto div_shift_info = magicu<uint64_t>(i.src2.value->constant.u32);
-		//todo: handle addflag
-        if (!div_shift_info.a) {
-          if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-            e.mov(e.rdx, div_shift_info.M);
-            e.mov(i.dest, i.src1);
-            e.mulx(i.dest, i.dest, i.dest);
-          } else {
-            e.mov(e.rax, div_shift_info.M);
-            e.mul(i.src1);
-            e.mov(i.dest, e.rdx);
-          }
-          e.shr(i.dest, div_shift_info.s);
-          return;
+        // todo: handle addflag
+
+        if (e.IsFeatureEnabled(kX64EmitAVX2)) {
+        e.mov(e.rdx, div_shift_info.M);
+        e.mov(i.dest, i.src1);
+        e.mulx(i.dest, i.dest, i.dest);
+        } else {
+        e.mov(e.rax, div_shift_info.M);
+        e.mul(i.src1);
+        e.mov(i.dest, e.rdx);
         }
-        e.mov(e.rcx, i.src2.constant());
-        e.mov(e.rax, i.src1);
-        // Zero upper bits.
-        e.xor_(e.rdx, e.rdx);
-        e.div(e.rcx);
+        if (div_shift_info.a) {
+          // pg 228, hackers delight, 2nd edition. add initial input to product,
+          // result may carry we need to handle this carry, treat result as 65
+          // bits with carry as bit 65
+          e.add(i.dest, i.src1);
+          e.rcr(i.dest, 1);
+		}
+        if (div_shift_info.s) {
+          e.shr(i.dest, div_shift_info.s);
+        }
+        return;
+
+
       } else {
         e.mov(e.rax, i.src1);
         e.cqo();  // rdx:rax = sign-extend rax

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1111,22 +1111,40 @@ void EmitAddXX(X64Emitter& e, const ARGS& i) {
 }
 struct ADD_I8 : Sequence<ADD_I8, I<OPCODE_ADD, I8Op, I8Op, I8Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitAddXX<ADD_I8, Reg8>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u8 == 1) {
+      e.inc(i.dest.reg());
+    } else
+      EmitAddXX<ADD_I8, Reg8>(e, i);
   }
 };
 struct ADD_I16 : Sequence<ADD_I16, I<OPCODE_ADD, I16Op, I16Op, I16Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitAddXX<ADD_I16, Reg16>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u16 == 1) {
+      e.inc(i.dest.reg());
+
+    } else
+      EmitAddXX<ADD_I16, Reg16>(e, i);
   }
 };
 struct ADD_I32 : Sequence<ADD_I32, I<OPCODE_ADD, I32Op, I32Op, I32Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitAddXX<ADD_I32, Reg32>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u32 == 1) {
+      e.inc(i.dest.reg());
+
+    } else
+      EmitAddXX<ADD_I32, Reg32>(e, i);
   }
 };
 struct ADD_I64 : Sequence<ADD_I64, I<OPCODE_ADD, I64Op, I64Op, I64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitAddXX<ADD_I64, Reg64>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u64 == 1) {
+      e.inc(i.dest.reg());
+    } else
+      EmitAddXX<ADD_I64, Reg64>(e, i);
   }
 };
 struct ADD_F32 : Sequence<ADD_F32, I<OPCODE_ADD, F32Op, F32Op, F32Op>> {
@@ -1233,22 +1251,41 @@ void EmitSubXX(X64Emitter& e, const ARGS& i) {
 }
 struct SUB_I8 : Sequence<SUB_I8, I<OPCODE_SUB, I8Op, I8Op, I8Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitSubXX<SUB_I8, Reg8>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u8 == 1) {
+      e.dec(i.dest.reg());
+    } else
+      EmitSubXX<SUB_I8, Reg8>(e, i);
   }
 };
 struct SUB_I16 : Sequence<SUB_I16, I<OPCODE_SUB, I16Op, I16Op, I16Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitSubXX<SUB_I16, Reg16>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u16 == 1) {
+      e.dec(i.dest.reg());
+
+    } else
+      EmitSubXX<SUB_I16, Reg16>(e, i);
   }
 };
 struct SUB_I32 : Sequence<SUB_I32, I<OPCODE_SUB, I32Op, I32Op, I32Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitSubXX<SUB_I32, Reg32>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u32 == 1) {
+      e.dec(i.dest.reg());
+
+    } else
+      EmitSubXX<SUB_I32, Reg32>(e, i);
   }
 };
 struct SUB_I64 : Sequence<SUB_I64, I<OPCODE_SUB, I64Op, I64Op, I64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    EmitSubXX<SUB_I64, Reg64>(e, i);
+    if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
+        i.src2.value->constant.u64 == 1) {
+      e.dec(i.dest.reg());
+
+    } else
+      EmitSubXX<SUB_I64, Reg64>(e, i);
   }
 };
 struct SUB_F32 : Sequence<SUB_F32, I<OPCODE_SUB, F32Op, F32Op, F32Op>> {
@@ -1370,6 +1407,20 @@ struct MUL_I16 : Sequence<MUL_I16, I<OPCODE_MUL, I16Op, I16Op, I16Op>> {
 };
 struct MUL_I32 : Sequence<MUL_I32, I<OPCODE_MUL, I32Op, I32Op, I32Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
+    if (i.src2.is_constant) {
+      if (i.src2.value->constant.u32 == 3) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * 2 + i.src1.reg()]);
+        return;
+      }
+      if (i.src2.value->constant.u32 == 5) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * 4 + i.src1.reg()]);
+        return;
+      }
+      if (i.src2.value->constant.u32 == 9) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * 8 + i.src1.reg()]);
+        return;
+      }
+    }
     if (e.IsFeatureEnabled(kX64EmitBMI2)) {
       // mulx: $1:$2 = EDX * $3
 
@@ -1412,6 +1463,23 @@ struct MUL_I32 : Sequence<MUL_I32, I<OPCODE_MUL, I32Op, I32Op, I32Op>> {
 };
 struct MUL_I64 : Sequence<MUL_I64, I<OPCODE_MUL, I64Op, I64Op, I64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
+    if (i.src2.is_constant) {
+      if (i.src2.value->constant.u64 == 3) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * 2 + i.src1.reg()]);
+        // exit(0);
+        return;
+      }
+      if (i.src2.value->constant.u64 == 5) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * 4 + i.src1.reg()]);
+        // exit(0);
+        return;
+      }
+      if (i.src2.value->constant.u64 == 9) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * 8 + i.src1.reg()]);
+        // exit(0);
+        return;
+      }
+    }
     if (e.IsFeatureEnabled(kX64EmitBMI2)) {
       // mulx: $1:$2 = RDX * $3
 
@@ -1669,7 +1737,62 @@ struct MUL_HI_I64
 };
 EMITTER_OPCODE_TABLE(OPCODE_MUL_HI, MUL_HI_I8, MUL_HI_I16, MUL_HI_I32,
                      MUL_HI_I64);
+/*  from Hackers Delight - by Henry S. Warren Jr. Calculate magic number for
+ * unsigned division */
+template <typename T>
+auto magicu(T d) {
+  constexpr unsigned NBITS = sizeof(T) * CHAR_BIT;
+  constexpr unsigned NBITS_M1 = NBITS - 1;
+  constexpr T SIGNBIT = T(1) << NBITS_M1;
 
+  constexpr T POSMASK = ~SIGNBIT;
+
+  struct mu {
+    T M;    // Magic number,
+    int a;  // "add" indicator,
+    int s;
+  };  // and shift amount.
+
+  // Must have 1 <= d <= 2**32-1.
+  int p, gt = 0;
+  T nc, delta, q1, r1, q2, r2;
+  struct mu magu;
+
+  magu.a = 0;  // Initialize "add" indicator.
+  nc = -1 - ((T) - (std::make_signed_t<T>)d) % d;  // Unsigned arithmetic here.
+  p = NBITS_M1;                                    // Init. p.
+  q1 = SIGNBIT / nc;                               // Init. q1 = 2**p/nc.
+  r1 = SIGNBIT - q1 * nc;                          // Init. r1 = rem(2**p, nc).
+  q2 = POSMASK / d;                                // Init. q2 = (2**p - 1)/d.
+  r2 = POSMASK - q2 * d;  // Init. r2 = rem(2**p - 1, d).
+  do {
+    p = p + 1;
+    if (q1 >= SIGNBIT) gt = 1;  // Means q1 > delta.
+    if (r1 >= nc - r1) {
+      q1 = 2 * q1 + 1;  // Update q1.
+      r1 = 2 * r1 - nc;
+    }  // Update r1.
+    else {
+      q1 = 2 * q1;
+      r1 = 2 * r1;
+    }
+    if (r2 + 1 >= d - r2) {
+      if (q2 >= POSMASK) magu.a = 1;
+      q2 = 2 * q2 + 1;  // Update q2.
+      r2 = 2 * r2 + 1 - d;
+    }  // Update r2.
+    else {
+      if (q2 >= SIGNBIT) magu.a = 1;
+      q2 = 2 * q2;
+      r2 = 2 * r2 + 1;
+    }
+    delta = d - 1 - r2;
+  } while (gt == 0 && (q1 < delta || (q1 == delta && r1 == 0)));
+
+  magu.M = q2 + 1;     // Magic number
+  magu.s = p - NBITS;  // and shift amount to return
+  return magu;         // (magu.a was set above).
+}
 // ============================================================================
 // OPCODE_DIV
 // ============================================================================
@@ -1774,10 +1897,28 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
       assert_true(!i.src1.is_constant);
       e.mov(e.ecx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
-        e.mov(e.eax, i.src1);
-        // Zero upper bits.
-        e.xor_(e.edx, e.edx);
-        e.div(e.ecx);
+        auto magicgu_val = magicu<unsigned>(i.src2.value->constant.u32);
+
+        if (!magicgu_val.a) {
+          e.mov(i.dest, i.src1);
+          if (e.IsFeatureEnabled(kX64EmitAVX2)) {
+            e.mov(e.edx, magicgu_val.M);
+            e.mulx(i.dest, i.dest, i.dest);
+          } else {
+            e.mov(e.eax, magicgu_val.M);
+            e.mul(i.dest);
+            e.mov(i.dest, e.edx);
+          }
+          if (magicgu_val.s != 0) e.shr(i.dest, magicgu_val.s);
+
+          return;
+        } else {
+          e.mov(e.eax, i.src1);
+          // Zero upper bits.
+          e.xor_(e.edx, e.edx);
+          e.div(e.ecx);
+        }
+
       } else {
         e.mov(e.eax, i.src1);
         e.cdq();  // edx:eax = sign-extend eax
@@ -1822,6 +1963,22 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
       assert_true(!i.src1.is_constant);
       e.mov(e.rcx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
+        auto magicgu_val = magicu<uint64_t>(i.src2.value->constant.u32);
+
+        if (!magicgu_val.a) {
+          if (e.IsFeatureEnabled(kX64EmitAVX2)) {
+            e.mov(e.rdx, magicgu_val.M);
+            e.mov(i.dest, i.src1);
+            e.mulx(i.dest, i.dest, i.dest);
+          } else {
+            e.mov(e.rax, magicgu_val.M);
+            e.mul(i.src1);
+            e.mov(i.dest, e.rdx);
+          }
+          e.shr(i.dest, magicgu_val.s);
+          return;
+        }
+        e.mov(e.rcx, i.src2.constant());
         e.mov(e.rax, i.src1);
         // Zero upper bits.
         e.xor_(e.rdx, e.rdx);

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1883,6 +1883,7 @@ struct DIV_I16 : Sequence<DIV_I16, I<OPCODE_DIV, I16Op, I16Op, I16Op>> {
         e.idiv(i.src2);
       }
     }
+
     e.L(skip);
     e.outLocalLabel();
     e.mov(i.dest, e.ax);
@@ -1947,6 +1948,7 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
         e.idiv(i.src2);
       }
     }
+
     e.L(skip);
     e.outLocalLabel();
     e.mov(i.dest, e.eax);

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1882,30 +1882,40 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
 
     if (i.src2.is_constant) {
       assert_true(!i.src1.is_constant);
-      e.mov(e.ecx, i.src2.constant());
+      
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
         auto div_shift_info = magicu<unsigned>(i.src2.value->constant.u32);
-        e.mov(i.dest, i.src1);
-        if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-          e.mov(e.edx, div_shift_info.M);
-          e.mulx(i.dest, i.dest, i.dest);
+		//disabling addflag for now. the code for handling it is incorrect
+        if (!div_shift_info.a) {
+          e.mov(i.dest, i.src1);
+          if (e.IsFeatureEnabled(kX64EmitAVX2)) {
+            e.mov(e.edx, div_shift_info.M);
+            e.mulx(i.dest, i.dest, i.dest);
+          } else {
+            e.mov(e.eax, div_shift_info.M);
+            e.mul(i.dest);
+            e.mov(i.dest, e.edx);
+          }
+          if (div_shift_info.a) {
+            // pg 228, hackers delight, 2nd edition. add initial input to
+            // product, result may carry we need to handle this carry, treat
+            // result as 33 bits with carry as bit 33
+            e.add(i.dest, i.src1);
+            e.rcr(i.dest, 1);
+          }
+          if (div_shift_info.s != 0) {
+            e.shr(i.dest, div_shift_info.s);
+          }
+          return;
         } else {
-          e.mov(e.eax, div_shift_info.M);
-          e.mul(i.dest);
-          e.mov(i.dest, e.edx);
-        }
-        if (div_shift_info.a) {
-          // pg 228, hackers delight, 2nd edition. add initial input to product,
-          // result may carry we need to handle this carry, treat result as 33
-          // bits with carry as bit 33
-          e.add(i.dest, i.src1);
-          e.rcr(i.dest, 1);
-        }
-        if (div_shift_info.s != 0) {
-          e.shr(i.dest, div_shift_info.s);
-        }
-        return;
+          e.mov(e.ecx, i.src2.constant());
+          e.mov(e.eax, i.src1);
+          // Zero upper bits.
+          e.xor_(e.edx, e.edx);
+          e.div(e.ecx);
+		}
       } else {
+        e.mov(e.ecx, i.src2.constant());
         e.mov(e.eax, i.src1);
         e.cdq();  // edx:eax = sign-extend eax
         e.idiv(e.ecx);
@@ -1947,30 +1957,39 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
 
     if (i.src2.is_constant) {
       assert_true(!i.src1.is_constant);
-      e.mov(e.rcx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
         auto div_shift_info = magicu<uint64_t>(i.src2.value->constant.u32);
-        if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-          e.mov(e.rdx, div_shift_info.M);
-          e.mov(i.dest, i.src1);
-          e.mulx(i.dest, i.dest, i.dest);
+		//disabled addflag for now
+        if (!div_shift_info.a) {
+          if (e.IsFeatureEnabled(kX64EmitAVX2)) {
+            e.mov(e.rdx, div_shift_info.M);
+            e.mov(i.dest, i.src1);
+            e.mulx(i.dest, i.dest, i.dest);
+          } else {
+            e.mov(e.rax, div_shift_info.M);
+            e.mul(i.src1);
+            e.mov(i.dest, e.rdx);
+          }
+          if (div_shift_info.a) {
+            // pg 228, hackers delight, 2nd edition. add initial input to
+            // product, result may carry we need to handle this carry, treat
+            // result as 65 bits with carry as bit 65
+            e.add(i.dest, i.src1);
+            e.rcr(i.dest, 1);
+          }
+          if (div_shift_info.s) {
+            e.shr(i.dest, div_shift_info.s);
+          }
+          return;
         } else {
-          e.mov(e.rax, div_shift_info.M);
-          e.mul(i.src1);
-          e.mov(i.dest, e.rdx);
-        }
-        if (div_shift_info.a) {
-          // pg 228, hackers delight, 2nd edition. add initial input to product,
-          // result may carry we need to handle this carry, treat result as 65
-          // bits with carry as bit 65
-          e.add(i.dest, i.src1);
-          e.rcr(i.dest, 1);
-        }
-        if (div_shift_info.s) {
-          e.shr(i.dest, div_shift_info.s);
-        }
-        return;
+          e.mov(e.rcx, i.src2.constant());
+          e.mov(e.rax, i.src1);
+          // Zero upper bits.
+          e.xor_(e.rdx, e.rdx);
+          e.div(e.rcx);
+		}
       } else {
+        e.mov(e.rcx, i.src2.constant());
         e.mov(e.rax, i.src1);
         e.cqo();  // rdx:rax = sign-extend rax
         e.idiv(e.rcx);

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1412,16 +1412,9 @@ struct MUL_I16 : Sequence<MUL_I16, I<OPCODE_MUL, I16Op, I16Op, I16Op>> {
 struct MUL_I32 : Sequence<MUL_I32, I<OPCODE_MUL, I32Op, I32Op, I32Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
     if (i.src2.is_constant) {
-      if (i.src2.value->constant.u32 == 3) {
-        e.lea(i.dest, e.ptr[i.src1.reg() * 2 + i.src1.reg()]);
-        return;
-      }
-      if (i.src2.value->constant.u32 == 5) {
-        e.lea(i.dest, e.ptr[i.src1.reg() * 4 + i.src1.reg()]);
-        return;
-      }
-      if (i.src2.value->constant.u32 == 9) {
-        e.lea(i.dest, e.ptr[i.src1.reg() * 8 + i.src1.reg()]);
+      uint32_t multiplier = i.src2.value->constant.u32;
+      if (multiplier == 3 || multiplier == 5 || multiplier == 9) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * (multiplier - 1) + i.src1.reg()]);
         return;
       }
     }
@@ -1468,16 +1461,9 @@ struct MUL_I32 : Sequence<MUL_I32, I<OPCODE_MUL, I32Op, I32Op, I32Op>> {
 struct MUL_I64 : Sequence<MUL_I64, I<OPCODE_MUL, I64Op, I64Op, I64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
     if (i.src2.is_constant) {
-      if (i.src2.value->constant.u64 == 3) {
-        e.lea(i.dest, e.ptr[i.src1.reg() * 2 + i.src1.reg()]);
-        return;
-      }
-      if (i.src2.value->constant.u64 == 5) {
-        e.lea(i.dest, e.ptr[i.src1.reg() * 4 + i.src1.reg()]);
-        return;
-      }
-      if (i.src2.value->constant.u64 == 9) {
-        e.lea(i.dest, e.ptr[i.src1.reg() * 8 + i.src1.reg()]);
+      uint64_t multiplier = i.src2.value->constant.u64;
+      if (multiplier == 3 || multiplier == 5 || multiplier == 9) {
+        e.lea(i.dest, e.ptr[i.src1.reg() * ((int)multiplier - 1) + i.src1.reg()]);
         return;
       }
     }

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1958,7 +1958,7 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
     if (i.src2.is_constant) {
       assert_true(!i.src1.is_constant);
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
-        auto div_shift_info = magicu<uint64_t>(i.src2.value->constant.u32);
+        auto div_shift_info = magicu<uint64_t>(i.src2.value->constant.u64);
 		//disabled addflag for now
         if (!div_shift_info.a) {
           if (e.IsFeatureEnabled(kX64EmitAVX2)) {

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1114,8 +1114,9 @@ struct ADD_I8 : Sequence<ADD_I8, I<OPCODE_ADD, I8Op, I8Op, I8Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u8 == 1) {
       e.inc(i.dest.reg());
-    } else
+    } else {
       EmitAddXX<ADD_I8, Reg8>(e, i);
+    }
   }
 };
 struct ADD_I16 : Sequence<ADD_I16, I<OPCODE_ADD, I16Op, I16Op, I16Op>> {
@@ -1123,9 +1124,9 @@ struct ADD_I16 : Sequence<ADD_I16, I<OPCODE_ADD, I16Op, I16Op, I16Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u16 == 1) {
       e.inc(i.dest.reg());
-
-    } else
+    } else {
       EmitAddXX<ADD_I16, Reg16>(e, i);
+    }
   }
 };
 struct ADD_I32 : Sequence<ADD_I32, I<OPCODE_ADD, I32Op, I32Op, I32Op>> {
@@ -1134,8 +1135,9 @@ struct ADD_I32 : Sequence<ADD_I32, I<OPCODE_ADD, I32Op, I32Op, I32Op>> {
         i.src2.value->constant.u32 == 1) {
       e.inc(i.dest.reg());
 
-    } else
+    } else {
       EmitAddXX<ADD_I32, Reg32>(e, i);
+    }
   }
 };
 struct ADD_I64 : Sequence<ADD_I64, I<OPCODE_ADD, I64Op, I64Op, I64Op>> {
@@ -1143,8 +1145,9 @@ struct ADD_I64 : Sequence<ADD_I64, I<OPCODE_ADD, I64Op, I64Op, I64Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u64 == 1) {
       e.inc(i.dest.reg());
-    } else
+    } else {
       EmitAddXX<ADD_I64, Reg64>(e, i);
+    }
   }
 };
 struct ADD_F32 : Sequence<ADD_F32, I<OPCODE_ADD, F32Op, F32Op, F32Op>> {
@@ -1254,8 +1257,9 @@ struct SUB_I8 : Sequence<SUB_I8, I<OPCODE_SUB, I8Op, I8Op, I8Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u8 == 1) {
       e.dec(i.dest.reg());
-    } else
+    } else {
       EmitSubXX<SUB_I8, Reg8>(e, i);
+    }
   }
 };
 struct SUB_I16 : Sequence<SUB_I16, I<OPCODE_SUB, I16Op, I16Op, I16Op>> {
@@ -1263,9 +1267,9 @@ struct SUB_I16 : Sequence<SUB_I16, I<OPCODE_SUB, I16Op, I16Op, I16Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u16 == 1) {
       e.dec(i.dest.reg());
-
-    } else
+    } else {
       EmitSubXX<SUB_I16, Reg16>(e, i);
+    }
   }
 };
 struct SUB_I32 : Sequence<SUB_I32, I<OPCODE_SUB, I32Op, I32Op, I32Op>> {
@@ -1273,9 +1277,9 @@ struct SUB_I32 : Sequence<SUB_I32, I<OPCODE_SUB, I32Op, I32Op, I32Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u32 == 1) {
       e.dec(i.dest.reg());
-
-    } else
+    } else {
       EmitSubXX<SUB_I32, Reg32>(e, i);
+    }
   }
 };
 struct SUB_I64 : Sequence<SUB_I64, I<OPCODE_SUB, I64Op, I64Op, I64Op>> {
@@ -1283,9 +1287,9 @@ struct SUB_I64 : Sequence<SUB_I64, I<OPCODE_SUB, I64Op, I64Op, I64Op>> {
     if (i.src2.is_constant && i.dest.reg() == i.src1.reg() &&
         i.src2.value->constant.u64 == 1) {
       e.dec(i.dest.reg());
-
-    } else
+    } else {
       EmitSubXX<SUB_I64, Reg64>(e, i);
+    }
   }
 };
 struct SUB_F32 : Sequence<SUB_F32, I<OPCODE_SUB, F32Op, F32Op, F32Op>> {
@@ -1897,19 +1901,21 @@ struct DIV_I32 : Sequence<DIV_I32, I<OPCODE_DIV, I32Op, I32Op, I32Op>> {
       assert_true(!i.src1.is_constant);
       e.mov(e.ecx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
-        auto magicgu_val = magicu<unsigned>(i.src2.value->constant.u32);
-
-        if (!magicgu_val.a) {
+        auto div_shift_info = magicu<unsigned>(i.src2.value->constant.u32);
+		//todo: handle the add flag. 
+        if (!div_shift_info.a) {
           e.mov(i.dest, i.src1);
           if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-            e.mov(e.edx, magicgu_val.M);
+            e.mov(e.edx, div_shift_info.M);
             e.mulx(i.dest, i.dest, i.dest);
           } else {
-            e.mov(e.eax, magicgu_val.M);
+            e.mov(e.eax, div_shift_info.M);
             e.mul(i.dest);
             e.mov(i.dest, e.edx);
           }
-          if (magicgu_val.s != 0) e.shr(i.dest, magicgu_val.s);
+          if (div_shift_info.s != 0) {
+            e.shr(i.dest, div_shift_info.s);
+          }
 
           return;
         } else {
@@ -1963,19 +1969,19 @@ struct DIV_I64 : Sequence<DIV_I64, I<OPCODE_DIV, I64Op, I64Op, I64Op>> {
       assert_true(!i.src1.is_constant);
       e.mov(e.rcx, i.src2.constant());
       if (i.instr->flags & ARITHMETIC_UNSIGNED) {
-        auto magicgu_val = magicu<uint64_t>(i.src2.value->constant.u32);
-
-        if (!magicgu_val.a) {
+        auto div_shift_info = magicu<uint64_t>(i.src2.value->constant.u32);
+		//todo: handle addflag
+        if (!div_shift_info.a) {
           if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-            e.mov(e.rdx, magicgu_val.M);
+            e.mov(e.rdx, div_shift_info.M);
             e.mov(i.dest, i.src1);
             e.mulx(i.dest, i.dest, i.dest);
           } else {
-            e.mov(e.rax, magicgu_val.M);
+            e.mov(e.rax, div_shift_info.M);
             e.mul(i.src1);
             e.mov(i.dest, e.rdx);
           }
-          e.shr(i.dest, magicgu_val.s);
+          e.shr(i.dest, div_shift_info.s);
           return;
         }
         e.mov(e.rcx, i.src2.constant());


### PR DESCRIPTION
divisions and 32 bit divisions (add flag is not handled right now, divs
requiring that instead do the full x86 div)

For 32 and 64 bit values, constant multiplications by 3, 5, and 9 will
now be done with lea.

Integer adds of all widths now check to see if they can be inc instead
Integer subs of all widths now check to see if they can be dec instead

Added fast path for VECTOR_SHL::EmitInt8 that only requires three
instructions if src2 is constant and every value is the same, which is
universal on Halo: Reach at least.