### PR TITLE
Add support for logging transports 

### DIFF
--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -56,7 +56,7 @@ class LogTransport {
 
 class FileTransport : public LogTransport {
  public:
-  explicit FileTransport(LogLevel log_level, const std::wstring& file_path);
+  FileTransport(LogLevel log_level, const std::wstring& file_path);
   ~FileTransport();
 
   virtual void LogLine(uint32_t thread_id, LogLevel level,
@@ -92,15 +92,9 @@ class Logger {
   explicit Logger(const std::wstring& app_name) : app_name_(app_name) {}
 
   void AppendLine(uint32_t thread_id, LogLevel level, const char prefix_char,
-                  const char* buffer, size_t buffer_length) {
-    for (const auto& transport : transports_) {
-      transport->LogLine(thread_id, level, prefix_char, buffer, buffer_length);
-    }
-  }
+                  const char* buffer, size_t buffer_length);
 
-  void AddLogTransport(std::unique_ptr<LogTransport> transport) {
-    transports_.emplace_back(std::move(transport));
-  }
+  void AddLogTransport(std::unique_ptr<LogTransport> transport);
 
   const std::wstring& app_name() const { return app_name_; }
 


### PR DESCRIPTION
Adds the concept of "transports" to the logging system which can be used to receive, store and write logs as they are received.

This doesn't really have much use in xenia as-is but would allow for things like a logging console window to be created by creating a console transport, for example.

This is a similar concept to the transport system found [in Winston](https://github.com/winstonjs/winston)

I still need to clean up the code a bit so keeping as a draft for now