### PR TITLE
Fix an issue in git-clang-format that exists with Python 3.4.

### DIFF
--- a/third_party/clang-format/git-clang-format
+++ b/third_party/clang-format/git-clang-format
@@ -522,7 +522,7 @@ def apply_changes(old_tree, new_tree, force=False, patch_mode=False):
 
 
 def run(*args, **kwargs):
-  stdin = kwargs.pop('stdin', '')
+  stdin = kwargs.pop('stdin', to_bytes(''))
   verbose = kwargs.pop('verbose', True)
   strip = kwargs.pop('strip', True)
   for name in kwargs:


### PR DESCRIPTION
…esolved on its own by Python 3.7 (unknown when it's actually resolved) but still good to have this fix.