### PR TITLE
Improve Error Logging

### DIFF
--- a/src/xenia/apu/audio_system.cc
+++ b/src/xenia/apu/audio_system.cc
@@ -252,7 +252,7 @@ bool AudioSystem::Save(ByteStream* stream) {
 
 bool AudioSystem::Restore(ByteStream* stream) {
   if (stream->Read<uint32_t>() != 'XAUD') {
-    XELOGE("AudioSystem::Restore - Invalid magic value!");
+    XELOG_APU_E("[APU] AudioSystem::Restore - Invalid magic value!");
     return false;
   }
 
@@ -281,8 +281,8 @@ bool AudioSystem::Restore(ByteStream* stream) {
     AudioDriver* driver = nullptr;
     auto status = CreateDriver(id, client_semaphore, &driver);
     if (XFAILED(status)) {
-      XELOGE(
-          "AudioSystem::Restore - Call to CreateDriver failed with status %.8X",
+      XELOG_APU_E(
+          "[APU] AudioSystem::Restore - Call to CreateDriver failed with status %.8X",
           status);
       return false;
     }

--- a/src/xenia/apu/xma_decoder.cc
+++ b/src/xenia/apu/xma_decoder.cc
@@ -245,7 +245,7 @@ uint32_t XmaDecoder::ReadRegister(uint32_t addr) {
   switch (r) {
     default: {
       if (!register_file_.GetRegisterInfo(r)) {
-        XELOGE("XMA: Read from unknown register (%.4X)", r);
+        XELOG_APU_E("[APU] XMA: Read from unknown register (%.4X)", r);
       }
     }
 #pragma warning(suppress : 4065)
@@ -282,7 +282,7 @@ void XmaDecoder::WriteRegister(uint32_t addr, uint32_t value) {
   } else {
     switch (r) {
       default: {
-        XELOGE("XMA: Write to unhandled register (%.4X): %.8X", r, value);
+        XELOG_APU_E("[APU] XMA: Write to unhandled register (%.4X): %.8X", r, value);
         break;
       }
 #pragma warning(suppress : 4065)

--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -46,8 +46,15 @@ DEFINE_int32(
     "Logging");
 
 DEFINE_bool(exclude_cpu_from_log, false,
-            "Excludes CPU messages from being logged.", "Logging");
-DEFINE_bool(exclude_gpu_from_log, false, "Excludes GPU messages from being logged.", "Logging");
+            "Excludes 'CPU' messages from being logged.", "Logging");
+DEFINE_bool(exclude_gpu_from_log, false, "Excludes 'GPU' messages from being logged.", "Logging");
+DEFINE_bool(exclude_apu_from_log, false, "Excludes 'APU' messages from being logged.", "Logging");
+DEFINE_bool(exclude_kernel_from_log, false, "Excludes 'Kernel' messages from being logged.", "Logging");
+DEFINE_bool(exclude_hid_from_log, false, "Excludes 'HI'D messages from being logged.", "Logging");
+DEFINE_bool(exclude_vfs_from_log, false, "Excludes 'VFS' messages from being logged.", "Logging");
+DEFINE_bool(exclude_ui_from_log, false, "Excludes 'UI' messages from being logged.", "Logging");
+// The last log category for which these definitions relate is ALWAYS_LOG,
+// therefore we don't define a flag here for that.
 
 
 namespace xe {

--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -53,9 +53,6 @@ DEFINE_bool(exclude_kernel_from_log, false, "Excludes 'Kernel' messages from bei
 DEFINE_bool(exclude_hid_from_log, false, "Excludes 'HI'D messages from being logged.", "Logging");
 DEFINE_bool(exclude_vfs_from_log, false, "Excludes 'VFS' messages from being logged.", "Logging");
 DEFINE_bool(exclude_ui_from_log, false, "Excludes 'UI' messages from being logged.", "Logging");
-// The last log category for which these definitions relate is ALWAYS_LOG,
-// therefore we don't define a flag here for that.
-
 
 namespace xe {
 
@@ -154,15 +151,31 @@ class Logger {
       return;
     }
 
-	// New logging features.
-	// Check the category of the logged message and return if that
-	// category is turned off within the config.
+	// NEW LOGGING FUNCTIONS
+	// Check if the message being logged should be excluded based on user-config.
     if (cvars::exclude_cpu_from_log && category == LogCategory::CPU) {
       return;
     }
     if (cvars::exclude_gpu_from_log && category == LogCategory::GPU) {
       return;
 	}
+    if (cvars::exclude_apu_from_log && category == LogCategory::APU) {
+      return;
+    }
+    if (cvars::exclude_kernel_from_log && category == LogCategory::KERNEL) {
+      return;
+    }
+    if (cvars::exclude_hid_from_log && category == LogCategory::HID) {
+      return;
+    }
+    if (cvars::exclude_vfs_from_log && category == LogCategory::VFS) {
+      return;
+    }
+    if (cvars::exclude_ui_from_log && category == LogCategory::UI) {
+      return;
+    }
+    // We don't check for the log category 'ALWAYS_LOG' here as we
+	// always want to log whatever called it.
 
     LogLine line;
     line.buffer_length = buffer_length;

--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -148,11 +148,12 @@ class Logger {
     }
 
 	// New logging features.
-	// If the category has logging set to false, discard.
-    if (cvars::exclude_cpu_from_log) {
+	// Check the category of the logged message and return if that
+	// category is turned off within the config.
+    if (cvars::exclude_cpu_from_log && category == LogCategory::CPU) {
       return;
     }
-    if (cvars::exclude_gpu_from_log) {
+    if (cvars::exclude_gpu_from_log && category == LogCategory::GPU) {
       return;
 	}
 

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -81,9 +81,12 @@ void FatalError(const std::wstring& str);
   } while (false)
 #endif  // ENABLE_LOGGING
 
+// -- BEGIN EXISTING (OLD) LOGGING FUNCTIONS --
+// These functions have been kept for older modules that have yet to be converted over
+// to the new functions. They are also used where a new logging function doesn't exist
+// (e.g. generic logging).
 #define XELOGE(fmt, ...) XELOGCORE(xe::LogLevel::Error, '!', fmt, ##__VA_ARGS__)
-#define XELOGW(fmt, ...) \
-  XELOGCORE(xe::LogLevel::Warning, 'w', fmt, ##__VA_ARGS__)
+#define XELOGW(fmt, ...) XELOGCORE(xe::LogLevel::Warning, 'w', fmt, ##__VA_ARGS__)
 #define XELOGI(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'i', fmt, ##__VA_ARGS__)
 #define XELOGD(fmt, ...) XELOGCORE(xe::LogLevel::Debug, 'd', fmt, ##__VA_ARGS__)
 

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -32,6 +32,15 @@ enum class LogLevel {
   Trace,
 };
 
+enum class LogCategory {
+	CPU,
+	GPU,
+	HID,
+	KERNEL,
+	UI,
+	VFS
+};
+
 // Initializes the logging system and any outputs requested.
 // Must be called on startup.
 void InitializeLogging(const std::wstring& app_name);
@@ -40,6 +49,10 @@ void ShutdownLogging();
 // Appends a line to the log with printf-style formatting.
 void LogLineFormat(LogLevel log_level, const char prefix_char, const char* fmt,
                    ...);
+
+void LogLineFormat2(LogLevel log_level, LogCategory log_category, const char prefix_char, const char* fmt,
+                   ...);
+
 void LogLineVarargs(LogLevel log_level, const char prefix_char, const char* fmt,
                     va_list args);
 // Appends a line to the log.
@@ -58,6 +71,8 @@ void FatalError(const std::wstring& str);
 #if XE_OPTION_ENABLE_LOGGING
 #define XELOGCORE(level, prefix, fmt, ...) \
   xe::LogLineFormat(level, prefix, fmt, ##__VA_ARGS__)
+#define XELOGCORE2(level, category, prefix, fmt, ...) \
+  xe::LogLineFormat2(level, category, prefix, fmt, ##__VA_ARGS__)
 #else
 #define XELOGCORE(level, fmt, ...) \
   do {                             \
@@ -79,6 +94,14 @@ void FatalError(const std::wstring& str);
 #define XELOGKERNEL(fmt, ...) \
   XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)
 #define XELOGFS(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'F', fmt, ##__VA_ARGS__)
+
+// new logging functions
+#define XELOG_GPU_E(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::GPU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_W(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::GPU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_I(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::GPU, 'i', fmt, ##__VA_ARGS__)
 
 }  // namespace xe
 

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -97,7 +97,7 @@ void FatalError(const std::wstring& str);
   XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)
 #define XELOGFS(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'F', fmt, ##__VA_ARGS__)
 
-// new logging functions
+// -- BEGIN NEW LOGGING FUNCTIONS --
 // [CPU]
 #define XELOG_CPU_E(fmt, ...) \
   XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::CPU, '!', fmt, ##__VA_ARGS__)
@@ -183,6 +183,7 @@ void FatalError(const std::wstring& str);
              ##__VA_ARGS__)
 #define XELOG_ALWAYS_LOG_D(fmt, ...) \
   XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::ALWAYS_LOG, 'd', fmt, ##__VA_ARGS__)
+// -- END NEW LOGGING FUNCTIONS --
 
 }  // namespace xe
 

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -33,12 +33,14 @@ enum class LogLevel {
 };
 
 enum class LogCategory {
-	CPU,
+	CPU = 0,
 	GPU,
-	HID,
+	APU,
 	KERNEL,
+	HID,
+	VFS,
 	UI,
-	VFS
+	ALWAYS_LOG
 };
 
 // Initializes the logging system and any outputs requested.
@@ -96,12 +98,91 @@ void FatalError(const std::wstring& str);
 #define XELOGFS(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'F', fmt, ##__VA_ARGS__)
 
 // new logging functions
+// [CPU]
+#define XELOG_CPU_E(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::CPU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_CPU_W(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::CPU, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_I(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::CPU, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_D(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::CPU, 'd', fmt, ##__VA_ARGS__)
+// [GPU]
 #define XELOG_GPU_E(fmt, ...) \
   XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::GPU, '!', fmt, ##__VA_ARGS__)
 #define XELOG_GPU_W(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::GPU, '!', fmt, ##__VA_ARGS__)
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::GPU, 'w', fmt, ##__VA_ARGS__)
 #define XELOG_GPU_I(fmt, ...) \
   XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::GPU, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_D(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::GPU, 'd', fmt, ##__VA_ARGS__)
+// [APU]
+#define XELOG_APU_E(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::APU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_APU_W(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::APU, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_APU_I(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::APU, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_APU_D(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::APU, 'd', fmt, ##__VA_ARGS__)
+// [KERNEL]
+#define XELOG_KERNEL_E(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::KERNEL, '!', fmt, ##__VA_ARGS__)
+#define XELOG_KERNEL_W(fmt, ...)                                       \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::KERNEL, 'w', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_KERNEL_I(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::KERNEL, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_KERNEL_D(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::KERNEL, 'd', fmt, ##__VA_ARGS__)
+// [HID]
+#define XELOG_HID_E(fmt, ...)                                     \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::KERNEL, '!', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_HID_W(fmt, ...)                                       \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::KERNEL, 'w', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_HID_I(fmt, ...)                                    \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::KERNEL, 'i', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_HID_D(fmt, ...)                                     \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::KERNEL, 'd', fmt, \
+             ##__VA_ARGS__)
+// [VFS]
+#define XELOG_VFS_E(fmt, ...)                                        \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::VFS, '!', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_VFS_W(fmt, ...)                                          \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::VFS, 'w', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_VFS_I(fmt, ...)                                       \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::VFS, 'i', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_VFS_D(fmt, ...)                                        \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::VFS, 'd', fmt, \
+             ##__VA_ARGS__)
+// [UI]
+#define XELOG_UI_E(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::UI, '!', fmt, ##__VA_ARGS__)
+#define XELOG_UI_W(fmt, ...)                                       \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::UI, 'w', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_UI_I(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::UI, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_UI_D(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::UI, 'd', fmt, ##__VA_ARGS__)
+// [ALWAYS_LOG]
+#define XELOG_ALWAYS_LOG_E(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::ALWAYS_LOG, '!', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_W(fmt, ...)                                       \
+  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::ALWAYS_LOG, 'w', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_I(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::ALWAYS_LOG, 'i', fmt, \
+             ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_D(fmt, ...) \
+  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::ALWAYS_LOG, 'd', fmt, ##__VA_ARGS__)
 
 }  // namespace xe
 

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -87,14 +87,14 @@ void FatalError(const std::wstring& str);
 #define XELOGI(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'i', fmt, ##__VA_ARGS__)
 #define XELOGD(fmt, ...) XELOGCORE(xe::LogLevel::Debug, 'd', fmt, ##__VA_ARGS__)
 
-#define XELOGCPU(fmt, ...) \
-  XELOGCORE(xe::LogLevel::Info, 'C', fmt, ##__VA_ARGS__)
-#define XELOGAPU(fmt, ...) \
-  XELOGCORE(xe::LogLevel::Info, 'A', fmt, ##__VA_ARGS__)
+//#define XELOGCPU(fmt, ...) \
+  // XELOGCORE(xe::LogLevel::Info, 'C', fmt, ##__VA_ARGS__)
+//#define XELOGAPU(fmt, ...) \
+  // XELOGCORE(xe::LogLevel::Info, 'A', fmt, ##__VA_ARGS__)
 //#define XELOGGPU(fmt, ...) \
   // XELOGCORE(xe::LogLevel::Info, 'G', fmt, ##__VA_ARGS__)
-#define XELOGKERNEL(fmt, ...) \
-  XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)
+//#define XELOGKERNEL(fmt, ...) \
+  // XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)
 #define XELOGFS(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'F', fmt, ##__VA_ARGS__)
 
 // -- BEGIN NEW LOGGING FUNCTIONS --

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -87,102 +87,47 @@ void FatalError(const std::wstring& str);
 #define XELOGI(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'i', fmt, ##__VA_ARGS__)
 #define XELOGD(fmt, ...) XELOGCORE(xe::LogLevel::Debug, 'd', fmt, ##__VA_ARGS__)
 
-//#define XELOGCPU(fmt, ...) \
-  // XELOGCORE(xe::LogLevel::Info, 'C', fmt, ##__VA_ARGS__)
-//#define XELOGAPU(fmt, ...) \
-  // XELOGCORE(xe::LogLevel::Info, 'A', fmt, ##__VA_ARGS__)
-//#define XELOGGPU(fmt, ...) \
-  // XELOGCORE(xe::LogLevel::Info, 'G', fmt, ##__VA_ARGS__)
-//#define XELOGKERNEL(fmt, ...) \
-  // XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)
-#define XELOGFS(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'F', fmt, ##__VA_ARGS__)
-
 // -- BEGIN NEW LOGGING FUNCTIONS --
 // [CPU]
-#define XELOG_CPU_E(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::CPU, '!', fmt, ##__VA_ARGS__)
-#define XELOG_CPU_W(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::CPU, 'w', fmt, ##__VA_ARGS__)
-#define XELOG_GPU_I(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::CPU, 'i', fmt, ##__VA_ARGS__)
-#define XELOG_GPU_D(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::CPU, 'd', fmt, ##__VA_ARGS__)
+#define XELOG_CPU_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::CPU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_CPU_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::CPU, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_CPU_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::CPU, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_CPU_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::CPU, 'd', fmt, ##__VA_ARGS__)
 // [GPU]
-#define XELOG_GPU_E(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::GPU, '!', fmt, ##__VA_ARGS__)
-#define XELOG_GPU_W(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::GPU, 'w', fmt, ##__VA_ARGS__)
-#define XELOG_GPU_I(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::GPU, 'i', fmt, ##__VA_ARGS__)
-#define XELOG_GPU_D(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::GPU, 'd', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::GPU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::GPU, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::GPU, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_GPU_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::GPU, 'd', fmt, ##__VA_ARGS__)
 // [APU]
-#define XELOG_APU_E(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::APU, '!', fmt, ##__VA_ARGS__)
-#define XELOG_APU_W(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::APU, 'w', fmt, ##__VA_ARGS__)
-#define XELOG_APU_I(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::APU, 'i', fmt, ##__VA_ARGS__)
-#define XELOG_APU_D(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::APU, 'd', fmt, ##__VA_ARGS__)
+#define XELOG_APU_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::APU, '!', fmt, ##__VA_ARGS__)
+#define XELOG_APU_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::APU, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_APU_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::APU, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_APU_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::APU, 'd', fmt, ##__VA_ARGS__)
 // [KERNEL]
-#define XELOG_KERNEL_E(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::KERNEL, '!', fmt, ##__VA_ARGS__)
-#define XELOG_KERNEL_W(fmt, ...)                                       \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::KERNEL, 'w', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_KERNEL_I(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::KERNEL, 'i', fmt, ##__VA_ARGS__)
-#define XELOG_KERNEL_D(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::KERNEL, 'd', fmt, ##__VA_ARGS__)
+#define XELOG_KERNEL_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::KERNEL, '!', fmt, ##__VA_ARGS__)
+#define XELOG_KERNEL_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::KERNEL, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_KERNEL_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::KERNEL, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_KERNEL_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::KERNEL, 'd', fmt, ##__VA_ARGS__)
 // [HID]
-#define XELOG_HID_E(fmt, ...)                                     \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::KERNEL, '!', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_HID_W(fmt, ...)                                       \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::KERNEL, 'w', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_HID_I(fmt, ...)                                    \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::KERNEL, 'i', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_HID_D(fmt, ...)                                     \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::KERNEL, 'd', fmt, \
-             ##__VA_ARGS__)
+#define XELOG_HID_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::KERNEL, '!', fmt, ##__VA_ARGS__)
+#define XELOG_HID_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::KERNEL, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_HID_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::KERNEL, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_HID_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::KERNEL, 'd', fmt, ##__VA_ARGS__)
 // [VFS]
-#define XELOG_VFS_E(fmt, ...)                                        \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::VFS, '!', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_VFS_W(fmt, ...)                                          \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::VFS, 'w', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_VFS_I(fmt, ...)                                       \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::VFS, 'i', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_VFS_D(fmt, ...)                                        \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::VFS, 'd', fmt, \
-             ##__VA_ARGS__)
+#define XELOG_VFS_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::VFS, '!', fmt, ##__VA_ARGS__)
+#define XELOG_VFS_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::VFS, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_VFS_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::VFS, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_VFS_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::VFS, 'd', fmt, ##__VA_ARGS__)
 // [UI]
-#define XELOG_UI_E(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::UI, '!', fmt, ##__VA_ARGS__)
-#define XELOG_UI_W(fmt, ...)                                       \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::UI, 'w', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_UI_I(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::UI, 'i', fmt, ##__VA_ARGS__)
-#define XELOG_UI_D(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::UI, 'd', fmt, ##__VA_ARGS__)
+#define XELOG_UI_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::UI, '!', fmt, ##__VA_ARGS__)
+#define XELOG_UI_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::UI, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_UI_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::UI, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_UI_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::UI, 'd', fmt, ##__VA_ARGS__)
 // [ALWAYS_LOG]
-#define XELOG_ALWAYS_LOG_E(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::ALWAYS_LOG, '!', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_ALWAYS_LOG_W(fmt, ...)                                       \
-  XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::ALWAYS_LOG, 'w', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_ALWAYS_LOG_I(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::ALWAYS_LOG, 'i', fmt, \
-             ##__VA_ARGS__)
-#define XELOG_ALWAYS_LOG_D(fmt, ...) \
-  XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::ALWAYS_LOG, 'd', fmt, ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_E(fmt, ...) XELOGCORE2(xe::LogLevel::Error, xe::LogCategory::ALWAYS_LOG, '!', fmt, ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_W(fmt, ...) XELOGCORE2(xe::LogLevel::Warning, xe::LogCategory::ALWAYS_LOG, 'w', fmt, ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_I(fmt, ...) XELOGCORE2(xe::LogLevel::Info, xe::LogCategory::ALWAYS_LOG, 'i', fmt, ##__VA_ARGS__)
+#define XELOG_ALWAYS_LOG_D(fmt, ...) XELOGCORE2(xe::LogLevel::Debug, xe::LogCategory::ALWAYS_LOG, 'd', fmt, ##__VA_ARGS__)
 // -- END NEW LOGGING FUNCTIONS --
 
 }  // namespace xe

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -90,7 +90,7 @@ void FatalError(const std::wstring& str);
 #define XELOGAPU(fmt, ...) \
   XELOGCORE(xe::LogLevel::Info, 'A', fmt, ##__VA_ARGS__)
 //#define XELOGGPU(fmt, ...) \
-  XELOGCORE(xe::LogLevel::Info, 'G', fmt, ##__VA_ARGS__)
+  // XELOGCORE(xe::LogLevel::Info, 'G', fmt, ##__VA_ARGS__)
 #define XELOGKERNEL(fmt, ...) \
   XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)
 #define XELOGFS(fmt, ...) XELOGCORE(xe::LogLevel::Info, 'F', fmt, ##__VA_ARGS__)

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -89,7 +89,7 @@ void FatalError(const std::wstring& str);
   XELOGCORE(xe::LogLevel::Info, 'C', fmt, ##__VA_ARGS__)
 #define XELOGAPU(fmt, ...) \
   XELOGCORE(xe::LogLevel::Info, 'A', fmt, ##__VA_ARGS__)
-#define XELOGGPU(fmt, ...) \
+//#define XELOGGPU(fmt, ...) \
   XELOGCORE(xe::LogLevel::Info, 'G', fmt, ##__VA_ARGS__)
 #define XELOGKERNEL(fmt, ...) \
   XELOGCORE(xe::LogLevel::Info, 'K', fmt, ##__VA_ARGS__)

--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -79,7 +79,7 @@ bool X64Backend::Initialize(Processor* processor) {
 
   Xbyak::util::Cpu cpu;
   if (!cpu.has(Xbyak::util::Cpu::tAVX)) {
-    XELOGE("This CPU does not support AVX. The emulator will now crash.");
+    XELOG_CPU_E("[CPU] This CPU does not support AVX. The emulator will now crash.");
     return false;
   }
 

--- a/src/xenia/cpu/backend/x64/x64_code_cache.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.cc
@@ -53,8 +53,8 @@ bool X64CodeCache::Initialize() {
       xe::memory::AllocationType::kReserve,
       xe::memory::PageAccess::kReadWrite));
   if (!indirection_table_base_) {
-    XELOGE("Unable to allocate code cache indirection table");
-    XELOGE(
+    XELOG_CPU_E("[CPU] Unable to allocate code cache indirection table");
+    XELOG_CPU_E(
         "This is likely because the %.8X-%.8X range is in use by some other "
         "system DLL",
         kIndirectionTableBase, kIndirectionTableBase + kIndirectionTableSize);
@@ -67,7 +67,7 @@ bool X64CodeCache::Initialize() {
       file_name_, kGeneratedCodeSize, xe::memory::PageAccess::kExecuteReadWrite,
       false);
   if (!mapping_) {
-    XELOGE("Unable to create code cache mmap");
+    XELOG_CPU_E("[CPU] Unable to create code cache mmap");
     return false;
   }
 
@@ -76,8 +76,8 @@ bool X64CodeCache::Initialize() {
       mapping_, reinterpret_cast<void*>(kGeneratedCodeBase), kGeneratedCodeSize,
       xe::memory::PageAccess::kExecuteReadWrite, 0));
   if (!generated_code_base_) {
-    XELOGE("Unable to allocate code cache generated code storage");
-    XELOGE(
+    XELOG_CPU_E("[CPU] Unable to allocate code cache generated code storage");
+    XELOG_CPU_E(
         "This is likely because the %.8X-%.8X range is in use by some other "
         "system DLL",
         kGeneratedCodeBase, kGeneratedCodeBase + kGeneratedCodeSize);

--- a/src/xenia/cpu/backend/x64/x64_code_cache_win.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache_win.cc
@@ -180,7 +180,7 @@ bool Win32X64CodeCache::Initialize() {
                             reinterpret_cast<ULONG_PTR>(generated_code_base_),
                             reinterpret_cast<ULONG_PTR>(generated_code_base_ +
                                                         kGeneratedCodeSize))) {
-      XELOGE("Unable to create unwind function table");
+      XELOG_CPU_E("[CPU] Unable to create unwind function table");
       return false;
     }
   } else {
@@ -195,7 +195,7 @@ bool Win32X64CodeCache::Initialize() {
                   code_cache->LookupUnwindInfo(control_pc));
             },
             this, nullptr)) {
-      XELOGE("Unable to install function table callback");
+      XELOG_CPU_E("[CPU] Unable to install function table callback");
       return false;
     }
   }

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -227,7 +227,7 @@ bool X64Emitter::Emit(HIRBuilder* builder, size_t* out_stack_size) {
         // NOTE: If you encounter this after adding a new instruction, do a full
         // rebuild!
         assert_always();
-        XELOGE("Unable to process HIR opcode %s", instr->opcode->name);
+        XELOG_CPU_E("[CPU] Unable to process HIR opcode %s", instr->opcode->name);
         break;
       }
       instr = new_tail;
@@ -307,7 +307,7 @@ uint64_t TrapDebugPrint(void* raw_context, uint64_t address) {
 
 uint64_t TrapDebugBreak(void* raw_context, uint64_t address) {
   auto thread_state = *reinterpret_cast<ThreadState**>(raw_context);
-  XELOGE("tw/td forced trap hit! This should be a crash!");
+  XELOG_CPU_E("[CPU] tw/td forced trap hit! This should be a crash!");
   if (cvars::break_on_debugbreak) {
     xe::debugging::Break();
   }
@@ -449,7 +449,7 @@ uint64_t UndefinedCallExtern(void* raw_context, uint64_t function_ptr) {
     xe::FatalError("undefined extern call to %.8X %s", function->address(),
                    function->name().c_str());
   } else {
-    XELOGE("undefined extern call to %.8X %s", function->address(),
+    XELOG_CPU_E("[CPU] undefined extern call to %.8X %s", function->address(),
            function->name().c_str());
   }
   return 0;

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -3076,7 +3076,7 @@ bool SelectSequence(X64Emitter* e, const Instr* i, const Instr** new_tail) {
       return true;
     }
   }
-  XELOGE("No sequence match for variant %s", i->opcode->name);
+  XELOG_CPU_E("[CPU] No sequence match for variant %s", i->opcode->name);
   return false;
 }
 

--- a/src/xenia/cpu/compiler/passes/register_allocation_pass.cc
+++ b/src/xenia/cpu/compiler/passes/register_allocation_pass.cc
@@ -150,7 +150,7 @@ bool RegisterAllocationPass::Run(HIRBuilder* builder) {
           // We spill only those registers we aren't using.
           if (!SpillOneRegister(builder, block, instr->dest->type)) {
             // Unable to spill anything - this shouldn't happen.
-            XELOGE("Unable to spill any registers");
+            XELOG_CPU_E("[CPU] Unable to spill any registers");
             assert_always();
             return false;
           }
@@ -158,7 +158,7 @@ bool RegisterAllocationPass::Run(HIRBuilder* builder) {
           // Demand allocation.
           if (!TryAllocateRegister(instr->dest)) {
             // Boned.
-            XELOGE("Register allocation failed");
+            XELOG_CPU_E("[CPU] Register allocation failed");
             assert_always();
             return false;
           }

--- a/src/xenia/cpu/elf_module.cc
+++ b/src/xenia/cpu/elf_module.cc
@@ -75,14 +75,14 @@ bool ElfModule::Load(const std::string& name, const std::string& path,
 
   if (hdr->e_type != 2 /* ET_EXEC */) {
     // Not executable (shared objects not supported yet)
-    XELOGE("ELF: Could not load ELF because it isn't executable!");
+    XELOG_CPU_E("[CPU] ELF: Could not load ELF because it isn't executable!");
     return false;
   }
 
   if (hdr->e_machine != 20 /* EM_PPC */) {
     // Not a PPC ELF!
-    XELOGE(
-        "ELF: Could not load ELF because target machine is not PPC! (target: "
+    XELOG_CPU_E(
+        "[CPU] ELF: Could not load ELF because target machine is not PPC! (target: "
         "%d)",
         uint32_t(hdr->e_machine));
     return false;
@@ -90,12 +90,12 @@ bool ElfModule::Load(const std::string& name, const std::string& path,
 
   // Parse LOAD program headers and load into memory.
   if (!hdr->e_phoff) {
-    XELOGE("ELF: File doesn't have a program header!");
+    XELOG_CPU_E("[CPU] ELF: File doesn't have a program header!");
     return false;
   }
 
   if (!hdr->e_entry) {
-    XELOGE("ELF: Executable has no entry point!");
+    XELOG_CPU_E("[CPU] ELF: Executable has no entry point!");
     return false;
   }
 
@@ -114,7 +114,8 @@ bool ElfModule::Load(const std::string& name, const std::string& path,
       // Allocate and copy into memory.
       // Base address @ 0x80000000
       if (phdr[i].p_vaddr < 0x80000000 || phdr[i].p_vaddr > 0x9FFFFFFF) {
-        XELOGE("ELF: Could not allocate memory for section @ address 0x%.8X",
+        XELOG_CPU_E(
+            "[CPU] ELF: Could not allocate memory for section @ address 0x%.8X",
                uint32_t(phdr[i].p_vaddr));
         return false;
       }
@@ -129,7 +130,7 @@ bool ElfModule::Load(const std::string& name, const std::string& path,
                    virtual_addr, virtual_size, phdr[i].p_align,
                    xe::kMemoryAllocationReserve | xe::kMemoryAllocationCommit,
                    xe::kMemoryProtectRead | xe::kMemoryProtectWrite)) {
-        XELOGE("ELF: Could not allocate memory!");
+        XELOG_CPU_E("[CPU] ELF: Could not allocate memory!");
       }
 
       auto p = memory()->TranslateVirtual(phdr[i].p_vaddr);

--- a/src/xenia/cpu/mmio_handler.cc
+++ b/src/xenia/cpu/mmio_handler.cc
@@ -331,7 +331,7 @@ bool MMIOHandler::ExceptionCallback(Exception* ex) {
   DecodedMov mov = {0};
   bool decoded = TryDecodeMov(p, &mov);
   if (!decoded) {
-    XELOGE("Unable to decode MMIO mov at %p", p);
+    XELOG_CPU_E("[CPU] Unable to decode MMIO mov at %p", p);
     assert_always("Unknown MMIO instruction type");
     return false;
   }

--- a/src/xenia/cpu/ppc/ppc_emit-private.h
+++ b/src/xenia/cpu/ppc/ppc_emit-private.h
@@ -23,7 +23,7 @@ namespace ppc {
   RegisterOpcodeEmitter(PPCOpcode::name, InstrEmit_##name);
 
 #define XEINSTRNOTIMPLEMENTED()                          \
-  XELOGE("Unimplemented instruction: %s", __FUNCTION__); \
+  XELOG_CPU_E("[CPU] Unimplemented instruction: %s", __FUNCTION__); \
   assert_always("Instruction not implemented");
 
 }  // namespace ppc

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -144,7 +144,7 @@ bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
     instr_offset_list_[offset] = first_instr;
 
     if (opcode == PPCOpcode::kInvalid) {
-      XELOGE("Invalid instruction %.8llX %.8X", address, code);
+      XELOG_CPU_E("[CPU] Invalid instruction %.8llX %.8X", address, code);
       Comment("INVALID!");
       // TraceInvalidInstruction(i);
       continue;
@@ -167,7 +167,7 @@ bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
     i.opcode_info = &opcode_info;
     if (!opcode_info.emit || opcode_info.emit(*this, i)) {
       auto& disasm_info = GetOpcodeDisasmInfo(opcode);
-      XELOGE("Unimplemented instr %.8llX %.8X %s", address, code,
+      XELOG_CPU_E("[CPU] Unimplemented instr %.8llX %.8X %s", address, code,
              disasm_info.name);
       Comment("UNIMPLEMENTED!");
       DebugBreak();

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -323,7 +323,7 @@ bool Processor::Execute(ThreadState* thread_state, uint32_t address) {
   auto function = ResolveFunction(address);
   if (!function) {
     // Symbol not found in any module.
-    XELOGCPU("Execute(%.8X): failed to find function", address);
+    XELOG_CPU_E("[CPU] Execute(%.8X): failed to find function", address);
     return false;
   }
 
@@ -354,7 +354,7 @@ bool Processor::ExecuteRaw(ThreadState* thread_state, uint32_t address) {
   auto function = ResolveFunction(address);
   if (!function) {
     // Symbol not found in any module.
-    XELOGCPU("Execute(%.8X): failed to find function", address);
+    XELOG_CPU_E("[CPU] Execute(%.8X): failed to find function", address);
     return false;
   }
 

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -439,7 +439,7 @@ bool Processor::Save(ByteStream* stream) {
 
 bool Processor::Restore(ByteStream* stream) {
   if (stream->Read<uint32_t>() != 'PROC') {
-    XELOGE("Processor::Restore - Invalid magic value!");
+    XELOG_CPU_E("[CPU] Processor::Restore - Invalid magic value!");
     return false;
   }
 
@@ -602,7 +602,7 @@ void Processor::DemandDebugListener() {
     return;
   }
   if (!debug_listener_handler_) {
-    XELOGE("Debugger demanded a listener but no handler was registered.");
+    XELOG_CPU_E("[CPU] Debugger demanded a listener but no handler was registered.");
     xe::debugging::Break();
     return;
   }
@@ -973,7 +973,8 @@ bool Processor::StepToGuestAddress(uint32_t thread_id, uint32_t pc) {
   if (functions.empty()) {
     // Function hasn't been generated yet. Generate it.
     if (!ResolveFunction(pc)) {
-      XELOGE("Processor::StepToAddress(%.8X) - Function could not be resolved",
+      XELOG_CPU_E(
+          "[CPU] Processor::StepToAddress(%.8X) - Function could not be resolved",
              pc);
       return false;
     }

--- a/src/xenia/cpu/stack_walker_win.cc
+++ b/src/xenia/cpu/stack_walker_win.cc
@@ -70,7 +70,7 @@ bool InitializeStackWalker() {
   // NOTE: we never free it. That's fine.
   HMODULE module = LoadLibrary(TEXT("dbghelp.dll"));
   if (!module) {
-    XELOGE("Unable to load dbghelp.dll - not found on path or invalid");
+    XELOG_CPU_E("[CPU] Unable to load dbghelp.dll - not found on path or invalid");
     return false;
   }
   sym_get_options_ = reinterpret_cast<LPSYMGETOPTIONS>(
@@ -90,7 +90,7 @@ bool InitializeStackWalker() {
   if (!sym_get_options_ || !sym_set_options_ || !sym_initialize_ ||
       !stack_walk_64_ || !sym_function_table_access_64_ ||
       !sym_get_module_base_64_ || !sym_get_sym_from_addr_64_) {
-    XELOGE("Unable to get one or more symbols from dbghelp.dll");
+    XELOG_CPU_E("[CPU] Unable to get one or more symbols from dbghelp.dll");
     return false;
   }
 
@@ -104,7 +104,7 @@ bool InitializeStackWalker() {
   options |= SYMOPT_FAIL_CRITICAL_ERRORS;
   sym_set_options_(options);
   if (!sym_initialize_(GetCurrentProcess(), nullptr, TRUE)) {
-    XELOGE("Unable to initialize symbol services - already in use?");
+    XELOG_CPU_E("[CPU] Unable to initialize symbol services - already in use?");
     return false;
   }
 
@@ -166,7 +166,7 @@ class Win32StackWalker : public StackWalker {
       // This gets the state of the thread exactly where it was when suspended.
       thread_context.ContextFlags = CONTEXT_FULL;
       if (!GetThreadContext(thread_handle, &thread_context)) {
-        XELOGE("Unable to read thread context for stack walk");
+        XELOG_CPU_E("[CPU] Unable to read thread context for stack walk");
         return 0;
       }
     } else {
@@ -309,7 +309,8 @@ std::unique_ptr<StackWalker> StackWalker::Create(
     backend::CodeCache* code_cache) {
   auto stack_walker = std::make_unique<Win32StackWalker>(code_cache);
   if (!stack_walker->Initialize()) {
-    XELOGE("Unable to initialize stack walker: debug/save states disabled");
+    XELOG_CPU_E(
+        "[CPU] Unable to initialize stack walker: debug/save states disabled");
     return nullptr;
   }
   return std::unique_ptr<StackWalker>(stack_walker.release());

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -1136,7 +1136,7 @@ bool XexModule::SetupLibraryImports(const char* name,
           } else {
             // Not implemented - write with a dummy value.
             *record_slot = 0xD000BEEF | (kernel_export->ordinal & 0xFFF) << 16;
-            XELOGCPU("WARNING: imported a variable with no value: %s",
+            XELOG_CPU_W("[CPU] WARNING: imported a variable with no value: %s",
                      kernel_export->name);
           }
         }

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -137,7 +137,7 @@ void CommandProcessor::ClearCaches() {}
 void CommandProcessor::WorkerThreadMain() {
   context_->MakeCurrent();
   if (!SetupContext()) {
-    xe::FatalError("Unable to setup command processor internal state");
+    xe::FatalError("[GPU] Unable to setup command processor internal state");
     return;
   }
 
@@ -370,7 +370,7 @@ void CommandProcessor::MakeCoherent() {
   }
 
   // TODO(benvanik): notify resource cache of base->size and type.
-  XELOG_GPU_E("Make %.8X -> %.8X (%db) coherent, action = %s", base_host,
+  XELOG_GPU_I("[GPU] Make %.8X -> %.8X (%db) coherent, action = %s", base_host,
          base_host + size_host, size_host, action);
 
   // Mark coherent.
@@ -801,7 +801,7 @@ bool CommandProcessor::ExecutePacketType3_XE_SWAP(RingBuffer* reader,
                                                   uint32_t count) {
   SCOPE_profile_cpu_f("gpu");
 
-  XELOG_GPU_I("XE_SWAP");
+  XELOG_GPU_I("[GPU] XE_SWAP");
 
   Profiler::Flip();
 

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -779,7 +779,7 @@ bool D3D12CommandProcessor::SetupContext() {
           &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
           &swap_texture_desc, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
           nullptr, IID_PPV_ARGS(&swap_texture_)))) {
-    XELOGE("[D3D12] Failed to create the command processor front buffer");
+    XELOG_GPU_E("[D3D12] Failed to create the command processor front buffer");
     return false;
   }
   D3D12_DESCRIPTOR_HEAP_DESC swap_descriptor_heap_desc;

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -2874,7 +2874,7 @@ bool D3D12CommandProcessor::UpdateBindings(
       draw_view_full_update_, view_count_partial_update, view_count_full_update,
       view_cpu_handle, view_gpu_handle);
   if (view_full_update_index == 0) {
-    XELOGE("Failed to allocate view descriptors!");
+    XELOG_GPU_E("[D3D12] Failed to allocate view descriptors!");
     return false;
   }
   uint32_t sampler_count_partial_update = 0;
@@ -2894,7 +2894,7 @@ bool D3D12CommandProcessor::UpdateBindings(
         sampler_count_vertex + sampler_count_pixel, sampler_cpu_handle,
         sampler_gpu_handle);
     if (sampler_full_update_index == 0) {
-      XELOGE("Failed to allocate sampler descriptors!");
+      XELOG_GPU_E("[D3D12] Failed to allocate sampler descriptors!");
       return false;
     }
   }

--- a/src/xenia/gpu/d3d12/d3d12_graphics_system.cc
+++ b/src/xenia/gpu/d3d12/d3d12_graphics_system.cc
@@ -98,7 +98,8 @@ X_STATUS D3D12GraphicsSystem::Setup(cpu::Processor* processor,
   stretch_root_signature_ =
       ui::d3d12::util::CreateRootSignature(d3d12_provider, stretch_root_desc);
   if (stretch_root_signature_ == nullptr) {
-    XELOGE("Failed to create the front buffer stretch root signature");
+    XELOG_GPU_E(
+        "[D3D12] Failed to create the front buffer stretch root signature");
     return X_STATUS_UNSUCCESSFUL;
   }
   // Gamma.
@@ -125,8 +126,8 @@ X_STATUS D3D12GraphicsSystem::Setup(cpu::Processor* processor,
   stretch_gamma_root_signature_ =
       ui::d3d12::util::CreateRootSignature(d3d12_provider, stretch_root_desc);
   if (stretch_gamma_root_signature_ == nullptr) {
-    XELOGE(
-        "Failed to create the gamma-correcting front buffer stretch root "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create the gamma-correcting front buffer stretch root "
         "signature");
     stretch_root_signature_->Release();
     stretch_root_signature_ = nullptr;
@@ -154,7 +155,7 @@ X_STATUS D3D12GraphicsSystem::Setup(cpu::Processor* processor,
   stretch_pipeline_desc.SampleDesc.Count = 1;
   if (FAILED(device->CreateGraphicsPipelineState(
           &stretch_pipeline_desc, IID_PPV_ARGS(&stretch_pipeline_)))) {
-    XELOGE("Failed to create the front buffer stretch pipeline state");
+    XELOG_GPU_E("[D3D12] Failed to create the front buffer stretch pipeline state");
     stretch_gamma_root_signature_->Release();
     stretch_gamma_root_signature_ = nullptr;
     stretch_root_signature_->Release();
@@ -166,8 +167,8 @@ X_STATUS D3D12GraphicsSystem::Setup(cpu::Processor* processor,
   stretch_pipeline_desc.PS.BytecodeLength = sizeof(stretch_gamma_ps);
   if (FAILED(device->CreateGraphicsPipelineState(
           &stretch_pipeline_desc, IID_PPV_ARGS(&stretch_gamma_pipeline_)))) {
-    XELOGE(
-        "Failed to create the gamma-correcting front buffer stretch "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create the gamma-correcting front buffer stretch "
         "pipeline state");
     stretch_pipeline_->Release();
     stretch_pipeline_ = nullptr;

--- a/src/xenia/gpu/d3d12/primitive_converter.cc
+++ b/src/xenia/gpu/d3d12/primitive_converter.cc
@@ -69,8 +69,8 @@ bool PrimitiveConverter::Initialize() {
           &ui::d3d12::util::kHeapPropertiesUpload, D3D12_HEAP_FLAG_NONE,
           &static_ib_desc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
           IID_PPV_ARGS(&static_ib_upload_)))) {
-    XELOGE(
-        "Failed to create the upload buffer for the primitive conversion "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create the upload buffer for the primitive conversion "
         "static index buffer");
     Shutdown();
     return false;
@@ -81,8 +81,8 @@ bool PrimitiveConverter::Initialize() {
   void* static_ib_mapping;
   if (FAILED(static_ib_upload_->Map(0, &static_ib_read_range,
                                     &static_ib_mapping))) {
-    XELOGE(
-        "Failed to map the upload buffer for the primitive conversion "
+    XELOG_GPU_E(
+        "[D3D12] Failed to map the upload buffer for the primitive conversion "
         "static index buffer");
     Shutdown();
     return false;
@@ -115,7 +115,8 @@ bool PrimitiveConverter::Initialize() {
           &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
           &static_ib_desc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
           IID_PPV_ARGS(&static_ib_)))) {
-    XELOGE("Failed to create the primitive conversion static index buffer");
+    XELOG_GPU_E(
+        "[D3D12] Failed to create the primitive conversion static index buffer");
     Shutdown();
     return false;
   }
@@ -691,7 +692,8 @@ void* PrimitiveConverter::AllocateIndices(
   uint8_t* mapping =
       buffer_pool_->RequestFull(size, nullptr, nullptr, &gpu_address);
   if (mapping == nullptr) {
-    XELOGE("Failed to allocate space for %u converted %u-bit vertex indices",
+    XELOG_GPU_E(
+        "[D3D12] Failed to allocate space for %u converted %u-bit vertex indices",
            count, format == IndexFormat::kInt32 ? 32 : 16);
     return nullptr;
   }

--- a/src/xenia/gpu/d3d12/render_target_cache.cc
+++ b/src/xenia/gpu/d3d12/render_target_cache.cc
@@ -128,7 +128,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
           &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
           &edram_buffer_desc, edram_buffer_state_, nullptr,
           IID_PPV_ARGS(&edram_buffer_)))) {
-    XELOGE("Failed to create the EDRAM buffer");
+    XELOG_GPU_E("[D3D12] Failed to create the EDRAM buffer");
     Shutdown();
     return false;
   }
@@ -145,7 +145,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
   if (FAILED(device->CreateDescriptorHeap(
           &edram_buffer_descriptor_heap_desc,
           IID_PPV_ARGS(&edram_buffer_descriptor_heap_)))) {
-    XELOGE("Failed to create the descriptor heap for EDRAM buffer views");
+    XELOG_GPU_E("[D3D12] Failed to create the descriptor heap for EDRAM buffer views");
     Shutdown();
     return false;
   }
@@ -217,7 +217,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
   edram_load_store_root_signature_ =
       ui::d3d12::util::CreateRootSignature(provider, load_store_root_desc);
   if (edram_load_store_root_signature_ == nullptr) {
-    XELOGE("Failed to create the EDRAM load/store root signature");
+    XELOG_GPU_E("[D3D12] Failed to create the EDRAM load/store root signature");
     Shutdown();
     return false;
   }
@@ -228,7 +228,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
   edram_clear_root_signature_ =
       ui::d3d12::util::CreateRootSignature(provider, load_store_root_desc);
   if (edram_clear_root_signature_ == nullptr) {
-    XELOGE("Failed to create the EDRAM buffer clear root signature");
+    XELOG_GPU_E("[D3D12] Failed to create the EDRAM buffer clear root signature");
     Shutdown();
     return false;
   }
@@ -262,7 +262,8 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
         (!rov_used && edram_store_pipelines_[i] == nullptr) ||
         (load_2x_resolve_pipeline_used &&
          edram_load_2x_resolve_pipelines_[i] == nullptr)) {
-      XELOGE("Failed to create the EDRAM load/store pipelines for mode %u", i);
+      XELOG_GPU_E("[D3D12] Failed to create the EDRAM load/store pipelines for mode %u",
+                  i);
       Shutdown();
       return false;
     }
@@ -280,7 +281,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
       device, edram_tile_sample_32bpp_cs, sizeof(edram_tile_sample_32bpp_cs),
       edram_load_store_root_signature_);
   if (edram_tile_sample_32bpp_pipeline_ == nullptr) {
-    XELOGE("Failed to create the 32bpp EDRAM raw resolve pipeline");
+    XELOG_GPU_E("[D3D12] Failed to create the 32bpp EDRAM raw resolve pipeline");
     Shutdown();
     return false;
   }
@@ -290,7 +291,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
       device, edram_tile_sample_64bpp_cs, sizeof(edram_tile_sample_64bpp_cs),
       edram_load_store_root_signature_);
   if (edram_tile_sample_64bpp_pipeline_ == nullptr) {
-    XELOGE("Failed to create the 64bpp EDRAM raw resolve pipeline");
+    XELOG_GPU_E("[D3D12] Failed to create the 64bpp EDRAM raw resolve pipeline");
     Shutdown();
     return false;
   }
@@ -300,7 +301,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
       device, edram_clear_32bpp_cs, sizeof(edram_clear_32bpp_cs),
       edram_clear_root_signature_);
   if (edram_clear_32bpp_pipeline_ == nullptr) {
-    XELOGE("Failed to create the EDRAM 32bpp clear pipeline");
+    XELOG_GPU_E("[D3D12] Failed to create the EDRAM 32bpp clear pipeline");
     Shutdown();
     return false;
   }
@@ -310,7 +311,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
       device, edram_clear_64bpp_cs, sizeof(edram_clear_64bpp_cs),
       edram_clear_root_signature_);
   if (edram_clear_64bpp_pipeline_ == nullptr) {
-    XELOGE("Failed to create the EDRAM 64bpp clear pipeline");
+    XELOG_GPU_E("[D3D12] Failed to create the EDRAM 64bpp clear pipeline");
     Shutdown();
     return false;
   }
@@ -320,7 +321,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
       device, edram_clear_depth_float_cs, sizeof(edram_clear_depth_float_cs),
       edram_clear_root_signature_);
   if (edram_clear_depth_float_pipeline_ == nullptr) {
-    XELOGE("Failed to create the EDRAM float depth clear pipeline");
+    XELOG_GPU_E("[D3D12] Failed to create the EDRAM float depth clear pipeline");
     Shutdown();
     return false;
   }
@@ -374,7 +375,7 @@ bool RenderTargetCache::Initialize(const TextureCache* texture_cache) {
   resolve_root_signature_ =
       ui::d3d12::util::CreateRootSignature(provider, resolve_root_desc);
   if (resolve_root_signature_ == nullptr) {
-    XELOGE("Failed to create the converting resolve root signature");
+    XELOG_GPU_E("[D3D12] Failed to create the converting resolve root signature");
     Shutdown();
     return false;
   }
@@ -800,7 +801,7 @@ bool RenderTargetCache::UpdateRenderTargets(const D3D12Shader* pixel_shader) {
       }
 #endif
     }
-    XELOGGPU("RT Cache: %s update - pitch %u, samples %u, RTs to attach %u",
+    XELOG_GPU_I("[D3D12] RT Cache: %s update - pitch %u, samples %u, RTs to attach %u",
              full_update ? "Full" : "Partial", surface_pitch, msaa_samples,
              render_targets_to_attach);
 
@@ -926,7 +927,7 @@ bool RenderTargetCache::UpdateRenderTargets(const D3D12Shader* pixel_shader) {
         if (!binding.is_bound || render_target == nullptr) {
           continue;
         }
-        XELOGGPU("RT Color %u: base %u, format %u", i, edram_bases[i],
+        XELOG_GPU_I("[D3D12] RT Color %u: base %u, format %u", i, edram_bases[i],
                  formats[i]);
         command_processor_->PushTransitionBarrier(
             render_target->resource, render_target->state,
@@ -947,7 +948,7 @@ bool RenderTargetCache::UpdateRenderTargets(const D3D12Shader* pixel_shader) {
       RenderTarget* depth_render_target = depth_binding.render_target;
       current_pipeline_render_targets_[4].guest_render_target = 4;
       if (depth_binding.is_bound && depth_render_target != nullptr) {
-        XELOGGPU("RT Depth: base %u, format %u", edram_bases[4], formats[4]);
+        XELOG_GPU_I("[D3D12] RT Depth: base %u, format %u", edram_bases[4], formats[4]);
         command_processor_->PushTransitionBarrier(
             depth_render_target->resource, depth_render_target->state,
             D3D12_RESOURCE_STATE_DEPTH_WRITE);
@@ -1136,8 +1137,8 @@ bool RenderTargetCache::Resolve(SharedMemory* shared_memory,
   rect.top = std::max(rect.top, scissor.top);
   rect.bottom = std::min(rect.bottom, scissor.bottom);
 
-  XELOGGPU(
-      "Resolve: (%d,%d)->(%d,%d) of RT %u (pitch %u, %u sample%s, format %u) "
+  XELOG_GPU_I(
+      "[D3D12] Resolve: (%d,%d)->(%d,%d) of RT %u (pitch %u, %u sample%s, format %u) "
       "at %u",
       rect.left, rect.top, rect.right, rect.bottom, surface_index,
       surface_pitch, 1 << uint32_t(msaa_samples),
@@ -1311,8 +1312,8 @@ bool RenderTargetCache::ResolveCopy(SharedMemory* shared_memory,
   }
   bool dest_swap = !is_depth && ((rb_copy_dest_info >> 24) & 0x1);
 
-  XELOGGPU(
-      "Resolve: Copying samples %u to 0x%.8X (%ux%u, %cD), destination Z %u, "
+  XELOG_GPU_I(
+      "[D3D12] Resolve: Copying samples %u to 0x%.8X (%ux%u, %cD), destination Z %u, "
       "destination format %s, exponent bias %d, red and blue %sswapped",
       uint32_t(sample_select), dest_address, dest_pitch, dest_height,
       dest_3d ? '3' : '2', dest_z, dest_format_info->name, dest_exp_bias,
@@ -1350,7 +1351,7 @@ bool RenderTargetCache::ResolveCopy(SharedMemory* shared_memory,
     // *************************************************************************
     // Raw copy
     // *************************************************************************
-    XELOGGPU("Resolve: Copying using a compute shader");
+    XELOG_GPU_I("[D3D12] Resolve: Copying using a compute shader");
 
     // Calculate the size of the region that specifically is being resolved.
     // Can't just use the texture height for size calculation because it's
@@ -1491,7 +1492,7 @@ bool RenderTargetCache::ResolveCopy(SharedMemory* shared_memory,
     // *************************************************************************
     // Conversion and AA resolving
     // *************************************************************************
-    XELOGGPU("Resolve: Copying via drawing");
+    XELOG_GPU_I("[D3D12] Resolve: Copying via drawing");
 
     // Get everything we need for the conversion.
 
@@ -1499,8 +1500,8 @@ bool RenderTargetCache::ResolveCopy(SharedMemory* shared_memory,
     DXGI_FORMAT dest_dxgi_format =
         texture_cache->GetResolveDXGIFormat(dest_format);
     if (dest_dxgi_format == DXGI_FORMAT_UNKNOWN) {
-      XELOGE(
-          "No resolve pipeline for destination format %s - tell Xenia "
+      XELOG_GPU_E(
+          "[D3D12] No resolve pipeline for destination format %s - tell Xenia "
           "developers!",
           FormatInfo::Get(dest_format)->name);
       return false;
@@ -1822,7 +1823,7 @@ bool RenderTargetCache::ResolveClear(uint32_t edram_base,
     return true;
   }
 
-  XELOGGPU("Resolve: Clearing the %s render target",
+  XELOG_GPU_I("[D3D12] Resolve: Clearing the %s render target",
            is_depth ? "depth" : "color");
 
   // Calculate the layout.
@@ -1936,7 +1937,7 @@ ID3D12PipelineState* RenderTargetCache::GetResolvePipeline(
   ID3D12PipelineState* pipeline;
   if (FAILED(device->CreateGraphicsPipelineState(&pipeline_desc,
                                                  IID_PPV_ARGS(&pipeline)))) {
-    XELOGE("Failed to create the resolve pipeline for DXGI format %u",
+    XELOG_GPU_E("[D3D12] Failed to create the resolve pipeline for DXGI format %u",
            dest_format);
     return nullptr;
   }
@@ -2018,8 +2019,8 @@ RenderTargetCache::ResolveTarget* RenderTargetCache::FindOrCreateResolveTarget(
       (uint32_t(allocation_info.SizeInBytes) + ((4 << 20) - 1)) >> 22;
   if (heap_page_count == 0 || heap_page_count > kHeap4MBPages) {
     assert_always();
-    XELOGE(
-        "%ux%u resolve target with DXGI format %u can't fit in a heap, "
+    XELOG_GPU_E(
+        "[D3D12] %ux%u resolve target with DXGI format %u can't fit in a heap, "
         "needs %u bytes - tell Xenia developers to increase the heap size!",
         uint32_t(resource_desc.Width), resource_desc.Height, format,
         uint32_t(allocation_info.SizeInBytes));
@@ -2045,8 +2046,8 @@ RenderTargetCache::ResolveTarget* RenderTargetCache::FindOrCreateResolveTarget(
   if (FAILED(device->CreatePlacedResource(
           heaps_[heap_index], (min_heap_page_first % kHeap4MBPages) << 22,
           &resource_desc, state, nullptr, IID_PPV_ARGS(&resource)))) {
-    XELOGE(
-        "Failed to create a placed resource for %ux%u resolve target with DXGI "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create a placed resource for %ux%u resolve target with DXGI "
         "format %u at heap 4 MB pages %u:%u",
         uint32_t(resource_desc.Width), resource_desc.Height, format,
         min_heap_page_first, min_heap_page_first + heap_page_count - 1);
@@ -2056,8 +2057,8 @@ RenderTargetCache::ResolveTarget* RenderTargetCache::FindOrCreateResolveTarget(
   if (FAILED(device->CreateCommittedResource(
           &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
           &resource_desc, state, nullptr, IID_PPV_ARGS(&resource)))) {
-    XELOGE(
-        "Failed to create a committed resource for %ux%u resolve target with "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create a committed resource for %ux%u resolve target with "
         "DXGI format %u",
         uint32_t(resource_desc.Width), resource_desc.Height, format);
     return nullptr;
@@ -2243,7 +2244,7 @@ bool RenderTargetCache::MakeHeapResident(uint32_t heap_index) {
   heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
   if (FAILED(
           device->CreateHeap(&heap_desc, IID_PPV_ARGS(&heaps_[heap_index])))) {
-    XELOGE("Failed to create a %u MB heap for render targets",
+    XELOG_GPU_E("[D3D12] Failed to create a %u MB heap for render targets",
            kHeap4MBPages * 4);
     return false;
   }
@@ -2268,7 +2269,7 @@ bool RenderTargetCache::EnsureRTVHeapAvailable(bool is_depth) {
   ID3D12DescriptorHeap* new_d3d_heap;
   if (FAILED(device->CreateDescriptorHeap(&heap_desc,
                                           IID_PPV_ARGS(&new_d3d_heap)))) {
-    XELOGE("Failed to create a heap for %u %s buffer descriptors",
+    XELOG_GPU_E("[D3D12] Failed to create a heap for %u %s buffer descriptors",
            kRenderTargetDescriptorHeapSize, is_depth ? "depth" : "color");
     return false;
   }
@@ -2375,8 +2376,8 @@ RenderTargetCache::RenderTarget* RenderTargetCache::FindOrCreateRenderTarget(
   if (FAILED(device->CreatePlacedResource(
           heaps_[heap_index], (heap_page_first % kHeap4MBPages) << 22,
           &resource_desc, state, nullptr, IID_PPV_ARGS(&resource)))) {
-    XELOGE(
-        "Failed to create a placed resource for %ux%u %s render target with "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create a placed resource for %ux%u %s render target with "
         "format %u at heap 4 MB pages %u:%u",
         uint32_t(resource_desc.Width), resource_desc.Height,
         key.is_depth ? "depth" : "color", key.format, heap_page_first,
@@ -2387,8 +2388,8 @@ RenderTargetCache::RenderTarget* RenderTargetCache::FindOrCreateRenderTarget(
   if (FAILED(device->CreateCommittedResource(
           &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
           &resource_desc, state, nullptr, IID_PPV_ARGS(&resource)))) {
-    XELOGE(
-        "Failed to create a committed resource for %ux%u %s render target with "
+    XELOG_GPU_E(
+        "[D3D12] Failed to create a committed resource for %ux%u %s render target with "
         "format %u",
         uint32_t(resource_desc.Width), resource_desc.Height,
         key.is_depth ? "depth" : "color", key.format);
@@ -2443,13 +2444,13 @@ RenderTargetCache::RenderTarget* RenderTargetCache::FindOrCreateRenderTarget(
   COUNT_profile_set("gpu/render_target_cache/render_targets",
                     render_targets_.size());
 #if 0
-  XELOGGPU(
-      "Created %ux%u %s render target with format %u at heap 4 MB pages %u:%u",
+  XELOG_GPU_I(
+      "[D3D12] Created %ux%u %s render target with format %u at heap 4 MB pages %u:%u",
       uint32_t(resource_desc.Width), resource_desc.Height,
       key.is_depth ? "depth" : "color", key.format, heap_page_first,
       heap_page_first + heap_page_count - 1);
 #else
-  XELOGGPU("Created %ux%u %s render target with format %u",
+  XELOG_GPU_I("[D3D12] Created %ux%u %s render target with format %u",
            uint32_t(resource_desc.Width), resource_desc.Height,
            key.is_depth ? "depth" : "color", key.format);
 #endif

--- a/src/xenia/gpu/d3d12/shared_memory.cc
+++ b/src/xenia/gpu/d3d12/shared_memory.cc
@@ -68,26 +68,26 @@ bool SharedMemory::Initialize() {
   if (AreTiledResourcesUsed()) {
     if (FAILED(device->CreateReservedResource(
             &buffer_desc, buffer_state_, nullptr, IID_PPV_ARGS(&buffer_)))) {
-      XELOGE("Shared memory: Failed to create the 512 MB tiled buffer");
+      XELOG_GPU_E("[D3D12] Shared memory: Failed to create the 512 MB tiled buffer");
       Shutdown();
       return false;
     }
   } else {
-    XELOGGPU(
-        "Direct3D 12 tiled resources are not used for shared memory "
+    XELOG_GPU_I(
+        "[D3D12] Direct3D 12 tiled resources are not used for shared memory "
         "emulation - video memory usage may increase significantly "
         "because a full 512 MB buffer will be created!");
     if (provider->GetGraphicsAnalysis() != nullptr) {
       // As of October 8th, 2018, PIX doesn't support tiled buffers.
       // FIXME(Triang3l): Re-enable tiled resources with PIX once fixed.
-      XELOGGPU(
-          "This is caused by PIX being attached, which doesn't support tiled "
+      XELOG_GPU_I(
+          "[D3D12] This is caused by PIX being attached, which doesn't support tiled "
           "resources yet.");
     }
     if (FAILED(device->CreateCommittedResource(
             &ui::d3d12::util::kHeapPropertiesDefault, D3D12_HEAP_FLAG_NONE,
             &buffer_desc, buffer_state_, nullptr, IID_PPV_ARGS(&buffer_)))) {
-      XELOGE("Shared memory: Failed to create the 512 MB buffer");
+      XELOG_GPU_E("[D3D12] Shared memory: Failed to create the 512 MB buffer");
       Shutdown();
       return false;
     }
@@ -107,8 +107,8 @@ bool SharedMemory::Initialize() {
   if (FAILED(device->CreateDescriptorHeap(
           &buffer_descriptor_heap_desc,
           IID_PPV_ARGS(&buffer_descriptor_heap_)))) {
-    XELOGE(
-        "Failed to create the descriptor heap for shared memory buffer views");
+    XELOG_GPU_E(
+        "[D3D12] Failed to create the descriptor heap for shared memory buffer views");
     Shutdown();
     return false;
   }
@@ -307,7 +307,7 @@ bool SharedMemory::MakeTilesResident(uint32_t start, uint32_t length) {
     heap_desc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
     heap_desc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     if (FAILED(device->CreateHeap(&heap_desc, IID_PPV_ARGS(&heaps_[i])))) {
-      XELOGE("Shared memory: Failed to create a tile heap");
+      XELOG_GPU_E("[D3D12] Shared memory: Failed to create a tile heap");
       heap_creation_failed_ = true;
       return false;
     }
@@ -378,7 +378,7 @@ bool SharedMemory::RequestRange(uint32_t start, uint32_t length) {
           upload_range_length << page_size_log2_, &upload_buffer,
           &upload_buffer_offset, &upload_buffer_size, nullptr);
       if (upload_buffer_mapping == nullptr) {
-        XELOGE("Shared memory: Failed to get an upload buffer");
+        XELOG_GPU_E("[D3D12] Shared memory: Failed to get an upload buffer");
         return false;
       }
       uint32_t upload_buffer_pages = upload_buffer_size >> page_size_log2_;

--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -84,7 +84,7 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
   // incoming ringbuffer packets.
   command_processor_ = CreateCommandProcessor();
   if (!command_processor_->Initialize(std::move(processor_context))) {
-    XELOGE("Unable to initialize command processor");
+    XELOG_GPU_E("[GPU] Unable to initialize command processor");
     return X_STATUS_UNSUCCESSFUL;
   }
 
@@ -154,7 +154,7 @@ void GraphicsSystem::Shutdown() {
 
 void GraphicsSystem::Reset() {
   // TODO(DrChat): Reset the system.
-  XELOGI("Context lost; Reset invoked");
+  XELOG_GPU_I("[GPU] Context lost; Reset invoked");
   Shutdown();
 
   xe::FatalError("Graphics device lost (probably due to an internal error)");
@@ -188,7 +188,7 @@ uint32_t GraphicsSystem::ReadRegister(uint32_t addr) {
       return 0x050002D0;
     default:
       if (!register_file_.GetRegisterInfo(r)) {
-        XELOGE("GPU: Read from unknown register (%.4X)", r);
+        XELOG_GPU_E("[GPU] Read from unknown register (%.4X)", r);
       }
   }
 
@@ -206,7 +206,7 @@ void GraphicsSystem::WriteRegister(uint32_t addr, uint32_t value) {
     case 0x1844:  // AVIVO_D1GRPH_PRIMARY_SURFACE_ADDRESS
       break;
     default:
-      XELOGW("Unknown GPU register %.4X write: %.8X", r, value);
+      XELOG_GPU_W("[GPU] Unknown GPU register %.4X write: %.8X", r, value);
       break;
   }
 
@@ -227,7 +227,7 @@ void GraphicsSystem::SetInterruptCallback(uint32_t callback,
                                           uint32_t user_data) {
   interrupt_callback_ = callback;
   interrupt_callback_data_ = user_data;
-  XELOGGPU("SetInterruptCallback(%.4X, %.4X)", callback, user_data);
+  XELOG_GPU_I("[GPU] SetInterruptCallback(%.4X, %.4X)", callback, user_data);
 }
 
 void GraphicsSystem::DispatchInterruptCallback(uint32_t source, uint32_t cpu) {
@@ -244,7 +244,7 @@ void GraphicsSystem::DispatchInterruptCallback(uint32_t source, uint32_t cpu) {
   }
   thread->SetActiveCpu(cpu);
 
-  // XELOGGPU("Dispatching GPU interrupt at %.8X w/ mode %d on cpu %d",
+  // XELOG_GPU_I("[GPU] Dispatching GPU interrupt at %.8X w/ mode %d on cpu %d",
   //          interrupt_callback_, source, cpu);
 
   uint64_t args[] = {source, interrupt_callback_data_};

--- a/src/xenia/gpu/shader_compiler_main.cc
+++ b/src/xenia/gpu/shader_compiler_main.cc
@@ -56,7 +56,7 @@ int shader_compiler_main(const std::vector<std::wstring>& args) {
     } else if (cvars::shader_input_type == "ps") {
       shader_type = ShaderType::kPixel;
     } else {
-      XELOGE("Invalid --shader_input_type; must be 'vs' or 'ps'.");
+      XELOG_GPU_E("[SHADER_COMPILER] Invalid --shader_input_type; must be 'vs' or 'ps'.");
       return 1;
     }
   } else {
@@ -72,8 +72,8 @@ int shader_compiler_main(const std::vector<std::wstring>& args) {
       }
     }
     if (!valid_type) {
-      XELOGE(
-          "File type not recognized (use .vs, .ps or "
+      XELOG_GPU_E(
+          "[SHADER_COMPILER] File type not recognized (use .vs, .ps or "
           "--shader_input_type=vs|ps).");
       return 1;
     }
@@ -81,7 +81,7 @@ int shader_compiler_main(const std::vector<std::wstring>& args) {
 
   auto input_file = fopen(cvars::shader_input.c_str(), "rb");
   if (!input_file) {
-    XELOGE("Unable to open input file: %s", cvars::shader_input.c_str());
+    XELOG_GPU_E("[SHADER_COMPILER] Unable to open input file: %s", cvars::shader_input.c_str());
     return 1;
   }
   fseek(input_file, 0, SEEK_END);
@@ -91,7 +91,8 @@ int shader_compiler_main(const std::vector<std::wstring>& args) {
   fread(ucode_dwords.data(), 4, ucode_dwords.size(), input_file);
   fclose(input_file);
 
-  XELOGI("Opened %s as a %s shader, %" PRId64 " words (%" PRId64 " bytes).",
+  XELOG_GPU_I("[SHADER_COMPILER] Opened %s as a %s shader, %" PRId64 " words (%" PRId64
+              " bytes).",
          cvars::shader_input.c_str(),
          shader_type == ShaderType::kVertex ? "vertex" : "pixel",
          ucode_dwords.size(), ucode_dwords.size() * 4);

--- a/src/xenia/gpu/shader_translator.cc
+++ b/src/xenia/gpu/shader_translator.cc
@@ -1292,8 +1292,8 @@ void ShaderTranslator::ParseAluVectorOperation(const AluInstruction& op,
         } else {
           // Unimplemented.
           // assert_always();
-          XELOGE(
-              "ShaderTranslator::ParseAluVectorOperation: Unsupported write to "
+          XELOG_GPU_E(
+              "[GPU] ShaderTranslator::ParseAluVectorOperation: Unsupported write to "
               "export %d",
               dest_num);
           i.vector_result.storage_target = InstructionStorageTarget::kNone;
@@ -1336,8 +1336,8 @@ void ShaderTranslator::ParseAluVectorOperation(const AluInstruction& op,
         i.vector_result.storage_target = InstructionStorageTarget::kDepth;
         break;
       default:
-        XELOGE(
-            "ShaderTranslator::ParseAluVectorOperation: Unsupported write to "
+        XELOG_GPU_E(
+            "[GPU] ShaderTranslator::ParseAluVectorOperation: Unsupported write to "
             "export %d",
             dest_num);
         i.vector_result.storage_target = InstructionStorageTarget::kNone;
@@ -1460,8 +1460,8 @@ void ShaderTranslator::ParseAluScalarOperation(const AluInstruction& op,
         } else {
           // Unimplemented.
           // assert_always();
-          XELOGE(
-              "ShaderTranslator::ParseAluScalarOperation: Unsupported write to "
+          XELOG_GPU_E(
+              "[GPU] ShaderTranslator::ParseAluScalarOperation: Unsupported write to "
               "export %d",
               dest_num);
           i.scalar_result.storage_target = InstructionStorageTarget::kNone;

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -672,7 +672,7 @@ void SpirvShaderTranslator::PostTranslation(Shader* shader) {
         reinterpret_cast<const uint32_t*>(shader->translated_binary().data()),
         shader->translated_binary().size() / sizeof(uint32_t));
     if (validation->has_error()) {
-      XELOGE("SPIR-V Shader Validation failed! Error: %s",
+      XELOG_GPU_E("[GPU] SPIR-V Shader Validation failed! Error: %s",
              validation->error_string());
     }
   }
@@ -683,7 +683,7 @@ void SpirvShaderTranslator::PostTranslation(Shader* shader) {
         reinterpret_cast<const uint32_t*>(shader->translated_binary().data()),
         shader->translated_binary().size() / 4);
     if (disasm->has_error()) {
-      XELOGE("Failed to disassemble SPIRV - invalid?");
+      XELOG_GPU_E("[GPU] Failed to disassemble SPIRV - invalid?");
     } else {
       set_host_disassembly(shader, disasm->to_string());
     }

--- a/src/xenia/gpu/texture_dump.cc
+++ b/src/xenia/gpu/texture_dump.cc
@@ -85,7 +85,7 @@ void TextureDump(const TextureInfo& src, void* buffer, size_t length) {
       assert_unhandled_case(src.format);
       std::memset(&dds_header.pixel_format, 0xCD,
                   sizeof(dds_header.pixel_format));
-      XELOGW("Skipping %s for texture dump.", src.format_info()->name);
+      XELOG_GPU_W("[GPU] Skipping %s for texture dump.", src.format_info()->name);
       return;
     }
   }

--- a/src/xenia/gpu/texture_info.cc
+++ b/src/xenia/gpu/texture_info.cc
@@ -81,7 +81,7 @@ bool TextureInfo::Prepare(const xe_gpu_texture_fetch_t& fetch,
   info.has_packed_mips = fetch.packed_mips;
 
   if (info.format_info()->format == TextureFormat::kUnknown) {
-    XELOGE("Attempting to fetch from unsupported texture format %d",
+    XELOG_GPU_E("[GPU] Attempting to fetch from unsupported texture format %d",
            info.format);
     info.memory.base_address = fetch.base_address << 12;
     info.memory.mip_address = fetch.mip_address << 12;

--- a/src/xenia/gpu/trace_dump.cc
+++ b/src/xenia/gpu/trace_dump.cc
@@ -58,20 +58,20 @@ int TraceDump::Main(const std::vector<std::wstring>& args) {
   }
 
   if (path.empty()) {
-    XELOGE("No trace file specified");
+    XELOG_GPU_E("[GPU] No trace file specified");
     return 5;
   }
 
   // Normalize the path and make absolute.
   auto abs_path = xe::to_absolute_path(path);
-  XELOGI("Loading trace file %ls...", abs_path.c_str());
+  XELOG_GPU_I("[GPU] Loading trace file %ls...", abs_path.c_str());
 
   if (!Setup()) {
-    XELOGE("Unable to setup trace dump tool");
+    XELOG_GPU_E("[GPU] Unable to setup trace dump tool");
     return 4;
   }
   if (!Load(std::move(abs_path))) {
-    XELOGE("Unable to load trace file; not found?");
+    XELOG_GPU_E("[GPU] Unable to load trace file; not found?");
     return 5;
   }
 
@@ -106,7 +106,7 @@ bool TraceDump::Setup() {
   X_STATUS result = emulator_->Setup(
       nullptr, nullptr, [this]() { return CreateGraphicsSystem(); }, nullptr);
   if (XFAILED(result)) {
-    XELOGE("Failed to setup emulator: %.8X", result);
+    XELOG_GPU_E("[GPU] Failed to setup emulator: %.8X", result);
     return false;
   }
   graphics_system_ = emulator_->graphics_system();
@@ -118,7 +118,7 @@ bool TraceDump::Load(std::wstring trace_file_path) {
   trace_file_path_ = std::move(trace_file_path);
 
   if (!player_->Open(trace_file_path_)) {
-    XELOGE("Could not load trace file");
+    XELOG_GPU_E("[GPU] Could not load trace file");
     return false;
   }
 

--- a/src/xenia/gpu/trace_reader.cc
+++ b/src/xenia/gpu/trace_reader.cc
@@ -37,21 +37,22 @@ bool TraceReader::Open(const std::wstring& path) {
   // Verify version.
   auto header = reinterpret_cast<const TraceHeader*>(trace_data_);
   if (header->version != kTraceFormatVersion) {
-    XELOGE("Trace format version mismatch, code has %u, file has %u",
+    XELOG_GPU_E("[GPU] Trace format version mismatch, code has %u, file has %u",
            kTraceFormatVersion, header->version);
     if (header->version < kTraceFormatVersion) {
-      XELOGE("You need to regenerate your trace for the latest version");
+      XELOG_GPU_E("[GPU] You need to regenerate your trace for the latest version");
     }
     return false;
   }
 
   auto path_str = xe::to_string(path);
-  XELOGI("Mapped %" PRId64 "b trace from %s", trace_size_, path_str.c_str());
-  XELOGI("   Version: %u", header->version);
+  XELOG_GPU_I("[GPU] Mapped %" PRId64 "b trace from %s", trace_size_,
+              path_str.c_str());
+  XELOG_GPU_I("[GPU]   Version: %u", header->version);
   auto commit_str = std::string(header->build_commit_sha,
                                 xe::countof(header->build_commit_sha));
-  XELOGI("    Commit: %s", commit_str.c_str());
-  XELOGI("  Title ID: %u", header->title_id);
+  XELOG_GPU_I("[GPU]    Commit: %s", commit_str.c_str());
+  XELOG_GPU_I("[GPU]  Title ID: %u", header->title_id);
 
   ParseTrace();
 

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -114,7 +114,7 @@ bool TraceViewer::Setup() {
   });
   window_->on_closed.AddListener([&](xe::ui::UIEvent* e) {
     loop_->Quit();
-    XELOGI("User-initiated death!");
+    XELOG_GPU_I("[GPU] User-initiated death!");
     exit(1);
   });
   loop_->on_quit.AddListener([&](xe::ui::UIEvent* e) { window_.reset(); });
@@ -126,7 +126,7 @@ bool TraceViewer::Setup() {
       emulator_->Setup(window_.get(), nullptr,
                        [this]() { return CreateGraphicsSystem(); }, nullptr);
   if (XFAILED(result)) {
-    XELOGE("Failed to setup emulator: %.8X", result);
+    XELOG_GPU_E("[GPU] Failed to setup emulator: %.8X", result);
     return false;
   }
   memory_ = emulator_->memory();
@@ -159,7 +159,7 @@ bool TraceViewer::Load(std::wstring trace_file_path) {
   window_->set_title(std::wstring(L"Xenia GPU Trace Viewer: ") + file_name);
 
   if (!player_->Open(trace_file_path)) {
-    XELOGE("Could not load trace file");
+    XELOG_GPU_E("[GPU] Could not load trace file");
     return false;
   }
 

--- a/src/xenia/gpu/vulkan/pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/pipeline_cache.cc
@@ -380,7 +380,7 @@ bool PipelineCache::TranslateShader(VulkanShader* shader,
   }
 
   if (shader->is_valid()) {
-    XELOGGPU("Generated %s shader (%db) - hash %.16" PRIX64 ":\n%s\n",
+    XELOG_GPU_I("[Vulkan] Generated %s shader (%db) - hash %.16" PRIX64 ":\n%s\n",
              shader->type() == ShaderType::kVertex ? "vertex" : "pixel",
              shader->ucode_dword_count() * 4, shader->ucode_data_hash(),
              shader->ucode_disassembly().c_str());

--- a/src/xenia/gpu/vulkan/texture_cache.cc
+++ b/src/xenia/gpu/vulkan/texture_cache.cc
@@ -1066,8 +1066,8 @@ bool TextureCache::UploadTexture(VkCommandBuffer command_buffer,
 
   size_t unpack_length = ComputeTextureStorage(src);
 
-  XELOGGPU(
-      "Uploading texture @ 0x%.8X/0x%.8X (%ux%ux%u, format: %s, dim: %s, "
+  XELOG_GPU_I(
+      "[Vulkan] Uploading texture @ 0x%.8X/0x%.8X (%ux%ux%u, format: %s, dim: %s, "
       "levels: %u (%u-%u), stacked: %s, pitch: %u, tiled: %s, packed mips: %s, "
       "unpack length: 0x%.8X)",
       src.memory.base_address, src.memory.mip_address, src.width + 1,
@@ -1077,7 +1077,7 @@ bool TextureCache::UploadTexture(VkCommandBuffer command_buffer,
       src.is_tiled ? "yes" : "no", src.has_packed_mips ? "yes" : "no",
       unpack_length);
 
-  XELOGGPU("Extent: %ux%ux%u  %u,%u,%u", src.extent.pitch, src.extent.height,
+  XELOG_GPU_I("[Vulkan] Extent: %ux%ux%u  %u,%u,%u", src.extent.pitch, src.extent.height,
            src.extent.depth, src.extent.block_pitch_h, src.extent.block_height,
            src.extent.block_pitch_v);
 
@@ -1500,7 +1500,7 @@ bool TextureCache::SetupTextureBinding(VkCommandBuffer command_buffer,
   // Disabled?
   // TODO(benvanik): reset sampler.
   if (fetch.type != 0x2) {
-    XELOGGPU("Fetch type is not 2!");
+    XELOG_GPU_I("[Vulkan] Fetch type is not 2!");
     return false;
   }
 

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -1114,7 +1114,8 @@ bool VulkanCommandProcessor::IssueCopy() {
                                         : static_cast<uint32_t>(depth_format);
   VkFilter filter = is_color_source ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
 
-  XELOGGPU("Resolve RT %.8X %.8X(%d) -> 0x%.8X (%dx%d, format: %s)", edram_base,
+  XELOG_GPU_I("[Vulkan] Resolve RT %.8X %.8X(%d) -> 0x%.8X (%dx%d, format: %s)",
+              edram_base,
            surface_pitch, surface_pitch, copy_dest_base, copy_dest_pitch,
            copy_dest_height, texture_info.format_info()->name);
   switch (copy_command) {
@@ -1143,7 +1144,7 @@ bool VulkanCommandProcessor::IssueCopy() {
       auto view = render_cache_->FindTileView(
           edram_base, surface_pitch, surface_msaa, is_color_source, src_format);
       if (!view) {
-        XELOGGPU("Failed to find tile view!");
+        XELOG_GPU_I("[Vulkan] Failed to find tile view!");
         break;
       }
 

--- a/src/xenia/kernel/kernel_module.cc
+++ b/src/xenia/kernel/kernel_module.cc
@@ -63,7 +63,7 @@ uint32_t KernelModule::GenerateTrampoline(
   assert_true(guest_trampoline_next_ * 8 < guest_trampoline_size_);
   if (guest_trampoline_next_ * 8 >= guest_trampoline_size_) {
     assert_always();  // If you hit this, increase kTrampolineSize
-    XELOGE("KernelModule::GenerateTrampoline trampoline exhausted");
+    XELOG_KERNEL_E("[KERNEL] KernelModule::GenerateTrampoline trampoline exhausted");
     return 0;
   }
 
@@ -145,7 +145,7 @@ uint32_t KernelModule::GetProcAddressByOrdinal(uint16_t ordinal) {
 
 uint32_t KernelModule::GetProcAddressByName(const char* name) {
   // TODO: Does this even work for kernel modules?
-  XELOGE("KernelModule::GetProcAddressByName not implemented");
+  XELOG_KERNEL_E("[KERNEL] KernelModule::GetProcAddressByName not implemented");
   return 0;
 }
 

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -249,7 +249,7 @@ object_ref<XThread> KernelState::LaunchModule(object_ref<UserModule> module) {
 
   X_STATUS result = thread->Create();
   if (XFAILED(result)) {
-    XELOGE("Could not create launch thread: %.8X", result);
+    XELOG_KERNEL_E("[KERNEL] Could not create launch thread: %.8X", result);
     return nullptr;
   }
 

--- a/src/xenia/kernel/user_module.cc
+++ b/src/xenia/kernel/user_module.cc
@@ -55,7 +55,7 @@ X_STATUS UserModule::LoadFromFile(std::string path) {
   // TODO(benvanik): make this code shared?
   auto fs_entry = kernel_state()->file_system()->ResolvePath(path);
   if (!fs_entry) {
-    XELOGE("File not found: %s", path.c_str());
+    XELOG_KERNEL_E("[KERNEL] File not found: %s", path.c_str());
     return X_STATUS_NO_SUCH_FILE;
   }
 
@@ -116,10 +116,10 @@ X_STATUS UserModule::LoadFromFile(std::string path) {
       if (!result) {
         result = patch_module->xex_module()->ApplyPatch(xex_module());
         if (result) {
-          XELOGE("Failed to apply XEX patch, code: %d", result);
+          XELOG_KERNEL_E("[KERNEL] Failed to apply XEX patch, code: %d", result);
         }
       } else {
-        XELOGE("Failed to load XEX patch, code: %d", result);
+        XELOG_KERNEL_E("[KERNEL] Failed to load XEX patch, code: %d", result);
       }
 
       if (result) {
@@ -142,10 +142,10 @@ X_STATUS UserModule::LoadFromMemory(const void* addr, const size_t length) {
   } else {
     auto magic16 = xe::load_and_swap<uint16_t>(addr);
     if (magic16 == 0x4D5A) {
-      XELOGE("XNA executables are not yet implemented");
+      XELOG_KERNEL_E("[KERNEL] XNA executables are not yet implemented");
       return X_STATUS_NOT_IMPLEMENTED;
     } else {
-      XELOGE("Unknown module magic: %.8X", magic);
+      XELOG_KERNEL_E("[KERNEL] Unknown module magic: %.8X", magic);
       return X_STATUS_NOT_IMPLEMENTED;
     }
   }

--- a/src/xenia/kernel/util/shim_utils.h
+++ b/src/xenia/kernel/util/shim_utils.h
@@ -447,9 +447,17 @@ void PrintKernelCall(cpu::Export* export_entry, const Tuple& params) {
   string_buffer.Append('(');
   AppendKernelCallParams(string_buffer, export_entry, params);
   string_buffer.Append(')');
+
+  // We can log our Kernel calls here.
   if (export_entry->tags & xe::cpu::ExportTag::kImportant) {
-    xe::LogLine(xe::LogLevel::Info, 'i', string_buffer.GetString(),
-                string_buffer.length());
+    // VdSwap (tag->1074659345) has been singled out because it bulks out the log.
+	// TODO: remove/replace this code with better logging.
+    if (export_entry->tags == 1074659345) {
+      XELOG_GPU_I("[KERNEL] %s", string_buffer.GetString());
+    } else {
+      xe::LogLine(xe::LogLevel::Info, 'i', string_buffer.GetString(),
+                  string_buffer.length());
+    }
   } else {
     xe::LogLine(xe::LogLevel::Debug, 'd', string_buffer.GetString(),
                 string_buffer.length());

--- a/src/xenia/kernel/util/shim_utils.h
+++ b/src/xenia/kernel/util/shim_utils.h
@@ -450,10 +450,9 @@ void PrintKernelCall(cpu::Export* export_entry, const Tuple& params) {
 
   // We can log our Kernel calls here.
   if (export_entry->tags & xe::cpu::ExportTag::kImportant) {
-    // VdSwap (tag->1074659345) has been singled out because it bulks out the log.
-	// TODO: remove/replace this code with better logging.
+    // (TranzRail) VdSwap (tag->1074659345) has been singled out because it bulks out the log.
     if (export_entry->tags == 1074659345) {
-      XELOG_GPU_I("[KERNEL] %s", string_buffer.GetString());
+      XELOG_GPU_I("[KERNEL] Shim: %s", string_buffer.GetString());
     } else {
       xe::LogLine(xe::LogLevel::Info, 'i', string_buffer.GetString(),
                   string_buffer.length());

--- a/src/xenia/kernel/xam/apps/unknown_fe_app.cc
+++ b/src/xenia/kernel/xam/apps/unknown_fe_app.cc
@@ -42,8 +42,8 @@ X_RESULT UnknownFEApp::DispatchMessageSync(uint32_t message,
       return X_ERROR_SUCCESS;
     }
   }
-  XELOGE(
-      "Unimplemented 0xFE message app=%.8X, msg=%.8X, arg1=%.8X, "
+  XELOG_KERNEL_E(
+      "[KERNEL] Unimplemented 0xFE message app=%.8X, msg=%.8X, arg1=%.8X, "
       "arg2=%.8X",
       app_id(), message, buffer_ptr, buffer_length);
   return X_STATUS_UNSUCCESSFUL;

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -115,7 +115,8 @@ X_RESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       return X_ERROR_SUCCESS;
     }
   }
-  XELOGE("Unimplemented XGI message app=%.8X, msg=%.8X, arg1=%.8X, arg2=%.8X",
+  XELOG_KERNEL_E(
+      "[KERNEL] Unimplemented XGI message app=%.8X, msg=%.8X, arg1=%.8X, arg2=%.8X",
          app_id(), message, buffer_ptr, buffer_length);
   return X_STATUS_UNSUCCESSFUL;
 }

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -56,8 +56,8 @@ X_RESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
       return X_STATUS_UNSUCCESSFUL;
     }
   }
-  XELOGE(
-      "Unimplemented XLIVEBASE message app=%.8X, msg=%.8X, arg1=%.8X, "
+  XELOG_KERNEL_E(
+      "[KERNEL] Unimplemented XLIVEBASE message app=%.8X, msg=%.8X, arg1=%.8X, "
       "arg2=%.8X",
       app_id(), message, buffer_ptr, buffer_length);
   return X_STATUS_UNSUCCESSFUL;

--- a/src/xenia/kernel/xam/apps/xmp_app.cc
+++ b/src/xenia/kernel/xam/apps/xmp_app.cc
@@ -102,7 +102,7 @@ X_RESULT XmpApp::XMPDeleteTitlePlaylist(uint32_t playlist_handle) {
   auto global_lock = global_critical_region_.Acquire();
   auto it = playlists_.find(playlist_handle);
   if (it == playlists_.end()) {
-    XELOGE("Playlist %.8X not found", playlist_handle);
+    XELOG_KERNEL_E("[KERNEL] Playlist %.8X not found", playlist_handle);
     return X_ERROR_NOT_FOUND;
   }
   auto playlist = it->second;
@@ -122,7 +122,7 @@ X_RESULT XmpApp::XMPPlayTitlePlaylist(uint32_t playlist_handle,
     auto global_lock = global_critical_region_.Acquire();
     auto it = playlists_.find(playlist_handle);
     if (it == playlists_.end()) {
-      XELOGE("Playlist %.8X not found", playlist_handle);
+      XELOG_KERNEL_E("[KERNEL] Playlist %.8X not found", playlist_handle);
       return X_ERROR_NOT_FOUND;
     }
     playlist = it->second;
@@ -130,12 +130,12 @@ X_RESULT XmpApp::XMPPlayTitlePlaylist(uint32_t playlist_handle,
 
   if (disabled_) {
     // Ignored because we aren't enabled?
-    XELOGW("Ignoring XMPPlayTitlePlaylist because disabled");
+    XELOG_KERNEL_W("[KERNEL] Ignoring XMPPlayTitlePlaylist because disabled");
     return X_ERROR_SUCCESS;
   }
 
   // Start playlist?
-  XELOGW("Playlist playback not supported");
+  XELOG_KERNEL_W("[KERNEL] Playlist playback not supported");
   active_playlist_ = playlist;
   active_song_index_ = 0;
   state_ = State::kPlaying;
@@ -331,7 +331,7 @@ X_RESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       auto info = memory_->TranslateVirtual(info_ptr);
       assert_true(xmp_client == 0x00000002);
       assert_zero(unk_ptr);
-      XELOGE("XMPGetInfo?(%.8X, %.8X)", unk_ptr, info_ptr);
+      XELOG_KERNEL_E("[KERNEL] XMPGetInfo?(%.8X, %.8X)", unk_ptr, info_ptr);
       if (!active_playlist_) {
         return X_STATUS_UNSUCCESSFUL;
       }
@@ -446,7 +446,8 @@ X_RESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       return X_STATUS_UNSUCCESSFUL;
     }
   }
-  XELOGE("Unimplemented XMP message app=%.8X, msg=%.8X, arg1=%.8X, arg2=%.8X",
+  XELOG_KERNEL_E(
+      "[KERNEL] Unimplemented XMP message app=%.8X, msg=%.8X, arg1=%.8X, arg2=%.8X",
          app_id(), message, buffer_ptr, buffer_length);
   return X_STATUS_UNSUCCESSFUL;
 }

--- a/src/xenia/kernel/xam/xam_msg.cc
+++ b/src/xenia/kernel/xam/xam_msg.cc
@@ -23,7 +23,7 @@ dword_result_t XMsgInProcessCall(dword_t app, dword_t message, dword_t arg1,
   auto result = kernel_state()->app_manager()->DispatchMessageSync(app, message,
                                                                    arg1, arg2);
   if (result == X_ERROR_NOT_FOUND) {
-    XELOGE("XMsgInProcessCall: app %.8X undefined", (uint32_t)app);
+    XELOG_KERNEL_E("[KERNEL] XMsgInProcessCall: app %.8X undefined", (uint32_t)app);
   }
   return result;
 }
@@ -34,7 +34,7 @@ dword_result_t XMsgSystemProcessCall(dword_t app, dword_t message,
   auto result = kernel_state()->app_manager()->DispatchMessageAsync(
       app, message, buffer, buffer_length);
   if (result == X_ERROR_NOT_FOUND) {
-    XELOGE("XMsgSystemProcessCall: app %.8X undefined", (uint32_t)app);
+    XELOG_KERNEL_E("[KERNEL] XMsgSystemProcessCall: app %.8X undefined", (uint32_t)app);
   }
   return result;
 }
@@ -46,7 +46,7 @@ dword_result_t XMsgStartIORequest(dword_t app, dword_t message,
   auto result = kernel_state()->app_manager()->DispatchMessageAsync(
       app, message, buffer, buffer_length);
   if (result == X_ERROR_NOT_FOUND) {
-    XELOGE("XMsgStartIORequest: app %.8X undefined", (uint32_t)app);
+    XELOG_KERNEL_E("[KERNEL] XMsgStartIORequest: app %.8X undefined", (uint32_t)app);
   }
   if (overlapped_ptr) {
     kernel_state()->CompleteOverlappedImmediate(overlapped_ptr, result);
@@ -63,7 +63,7 @@ dword_result_t XMsgStartIORequestEx(dword_t app, dword_t message,
   auto result = kernel_state()->app_manager()->DispatchMessageAsync(
       app, message, buffer, buffer_length);
   if (result == X_ERROR_NOT_FOUND) {
-    XELOGE("XMsgStartIORequestEx: app %.8X undefined", (uint32_t)app);
+    XELOG_KERNEL_E("[KERNEL] XMsgStartIORequestEx: app %.8X undefined", (uint32_t)app);
   }
   if (overlapped_ptr) {
     kernel_state()->CompleteOverlappedImmediate(overlapped_ptr, result);

--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -196,7 +196,7 @@ dword_result_t NetDll_XNetGetOpt(dword_t one, dword_t option_id,
       std::memcpy(buffer_ptr, &xnet_startup_params, sizeof(XNetStartupParams));
       return 0;
     default:
-      XELOGE("NetDll_XNetGetOpt: option %d unimplemented", option_id);
+      XELOG_KERNEL_E("[KERNEL] NetDll_XNetGetOpt: option %d unimplemented", option_id);
       return 0x2726;  // WSAEINVAL
   }
 }

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -161,7 +161,8 @@ dword_result_t XamUserReadProfileSettings(
       }
     } else {
       any_missing = true;
-      XELOGE("XamUserReadProfileSettings requested unimplemented setting %.8X",
+      XELOG_KERNEL_E(
+          "[KERNEL] XamUserReadProfileSettings requested unimplemented setting %.8X",
              setting_id);
     }
   }
@@ -316,7 +317,8 @@ dword_result_t XamUserWriteProfileSettings(
       case UserProfile::Setting::Type::DATETIME:
       default:
 
-        XELOGE("XamUserWriteProfileSettings: Unimplemented data type %d",
+        XELOG_KERNEL_E(
+            "[KERNEL] XamUserWriteProfileSettings: Unimplemented data type %d",
                settingType);
         break;
     };

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_error.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_error.cc
@@ -1007,7 +1007,7 @@ uint32_t xeRtlNtStatusToDosError(uint32_t source_status) {
     return status & 0xFFFF;
   }
 
-  XELOGE("RtlNtStatusToDosError lookup NOT IMPLEMENTED");
+  XELOG_KERNEL_E("[KERNEL] RtlNtStatusToDosError lookup NOT IMPLEMENTED");
   return 317;  // ERROR_MR_MID_NOT_FOUND
 }
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_hal.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_hal.cc
@@ -26,7 +26,7 @@ void HalReturnToFirmware(dword_t routine) {
 
   // TODO(benvank): diediedie much more gracefully
   // Not sure how to blast back up the stack in LLVM without exceptions, though.
-  XELOGE("Game requested shutdown via HalReturnToFirmware");
+  XELOG_KERNEL_E("[KERNEL] Game requested shutdown via HalReturnToFirmware");
   exit(0);
 }
 DECLARE_XBOXKRNL_EXPORT2(HalReturnToFirmware, kNone, kStub, kImportant);

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -498,8 +498,8 @@ dword_result_t NtQueryInformationFile(
       }
       case XFileXctdCompressionInformation: {
         assert_true(length == 4);
-        XELOGE(
-            "NtQueryInformationFile(XFileXctdCompressionInformation) "
+        XELOG_KERNEL_E(
+            "[KERNEL] NtQueryInformationFile(XFileXctdCompressionInformation) "
             "unimplemented");
         // This is wrong and puts files into wrong states for games that use
         // XctdDecompression.
@@ -529,7 +529,8 @@ dword_result_t NtQueryInformationFile(
       case XFileSectorInformation:
         // TODO(benvanik): return sector this file's on.
         assert_true(length == 4);
-        XELOGE("NtQueryInformationFile(XFileSectorInformation) unimplemented");
+        XELOG_KERNEL_E(
+            "[KERNEL] NtQueryInformationFile(XFileSectorInformation) unimplemented");
         result = X_STATUS_UNSUCCESSFUL;
         info = 0;
         break;

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
@@ -119,7 +119,7 @@ dword_result_t NtAllocateVirtualMemory(lpdword_t base_addr_ptr,
     allocation_type |= kMemoryAllocationCommit;
   }
   if (alloc_type & X_MEM_RESET) {
-    XELOGE("X_MEM_RESET not implemented");
+    XELOG_KERNEL_E("[KERNEL] X_MEM_RESET not implemented");
     assert_always();
   }
   uint32_t protect = FromXdkProtectFlags(protect_bits);
@@ -301,7 +301,7 @@ dword_result_t MmAllocatePhysicalMemoryEx(dword_t flags, dword_t region_size,
 
   // Check protection bits.
   if (!(protect_bits & (X_PAGE_READONLY | X_PAGE_READWRITE))) {
-    XELOGE("MmAllocatePhysicalMemoryEx: bad protection bits");
+    XELOG_KERNEL_E("[KERNEL] MmAllocatePhysicalMemoryEx: bad protection bits");
     return 0;
   }
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -127,7 +127,7 @@ dword_result_t ExCreateThread(lpdword_t handle_ptr, dword_t stack_size,
   X_STATUS result = thread->Create();
   if (XFAILED(result)) {
     // Failed!
-    XELOGE("Thread creation failed: %.8X", result);
+    XELOG_KERNEL_E("[KERNEL] Thread creation failed: %.8X", result);
     return result;
   }
 

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -207,7 +207,7 @@ object_ref<XFile> XFile::Restore(KernelState* kernel_state,
       abs_path, vfs::FileDisposition::kOpen, access, is_directory, &vfs_file,
       &action);
   if (XFAILED(res)) {
-    XELOGE("Failed to open XFile: error %.8X", res);
+    XELOG_KERNEL_E("[KERNEL] Failed to open XFile: error %.8X", res);
     return object_ref<XFile>(file);
   }
 

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -495,7 +495,7 @@ X_STATUS XThread::Terminate(int exit_code) {
 }
 
 void XThread::Execute() {
-  XELOGKERNEL("XThread::Execute thid %d (handle=%.8X, '%s', native=%.8X)",
+  XELOG_KERNEL_W("[KERNEL] XThread::Execute thid %d (handle=%.8X, '%s', native=%.8X)",
               thread_id_, handle(), thread_name_.c_str(), thread_->system_id());
 
   // Let the kernel know we are starting.
@@ -1054,8 +1054,8 @@ XHostThread::XHostThread(KernelState* kernel_state, uint32_t stack_size,
 }
 
 void XHostThread::Execute() {
-  XELOGKERNEL(
-      "XThread::Execute thid %d (handle=%.8X, '%s', native=%.8X, <host>)",
+  XELOG_KERNEL_W(
+      "[KERNEL] XThread::Execute thid %d (handle=%.8X, '%s', native=%.8X, <host>)",
       thread_id_, handle(), thread_name_.c_str(), thread_->system_id());
 
   // Let the kernel know we are starting.

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -99,7 +99,7 @@ XThread::~XThread() {
 
   if (thread_) {
     // TODO(benvanik): platform kill
-    XELOGE("Thread disposed without exiting");
+    XELOG_KERNEL_E("[KERNEL] Thread disposed without exiting");
   }
 }
 
@@ -410,7 +410,7 @@ X_STATUS XThread::Create() {
 
   if (!thread_) {
     // TODO(benvanik): translate error?
-    XELOGE("CreateThread failed");
+    XELOG_KERNEL_E("[KERNEL] CreateThread failed");
     return X_STATUS_NO_MEMORY;
   }
 
@@ -864,7 +864,8 @@ bool XThread::Save(ByteStream* stream) {
   if (running_) {
     pc = emulator()->processor()->StepToGuestSafePoint(thread_id_);
     if (!pc) {
-      XELOGE("XThread %.8X failed to save: could not step to a safe point!",
+      XELOG_KERNEL_E(
+          "[KERNEL] XThread %.8X failed to save: could not step to a safe point!",
              handle());
       assert_always();
       return false;
@@ -936,7 +937,7 @@ object_ref<XThread> XThread::Restore(KernelState* kernel_state,
   }
 
   if (stream->Read<uint32_t>() != 'THRD') {
-    XELOGE("Could not restore XThread - invalid magic!");
+    XELOG_KERNEL_E("[KERNEL] Could not restore XThread - invalid magic!");
     return nullptr;
   }
 

--- a/src/xenia/ui/vk/vulkan_context.h
+++ b/src/xenia/ui/vk/vulkan_context.h
@@ -54,6 +54,12 @@ class VulkanContext : public GraphicsContext {
   uint32_t GetCurrentQueueFrame() { return current_queue_frame_; }
   void AwaitAllFramesCompletion();
 
+  const VkSurfaceFormatKHR& GetSurfaceFormat() const { return surface_format_; }
+
+  VkCommandBuffer GetPresentCommandBuffer() const {
+    return present_command_buffers_[current_queue_frame_];
+  }
+
  private:
   friend class VulkanProvider;
 
@@ -86,6 +92,10 @@ class VulkanContext : public GraphicsContext {
 
   VkSemaphore semaphore_present_complete_ = VK_NULL_HANDLE;
   VkSemaphore semaphore_draw_complete_ = VK_NULL_HANDLE;
+
+  VkRenderPass present_render_pass_ = VK_NULL_HANDLE;
+  VkCommandPool present_command_pool_ = VK_NULL_HANDLE;
+  VkCommandBuffer present_command_buffers_[kQueuedFrames] = {};
 
   std::unique_ptr<VulkanImmediateDrawer> immediate_drawer_ = nullptr;
 

--- a/src/xenia/vfs/devices/disc_image_device.cc
+++ b/src/xenia/vfs/devices/disc_image_device.cc
@@ -59,7 +59,7 @@ Entry* DiscImageDevice::ResolvePath(const std::string& path) {
   // be in the form:
   // some\PATH.foo
 
-  XELOGFS("DiscImageDevice::ResolvePath(%s)", path.c_str());
+  XELOG_VFS_I("[VFS] DiscImageDevice::ResolvePath(%s)", path.c_str());
 
   // Walk the path, one separator at a time.
   auto entry = root_entry_.get();

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -53,7 +53,7 @@ Entry* HostPathDevice::ResolvePath(const std::string& path) {
   // be in the form:
   // some\PATH.foo
 
-  XELOGFS("HostPathDevice::ResolvePath(%s)", path.c_str());
+  XELOG_VFS_I("[VFS] HostPathDevice::ResolvePath(%s)", path.c_str());
 
   // Walk the path, one separator at a time.
   auto entry = root_entry_.get();

--- a/src/xenia/vfs/devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/stfs_container_device.cc
@@ -154,7 +154,7 @@ Entry* StfsContainerDevice::ResolvePath(const std::string& path) {
   // be in the form:
   // some\PATH.foo
 
-  XELOGFS("StfsContainerDevice::ResolvePath(%s)", path.c_str());
+  XELOG_VFS_I("[VFS] StfsContainerDevice::ResolvePath(%s)", path.c_str());
 
   // Walk the path, one separator at a time.
   auto entry = root_entry_.get();


### PR DESCRIPTION
* Added new definitions for XELOGCORE for specific types of modules (such as CPU, GPU, APU, KERNEL).
* Added configuration flag to exclude error messages from specific types of modules (see above). Any logged message using the above new definitions can be excluded from the log by setting the corresponding config flag (in xenia.config.toml) to true (e.g. exclude_gpu_from_log = true).
* Improved error messages by adding what module generated it at the beginning of the string (e.g. "[GPU] Failed to read backbuffer.").
* Identified the function that generated the VdSwap log message, and tagged it with one of the new logging definitions (XELOG_GPU_I). This allows this message to be excluded from the log by setting 'exclude_gpu_from_log' to 'true'.

Rationale for the above changes is to improve the bug hunting experience. For example, instead of a few XELOGE calls, you can now see at a glance what the error is. The new format goes XELOG_%MODULE%_%ERROR_LEVEL% (e.g. 'XELOG_GPU_I' would be an Information level log entry for the GPU module.

In addition, the purpose of excluding items from the log is useful in the case where a particular XEX spews repetitive entries, thus generating large log files, while you might be working on a completely different module, making it harder to identify relevant entries to what you are working on.

If the PR is accepted, I'd be happy to go through and finish updating existing modules.