### PR TITLE
[x64] Unwind fixes.

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -409,6 +409,7 @@ HostToGuestThunk X64ThunkEmitter::EmitHostToGuestThunk() {
 
   struct _code_offsets {
     size_t prolog;
+    size_t prolog_stack_alloc;
     size_t body;
     size_t epilog;
     size_t tail;
@@ -424,6 +425,7 @@ HostToGuestThunk X64ThunkEmitter::EmitHostToGuestThunk() {
   mov(qword[rsp + 8 * 1], rcx);
   sub(rsp, stack_size);
 
+  code_offsets.prolog_stack_alloc = getSize();
   code_offsets.body = getSize();
 
   // Save nonvolatile registers.
@@ -453,6 +455,8 @@ HostToGuestThunk X64ThunkEmitter::EmitHostToGuestThunk() {
   func_info.code_size.body = code_offsets.epilog - code_offsets.body;
   func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
   func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.prolog_stack_alloc_offset =
+      code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = stack_size;
 
   void* fn = Emplace(func_info);
@@ -467,6 +471,7 @@ GuestToHostThunk X64ThunkEmitter::EmitGuestToHostThunk() {
 
   struct _code_offsets {
     size_t prolog;
+    size_t prolog_stack_alloc;
     size_t body;
     size_t epilog;
     size_t tail;
@@ -479,6 +484,7 @@ GuestToHostThunk X64ThunkEmitter::EmitGuestToHostThunk() {
   // rsp + 0 = return address
   sub(rsp, stack_size);
 
+  code_offsets.prolog_stack_alloc = getSize();
   code_offsets.body = getSize();
 
   // Save off volatile registers.
@@ -504,6 +510,8 @@ GuestToHostThunk X64ThunkEmitter::EmitGuestToHostThunk() {
   func_info.code_size.body = code_offsets.epilog - code_offsets.body;
   func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
   func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.prolog_stack_alloc_offset =
+      code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = stack_size;
 
   void* fn = Emplace(func_info);
@@ -519,6 +527,7 @@ ResolveFunctionThunk X64ThunkEmitter::EmitResolveFunctionThunk() {
 
   struct _code_offsets {
     size_t prolog;
+    size_t prolog_stack_alloc;
     size_t body;
     size_t epilog;
     size_t tail;
@@ -531,6 +540,7 @@ ResolveFunctionThunk X64ThunkEmitter::EmitResolveFunctionThunk() {
   // rsp + 0 = return address
   sub(rsp, stack_size);
 
+  code_offsets.prolog_stack_alloc = getSize();
   code_offsets.body = getSize();
 
   // Save volatile registers
@@ -557,6 +567,8 @@ ResolveFunctionThunk X64ThunkEmitter::EmitResolveFunctionThunk() {
   func_info.code_size.body = code_offsets.epilog - code_offsets.body;
   func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
   func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.prolog_stack_alloc_offset =
+      code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = stack_size;
 
   void* fn = Emplace(func_info);

--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -407,12 +407,24 @@ HostToGuestThunk X64ThunkEmitter::EmitHostToGuestThunk() {
   // rdx = arg0 (context)
   // r8 = arg1 (guest return address)
 
+  struct _code_offsets {
+    size_t prolog;
+    size_t body;
+    size_t epilog;
+    size_t tail;
+  } code_offsets = {};
+
   const size_t stack_size = StackLayout::THUNK_STACK_SIZE;
+
+  code_offsets.prolog = getSize();
+
   // rsp + 0 = return address
   mov(qword[rsp + 8 * 3], r8);
   mov(qword[rsp + 8 * 2], rdx);
   mov(qword[rsp + 8 * 1], rcx);
   sub(rsp, stack_size);
+
+  code_offsets.body = getSize();
 
   // Save nonvolatile registers.
   EmitSaveNonvolatileRegs();
@@ -424,13 +436,26 @@ HostToGuestThunk X64ThunkEmitter::EmitHostToGuestThunk() {
 
   EmitLoadNonvolatileRegs();
 
+  code_offsets.epilog = getSize();
+
   add(rsp, stack_size);
   mov(rcx, qword[rsp + 8 * 1]);
   mov(rdx, qword[rsp + 8 * 2]);
   mov(r8, qword[rsp + 8 * 3]);
   ret();
 
-  void* fn = Emplace(stack_size);
+  code_offsets.tail = getSize();
+
+  assert_zero(code_offsets.prolog);
+  EmitFunctionInfo func_info = {};
+  func_info.code_size.total = getSize();
+  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
+  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
+  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
+  func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.stack_size = stack_size;
+
+  void* fn = Emplace(func_info);
   return (HostToGuestThunk)fn;
 }
 
@@ -440,9 +465,21 @@ GuestToHostThunk X64ThunkEmitter::EmitGuestToHostThunk() {
   // r8  = arg1
   // r9  = arg2
 
+  struct _code_offsets {
+    size_t prolog;
+    size_t body;
+    size_t epilog;
+    size_t tail;
+  } code_offsets = {};
+
   const size_t stack_size = StackLayout::THUNK_STACK_SIZE;
+
+  code_offsets.prolog = getSize();
+
   // rsp + 0 = return address
   sub(rsp, stack_size);
+
+  code_offsets.body = getSize();
 
   // Save off volatile registers.
   EmitSaveVolatileRegs();
@@ -453,10 +490,23 @@ GuestToHostThunk X64ThunkEmitter::EmitGuestToHostThunk() {
 
   EmitLoadVolatileRegs();
 
+  code_offsets.epilog = getSize();
+
   add(rsp, stack_size);
   ret();
 
-  void* fn = Emplace(stack_size);
+  code_offsets.tail = getSize();
+
+  assert_zero(code_offsets.prolog);
+  EmitFunctionInfo func_info = {};
+  func_info.code_size.total = getSize();
+  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
+  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
+  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
+  func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.stack_size = stack_size;
+
+  void* fn = Emplace(func_info);
   return (GuestToHostThunk)fn;
 }
 
@@ -466,10 +516,22 @@ extern "C" uint64_t ResolveFunction(void* raw_context, uint32_t target_address);
 ResolveFunctionThunk X64ThunkEmitter::EmitResolveFunctionThunk() {
   // ebx = target PPC address
   // rcx = context
+
+  struct _code_offsets {
+    size_t prolog;
+    size_t body;
+    size_t epilog;
+    size_t tail;
+  } code_offsets = {};
+
   const size_t stack_size = StackLayout::THUNK_STACK_SIZE;
+
+  code_offsets.prolog = getSize();
 
   // rsp + 0 = return address
   sub(rsp, stack_size);
+
+  code_offsets.body = getSize();
 
   // Save volatile registers
   EmitSaveVolatileRegs();
@@ -481,10 +543,23 @@ ResolveFunctionThunk X64ThunkEmitter::EmitResolveFunctionThunk() {
 
   EmitLoadVolatileRegs();
 
+  code_offsets.epilog = getSize();
+
   add(rsp, stack_size);
   jmp(rax);
 
-  void* fn = Emplace(stack_size);
+  code_offsets.tail = getSize();
+
+  assert_zero(code_offsets.prolog);
+  EmitFunctionInfo func_info = {};
+  func_info.code_size.total = getSize();
+  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
+  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
+  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
+  func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.stack_size = stack_size;
+
+  void* fn = Emplace(func_info);
   return (ResolveFunctionThunk)fn;
 }
 

--- a/src/xenia/cpu/backend/x64/x64_code_cache.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */

--- a/src/xenia/cpu/backend/x64/x64_code_cache.h
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.h
@@ -25,6 +25,17 @@ namespace cpu {
 namespace backend {
 namespace x64 {
 
+struct EmitFunctionInfo {
+  struct _code_size {
+    size_t prolog;
+    size_t body;
+    size_t epilog;
+    size_t tail;
+    size_t total;
+  } code_size;
+  size_t stack_size;
+};
+
 class X64CodeCache : public CodeCache {
  public:
   ~X64CodeCache() override;
@@ -48,9 +59,9 @@ class X64CodeCache : public CodeCache {
   void CommitExecutableRange(uint32_t guest_low, uint32_t guest_high);
 
   void* PlaceHostCode(uint32_t guest_address, void* machine_code,
-                      size_t code_size, size_t stack_size);
+                      const EmitFunctionInfo& func_info);
   void* PlaceGuestCode(uint32_t guest_address, void* machine_code,
-                       size_t code_size, size_t stack_size,
+                       const EmitFunctionInfo& func_info,
                        GuestFunction* function_info);
   uint32_t PlaceData(const void* data, size_t length);
 
@@ -84,8 +95,7 @@ class X64CodeCache : public CodeCache {
     return UnwindReservation();
   }
   virtual void PlaceCode(uint32_t guest_address, void* machine_code,
-                         size_t code_size, size_t stack_size,
-                         void* code_address,
+                         const EmitFunctionInfo& func_info, void* code_address,
                          UnwindReservation unwind_reservation) {}
 
   std::wstring file_name_;

--- a/src/xenia/cpu/backend/x64/x64_code_cache.h
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -33,6 +33,7 @@ struct EmitFunctionInfo {
     size_t tail;
     size_t total;
   } code_size;
+  size_t prolog_stack_alloc_offset;  // offset of instruction after stack alloc
   size_t stack_size;
 };
 

--- a/src/xenia/cpu/backend/x64/x64_code_cache_win.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache_win.cc
@@ -163,12 +163,19 @@ bool Win32X64CodeCache::Initialize() {
   unwind_table_.resize(kMaximumFunctionCount);
 
   // Check if this version of Windows supports growable function tables.
-  add_growable_table_ = (FnRtlAddGrowableFunctionTable)GetProcAddress(
-      GetModuleHandleW(L"ntdll.dll"), "RtlAddGrowableFunctionTable");
-  delete_growable_table_ = (FnRtlDeleteGrowableFunctionTable)GetProcAddress(
-      GetModuleHandleW(L"ntdll.dll"), "RtlDeleteGrowableFunctionTable");
-  grow_table_ = (FnRtlGrowFunctionTable)GetProcAddress(
-      GetModuleHandleW(L"ntdll.dll"), "RtlGrowFunctionTable");
+  auto ntdll_handle = GetModuleHandleW(L"ntdll.dll");
+  if (!ntdll_handle) {
+    add_growable_table_ = nullptr;
+    delete_growable_table_ = nullptr;
+    grow_table_ = nullptr;
+  } else {
+    add_growable_table_ = (FnRtlAddGrowableFunctionTable)GetProcAddress(
+        ntdll_handle, "RtlAddGrowableFunctionTable");
+    delete_growable_table_ = (FnRtlDeleteGrowableFunctionTable)GetProcAddress(
+        ntdll_handle, "RtlDeleteGrowableFunctionTable");
+    grow_table_ = (FnRtlGrowFunctionTable)GetProcAddress(
+        ntdll_handle, "RtlGrowFunctionTable");
+  }
   supports_growable_table_ =
       add_growable_table_ && delete_growable_table_ && grow_table_;
 

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -163,6 +163,7 @@ bool X64Emitter::Emit(HIRBuilder* builder, EmitFunctionInfo& func_info) {
 
   struct _code_offsets {
     size_t prolog;
+    size_t prolog_stack_alloc;
     size_t body;
     size_t epilog;
     size_t tail;
@@ -183,6 +184,9 @@ bool X64Emitter::Emit(HIRBuilder* builder, EmitFunctionInfo& func_info) {
   stack_size_ = stack_size;
 
   sub(rsp, (uint32_t)stack_size);
+
+  code_offsets.prolog_stack_alloc = getSize();
+
   mov(qword[rsp + StackLayout::GUEST_CTX_HOME], GetContextReg());
   mov(qword[rsp + StackLayout::GUEST_RET_ADDR], rcx);
   mov(qword[rsp + StackLayout::GUEST_CALL_RET_ADDR], 0);
@@ -275,6 +279,8 @@ bool X64Emitter::Emit(HIRBuilder* builder, EmitFunctionInfo& func_info) {
   func_info.code_size.body = code_offsets.epilog - code_offsets.body;
   func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
   func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.prolog_stack_alloc_offset =
+      code_offsets.prolog_stack_alloc - code_offsets.prolog;
 
   return true;
 }

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -39,6 +39,8 @@ namespace x64 {
 class X64Backend;
 class X64CodeCache;
 
+struct EmitFunctionInfo;
+
 enum RegisterFlags {
   REG_DEST = (1 << 0),
   REG_ABCD = (1 << 1),
@@ -222,8 +224,9 @@ class X64Emitter : public Xbyak::CodeGenerator {
   size_t stack_size() const { return stack_size_; }
 
  protected:
-  void* Emplace(size_t stack_size, GuestFunction* function = nullptr);
-  bool Emit(hir::HIRBuilder* builder, size_t* out_stack_size);
+  void* Emplace(const EmitFunctionInfo& func_info,
+                GuestFunction* function = nullptr);
+  bool Emit(hir::HIRBuilder* builder, EmitFunctionInfo& func_info);
   void EmitGetCurrentThreadId();
   void EmitTraceUserCallReturn();
 

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -203,8 +203,6 @@ class X64Emitter : public Xbyak::CodeGenerator {
 
   void nop(size_t length = 1);
 
-  // TODO(benvanik): Label for epilog (don't use strings).
-
   // Moves a 64bit immediate into memory.
   bool ConstantFitsIn32Reg(uint64_t v);
   void MovMem64(const Xbyak::RegExp& addr, uint64_t v);


### PR DESCRIPTION
[x64] Fix up unwind info for emitted functions.

- [x64] Track size of code within emitted functions (prolog, body, epilog).
- [x64] Don't use hardcoded prolog size in generated unwind info.
- [x64] Update URLs to MSDN documentation on `UNWIND_INFO`/`UNWIND_CODE`.