### PR TITLE
[Kernel] Make XamShow*UI exports send XN_SYS_UI notifications, & small XNotifyListener fix

### DIFF
--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -111,6 +111,9 @@ dword_result_t XamShowMessageBoxUI(dword_t user_index, lpwstring_t title_ptr,
     buttons.push_back(button);
   }
 
+  // Broadcast XN_SYS_UI = true
+  kernel_state()->BroadcastNotification(0x9, true);
+
   uint32_t chosen_button;
   if (cvars::headless) {
     // Auto-pick the focused button.
@@ -143,6 +146,9 @@ dword_result_t XamShowMessageBoxUI(dword_t user_index, lpwstring_t title_ptr,
     --xam_dialogs_shown_;
   }
   *result_ptr = chosen_button;
+
+  // Broadcast XN_SYS_UI = false
+  kernel_state()->BroadcastNotification(0x9, false);
 
   if (overlapped) {
     kernel_state()->CompleteOverlappedImmediate(overlapped, X_ERROR_SUCCESS);
@@ -232,12 +238,18 @@ dword_result_t XamShowKeyboardUI(dword_t user_index, dword_t flags,
     return X_ERROR_INVALID_PARAMETER;
   }
 
+  // Broadcast XN_SYS_UI = true
+  kernel_state()->BroadcastNotification(0x9, true);
+
   if (cvars::headless) {
     // Redirect default_text back into the buffer.
     std::memset(buffer, 0, buffer_length * 2);
     if (default_text) {
       xe::store_and_swap<std::wstring>(buffer, default_text.value());
     }
+
+    // Broadcast XN_SYS_UI = false
+    kernel_state()->BroadcastNotification(0x9, false);
 
     if (overlapped) {
       kernel_state()->CompleteOverlappedImmediate(overlapped, X_ERROR_SUCCESS);
@@ -269,6 +281,9 @@ dword_result_t XamShowKeyboardUI(dword_t user_index, dword_t flags,
   out_text = out_text.substr(0, buffer_length - 1);
   xe::store_and_swap<std::wstring>(buffer, out_text);
 
+  // Broadcast XN_SYS_UI = false
+  kernel_state()->BroadcastNotification(0x9, false);
+
   if (overlapped) {
     kernel_state()->CompleteOverlappedImmediate(overlapped, X_ERROR_SUCCESS);
     return X_ERROR_IO_PENDING;
@@ -299,6 +314,10 @@ dword_result_t XamShowDeviceSelectorUI(dword_t user_index, dword_t content_type,
       *device_id_ptr = 0xF00D0000 | 0x0001;
       break;
   }
+
+  // Broadcast XN_SYS_UI = true followed by XN_SYS_UI = false
+  kernel_state()->BroadcastNotification(0x9, true);
+  kernel_state()->BroadcastNotification(0x9, false);
 
   if (overlapped) {
     kernel_state()->CompleteOverlappedImmediate(overlapped, X_ERROR_SUCCESS);

--- a/src/xenia/kernel/xnotifylistener.h
+++ b/src/xenia/kernel/xnotifylistener.h
@@ -48,8 +48,7 @@ class XNotifyListener : public XObject {
  private:
   std::unique_ptr<xe::threading::Event> wait_handle_;
   xe::global_critical_region global_critical_region_;
-  std::unordered_map<XNotificationID, uint32_t> notifications_;
-  size_t notification_count_ = 0;
+  std::vector<std::pair<XNotificationID, uint32_t>> notifications_;
   uint64_t mask_ = 0;
 };
 


### PR DESCRIPTION
It seems both Project Sylpheed & Sonic Unleashed require seeing ```XN_SYS_UI = true```, eventually followed by ```XN_SYS_UI = false```, for the game to realise all system UIs are closed, but ATM adding a notification that already exists (before the game gets a chance to dequeue it) will just overwrite the older notifications value, stopping the game from ever getting to see the older notification.

To accommodate sending the two notifications to those games I've changed XNotifyListener::notifications_ to a std::vector instead, allowing for multiple notifications to share the same ID, which should let the game see both XN_SYS_UI notifications instead of just the later XN_SYS_UI = false one.

(it seems my older threaded-xoverlapped stuff could workaround this issue as I guess the game would have a chance to run XNotifyGetNext before we sent over the second one, IMO this fix is probably better though, since it doesn't rely on needing to create new threads/hoping the game calls XNotifyGetNext/etc)

I don't think this should cause any regressions, since it seems the only time notifications are ever queued up is when Xenia adds them itself, and AFAIK it was always intended for the game to actually see the notifications we send (in other words, I'm pretty sure nothing was depending on this replace-if-exists behavior)

(Also, we currently send multiple notifys with the same ID inside kernel_state already: https://github.com/xenia-project/xenia/blob/master/src/xenia/kernel/kernel_state.cc#L581, atm the two on/off statements are useless since the game will only ever see the second statement, so maybe the current behavior wasn't intended)
