### PR TITLE
[Kernel] Exports & fixes needed for Forza 4 saving/loading

### DIFF
--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -55,6 +55,14 @@ X_RESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
              buffer_length);
       return X_STATUS_UNSUCCESSFUL;
     }
+    case 0x00058046: {
+      // Required to be successful for Forza 4 to detect signed-in profile
+      // Doesn't seem to set anything in the given buffer, probably only takes
+      // input
+      XELOGD("XLiveBaseUnk58046(%.8X, %.8X) unimplemented", buffer_ptr,
+             buffer_length);
+      return X_ERROR_SUCCESS;
+    }
   }
   XELOGE(
       "Unimplemented XLIVEBASE message app=%.8X, msg=%.8X, arg1=%.8X, "

--- a/src/xenia/vfs/devices/host_path_entry.cc
+++ b/src/xenia/vfs/devices/host_path_entry.cc
@@ -104,5 +104,17 @@ bool HostPathEntry::DeleteEntryInternal(Entry* entry) {
   }
 }
 
+void HostPathEntry::update() {
+  xe::filesystem::FileInfo file_info;
+  if (!xe::filesystem::GetInfo(local_path_, &file_info)) {
+    return;
+  }
+  if (file_info.type == xe::filesystem::FileInfo::Type::kFile) {
+    size_ = file_info.total_size;
+    allocation_size_ =
+        xe::round_up(file_info.total_size, device()->bytes_per_sector());
+  }
+}
+
 }  // namespace vfs
 }  // namespace xe

--- a/src/xenia/vfs/devices/host_path_entry.h
+++ b/src/xenia/vfs/devices/host_path_entry.h
@@ -38,6 +38,7 @@ class HostPathEntry : public Entry {
   std::unique_ptr<MappedMemory> OpenMapped(MappedMemory::Mode mode,
                                            size_t offset,
                                            size_t length) override;
+  void update() override;
 
  private:
   friend class HostPathDevice;

--- a/src/xenia/vfs/entry.h
+++ b/src/xenia/vfs/entry.h
@@ -120,6 +120,7 @@ class Entry {
                                                    size_t length = 0) {
     return nullptr;
   }
+  virtual void update() { return; }
 
  protected:
   Entry(Device* device, Entry* parent, const std::string& path);


### PR DESCRIPTION
This adds two functions used by Forza 4 when saving (XeKeysObscureKey & XeKeysAesCbcUsingKey), a stub for an XLiveBase message that it needs to return success, and a fix for the game truncating save files by accident.

The two functions should work pretty much like they do inside the HV, though on X360 they use a per-console key for the obscuring-crypto, I've just set that to an all zero key in Xenia.

The XLiveBase message doesn't seem to write anything to the message buffer, just reads something from it AFAIK. Forza needs it to return success for the profile to be recognised so I've just added a stub for it.

The truncation bug was a tricky one, but I've narrowed it down to how we handle the file size of an XFile.
When writing data to a save, the game uses NtQueryInfoFile to make sure there's enough room in the file for the data.
If there isn't, the game uses NtSetInfoFile(EndOfFileInfo) to set the length of the file to (position + data size)
Unfortunately after NtSetInfoFile(EndOfFileInfo) is ran we don't update the information inside vfs::Entry, the same information that NtQueryInfo retrieves when the game tries to get the file size...

This makes the game always think that there isn't enough space in the file whenever it writes something, even though the game explicitly set the EOF to 0x5000 when the file was opened!

The result of this is that important save data gets truncated when the game tries updating info inside the saves header, eg:
- sets EOF to 0x5000
- writes 8 byte header
- writes variable-size data
- sets position to 4, to update data-size in header
- uses NtQueryInformationFile to check if the file is big enough to write the data-size in
- if not, calls NtSetInformationFile(EndOfFileInfo) to set end of file to data-size offset + 4 (0x8)

Because the size wasn't updated when we set the EOF, NtQueryInformationFile returns size 0, making the game set a new EOF which deletes any data written past the 8 byte header

To fix this I've added an update() method to vfs::Entry, and made NtQueryInfo/NtSetInfo call that before doing anything size-related with the vfs::Entry.
This seemed like the best way to solve this, seeing as the vfs::Entry doesn't have anything to do with the opened file handle, but I'm open to any other suggestions for it of course!

Anyway, with all this Forza 4 should now load/save with no issues.
I'm curious if this might help with other games - maybe the whole NtQueryInfo/NtSetInfo stuff comes from some library function that other games share, probably worth checking out.