### PR TITLE
Add game_language as a config variable

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
@@ -15,6 +15,11 @@
 #include "xenia/kernel/xboxkrnl/xboxkrnl_private.h"
 #include "xenia/xbox.h"
 
+DEFINE_int32(game_language, 1,
+             "The language for the game to run in. 1=EN / 2=JP / 3=DE / 4=FR / "
+             "5=ES / 6=IT / 7=KR / 8=CN",
+             "General");
+
 namespace xe {
 namespace kernel {
 namespace xboxkrnl {
@@ -57,7 +62,7 @@ X_STATUS xeExGetXConfigSetting(uint16_t category, uint16_t setting,
           break;
         case 0x0009:  // XCONFIG_USER_LANGUAGE
           setting_size = 4;
-          xe::store_and_swap<uint32_t>(value, 0x00000001);  // English
+          xe::store_and_swap<uint32_t>(value, cvars::game_language);  // English
           break;
         case 0x000A:  // XCONFIG_USER_VIDEO_FLAGS
           setting_size = 4;


### PR DESCRIPTION
Adds game_language as a variable in the config file.

I think adding it to the UI is pointless for now, since a new UI is in the works. This at least gives users the possibility to change it without having to compile xenia.