### PR TITLE
[CPU] Store ymm registers in thunks

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -498,22 +498,22 @@ void X64ThunkEmitter::EmitSaveVolatileRegs() {
   mov(qword[rsp + offsetof(StackLayout::Thunk, r[5])], r10);
   mov(qword[rsp + offsetof(StackLayout::Thunk, r[6])], r11);
 
-  // vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[0])], xmm0);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[1])], xmm1);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[2])], xmm2);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[3])], xmm3);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[4])], xmm4);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[5])], xmm5);
+  // vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[0])], ymm0);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[1])], ymm1);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[2])], ymm2);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[3])], ymm3);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[4])], ymm4);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[5])], ymm5);
 }
 
 void X64ThunkEmitter::EmitLoadVolatileRegs() {
   // Load volatile registers from our stack frame.
-  // vmovaps(xmm0, qword[rsp + offsetof(StackLayout::Thunk, xmm[0])]);
-  vmovaps(xmm1, qword[rsp + offsetof(StackLayout::Thunk, xmm[1])]);
-  vmovaps(xmm2, qword[rsp + offsetof(StackLayout::Thunk, xmm[2])]);
-  vmovaps(xmm3, qword[rsp + offsetof(StackLayout::Thunk, xmm[3])]);
-  vmovaps(xmm4, qword[rsp + offsetof(StackLayout::Thunk, xmm[4])]);
-  vmovaps(xmm5, qword[rsp + offsetof(StackLayout::Thunk, xmm[5])]);
+  // vmovups(ymm0, qword[rsp + offsetof(StackLayout::Thunk, ymm[0])]);
+  vmovups(ymm1, qword[rsp + offsetof(StackLayout::Thunk, ymm[1])]);
+  vmovups(ymm2, qword[rsp + offsetof(StackLayout::Thunk, ymm[2])]);
+  vmovups(ymm3, qword[rsp + offsetof(StackLayout::Thunk, ymm[3])]);
+  vmovups(ymm4, qword[rsp + offsetof(StackLayout::Thunk, ymm[4])]);
+  vmovups(ymm5, qword[rsp + offsetof(StackLayout::Thunk, ymm[5])]);
 
   // mov(rax, qword[rsp + offsetof(StackLayout::Thunk, r[0])]);
   mov(rcx, qword[rsp + offsetof(StackLayout::Thunk, r[1])]);
@@ -536,29 +536,29 @@ void X64ThunkEmitter::EmitSaveNonvolatileRegs() {
   mov(qword[rsp + offsetof(StackLayout::Thunk, r[7])], r14);
   mov(qword[rsp + offsetof(StackLayout::Thunk, r[8])], r15);
 
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[0])], xmm6);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[1])], xmm7);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[2])], xmm8);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[3])], xmm9);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[4])], xmm10);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[5])], xmm11);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[6])], xmm12);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[7])], xmm13);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[8])], xmm14);
-  vmovaps(qword[rsp + offsetof(StackLayout::Thunk, xmm[9])], xmm15);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[0])], ymm6);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[1])], ymm7);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[2])], ymm8);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[3])], ymm9);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[4])], ymm10);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[5])], ymm11);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[6])], ymm12);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[7])], ymm13);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[8])], ymm14);
+  vmovups(qword[rsp + offsetof(StackLayout::Thunk, ymm[9])], ymm15);
 }
 
 void X64ThunkEmitter::EmitLoadNonvolatileRegs() {
-  vmovaps(xmm6, qword[rsp + offsetof(StackLayout::Thunk, xmm[0])]);
-  vmovaps(xmm7, qword[rsp + offsetof(StackLayout::Thunk, xmm[1])]);
-  vmovaps(xmm8, qword[rsp + offsetof(StackLayout::Thunk, xmm[2])]);
-  vmovaps(xmm9, qword[rsp + offsetof(StackLayout::Thunk, xmm[3])]);
-  vmovaps(xmm10, qword[rsp + offsetof(StackLayout::Thunk, xmm[4])]);
-  vmovaps(xmm11, qword[rsp + offsetof(StackLayout::Thunk, xmm[5])]);
-  vmovaps(xmm12, qword[rsp + offsetof(StackLayout::Thunk, xmm[6])]);
-  vmovaps(xmm13, qword[rsp + offsetof(StackLayout::Thunk, xmm[7])]);
-  vmovaps(xmm14, qword[rsp + offsetof(StackLayout::Thunk, xmm[8])]);
-  vmovaps(xmm15, qword[rsp + offsetof(StackLayout::Thunk, xmm[9])]);
+  vmovups(ymm6, qword[rsp + offsetof(StackLayout::Thunk, ymm[0])]);
+  vmovups(ymm7, qword[rsp + offsetof(StackLayout::Thunk, ymm[1])]);
+  vmovups(ymm8, qword[rsp + offsetof(StackLayout::Thunk, ymm[2])]);
+  vmovups(ymm9, qword[rsp + offsetof(StackLayout::Thunk, ymm[3])]);
+  vmovups(ymm10, qword[rsp + offsetof(StackLayout::Thunk, ymm[4])]);
+  vmovups(ymm11, qword[rsp + offsetof(StackLayout::Thunk, ymm[5])]);
+  vmovups(ymm12, qword[rsp + offsetof(StackLayout::Thunk, ymm[6])]);
+  vmovups(ymm13, qword[rsp + offsetof(StackLayout::Thunk, ymm[7])]);
+  vmovups(ymm14, qword[rsp + offsetof(StackLayout::Thunk, ymm[8])]);
+  vmovups(ymm15, qword[rsp + offsetof(StackLayout::Thunk, ymm[9])]);
 
   mov(rbx, qword[rsp + offsetof(StackLayout::Thunk, r[0])]);
   mov(rcx, qword[rsp + offsetof(StackLayout::Thunk, r[1])]);

--- a/src/xenia/cpu/backend/x64/x64_stack_layout.h
+++ b/src/xenia/cpu/backend/x64/x64_stack_layout.h
@@ -53,51 +53,72 @@ class StackLayout {
    *  +------------------+
    *  | r15              | rsp + 104
    *  +------------------+
-   *  | xmm6/0           | rsp + 112
+   *  | ymm6/0           | rsp + 112
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm7/1           | rsp + 128
+   *  | ymm7/1           | rsp + 144
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm8/2           | rsp + 144
+   *  | ymm8/2           | rsp + 176
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm9/3           | rsp + 160
+   *  | ymm9/3           | rsp + 208
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm10/4          | rsp + 176
+   *  | ymm10/4          | rsp + 240
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm11/5          | rsp + 192
+   *  | ymm11/5          | rsp + 272
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm12            | rsp + 208
+   *  | ymm12            | rsp + 304
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm13            | rsp + 224
+   *  | ymm13            | rsp + 336
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm14            | rsp + 240
+   *  | ymm14            | rsp + 368
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | xmm15            | rsp + 256
+   *  | ymm15            | rsp + 400
+   *  |                  |
+   *  |                  |
    *  |                  |
    *  +------------------+
-   *  | scratch, 8b      | rsp + 272
-   *  |                  |
+   *  | scratch, 8b      | rsp + 432
    *  +------------------+
-   *  | (return address) | rsp + 280
+   *  | (return address) | rsp + 440
    *  +------------------+
-   *  | (rcx home)       | rsp + 288
+   *  | (rcx home)       | rsp + 448
    *  +------------------+
-   *  | (rdx home)       | rsp + 296
+   *  | (rdx home)       | rsp + 456
    *  +------------------+
    */
   XEPACKEDSTRUCT(Thunk, {
     uint64_t arg_temp[3];
     uint8_t scratch[16];
     uint64_t r[10];
-    vec128_t xmm[10];
+    // The compiler may emit AVX instructions using 256-bit registers, or they
+    // may be used in translated instruction implementations.
+    uint8_t ymm[10][32];
     uint64_t dummy;
   });
   static_assert(sizeof(Thunk) % 16 == 0,


### PR DESCRIPTION
Since enabling AVX2 in MSVC added a lot of glitches to games, this is probably important.

I'm not sure though if vmovups is a good solution though, in cases when accesses cross cache lines (will happen every other 32-byte vmovups if they're unaligned), maybe we should try to align the stack (with one or two marker xmms for checking whether a padding was added).