### PR TITLE
[CPU] Use window size for LZX ref_data_size, fixes some problematic XEXP patches

### DIFF
--- a/src/xenia/cpu/lzx.cc
+++ b/src/xenia/cpu/lzx.cc
@@ -113,7 +113,7 @@ int lzx_decompress(const void* lzx_data, size_t lzx_len, void* dest,
       std::memset(lzxd->window, 0, window_data_len);
       std::memcpy(lzxd->window + (window_size - window_data_len), window_data,
                   window_data_len);
-      lzxd->ref_data_size = (uint32_t)window_data_len;
+      lzxd->ref_data_size = window_size;
     }
 
     result_code = lzxd_decompress(lzxd, (off_t)dest_len);


### PR DESCRIPTION
This minor change should fix some problematic patches which would cause "match offset beyond LZX stream" mspack errors.

Tested with Band of Bugs & Perfect Dark which both failed to apply any XEXP previously, now seem working with this fix.