### PR TITLE
Implement debug functions for Linux

### DIFF
--- a/src/xenia/base/debugging_posix.cc
+++ b/src/xenia/base/debugging_posix.cc
@@ -9,21 +9,51 @@
 
 #include "xenia/base/debugging.h"
 
-#include <signal.h>
+#include <csignal>
 #include <cstdarg>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
 
 #include "xenia/base/string_buffer.h"
 
 namespace xe {
 namespace debugging {
 
-bool IsDebuggerAttached() { return false; }
-void Break() { raise(SIGTRAP); }
+bool IsDebuggerAttached() {
+  std::ifstream proc_status_stream("/proc/self/status");
+  if (!proc_status_stream.is_open()) {
+    return false;
+  }
+  std::string line;
+  while (std::getline(proc_status_stream, line)) {
+    std::istringstream line_stream(line);
+    std::string key;
+    line_stream >> key;
+    if (key == "TracerPid:") {
+      uint32_t tracer_pid;
+      line_stream >> tracer_pid;
+      return tracer_pid != 0;
+    }
+  }
+  return false;
+}
+
+void Break() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    // Install handler for sigtrap only once
+    std::signal(SIGTRAP, [](int) {
+      // Forward signal to default handler after being caught
+      std::signal(SIGTRAP, SIG_DFL);
+    });
+  });
+  std::raise(SIGTRAP);
+}
 
 namespace internal {
-void DebugPrint(const char* s) {
-  // TODO: proper implementation.
-}
+void DebugPrint(const char* s) { std::clog << s << std::endl; }
 }  // namespace internal
 
 }  // namespace debugging


### PR DESCRIPTION
Check `TracerPid` in `/proc/self/status` for attached debugger.
Add `SIGTRAP` handler to prevent signal from halting app while not running
in a debugger.
Log `DebugPrint` in `clog` (`stderr`).