### PR TITLE
[Kernel] ContentManager: add support for STFS packages

### DIFF
--- a/src/xenia/vfs/devices/stfs_container_device.h
+++ b/src/xenia/vfs/devices/stfs_container_device.h
@@ -117,6 +117,8 @@ struct SvodVolumeDescriptor {
 
 class StfsHeader {
  public:
+  static const uint32_t kHeaderLength = 0xA000;
+
   bool Read(const uint8_t* p);
 
   uint8_t license_entries[0x100];


### PR DESCRIPTION
This PR allows ContentManager to see and mount from non-extracted STFS packages. It'll also read information from the package headers (such as display name) into the XCONTENT_DATA struct used during content enumeration (see #1407)

I also added some code to allow extracted packages to have a [filepath].headers file next to it with the StfsHeaders struct inside, so they can also have information read into XCONTENT_DATA, but I could remove this part from the PR if desired.