### PR TITLE
Fix up handling of positional options in cvar handling.

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -401,4 +401,5 @@ int xenia_main(const std::vector<std::wstring>& args) {
 }  // namespace app
 }  // namespace xe
 
-DEFINE_ENTRY_POINT(L"xenia", L"xenia some.xex", xe::app::xenia_main);
+DEFINE_ENTRY_POINT(L"xenia", xe::app::xenia_main, "[Path to .iso/.xex]",
+                   "target");

--- a/src/xenia/base/cvar.cc
+++ b/src/xenia/base/cvar.cc
@@ -1,3 +1,12 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
 #include "cvar.h"
 
 namespace cvar {
@@ -13,7 +22,9 @@ void PrintHelpAndExit() {
   exit(0);
 }
 
-void ParseLaunchArguments(int argc, char** argv) {
+void ParseLaunchArguments(int argc, char** argv,
+                          const std::string& positional_help,
+                          const std::vector<std::string>& positional_options) {
   options.add_options()("help", "Prints help and exit.");
   if (!CmdVars) CmdVars = new std::map<std::string, ICommandVar*>();
   if (!ConfigVars) ConfigVars = new std::map<std::string, IConfigVar*>();
@@ -29,8 +40,8 @@ void ParseLaunchArguments(int argc, char** argv) {
     configVar->AddToLaunchOptions(&options);
   }
   try {
-    options.positional_help("[Path to .iso/.xex]");
-    options.parse_positional({"target"});
+    options.positional_help(positional_help);
+    options.parse_positional(positional_options);
 
     auto result = options.parse(argc, argv);
     if (result.count("help")) {

--- a/src/xenia/base/cvar.h
+++ b/src/xenia/base/cvar.h
@@ -1,10 +1,23 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
 #ifndef XENIA_CVAR_H_
 #define XENIA_CVAR_H_
+
 #include <map>
 #include <string>
+#include <vector>
+
 #include "cpptoml/include/cpptoml.h"
 #include "cxxopts/include/cxxopts.hpp"
 #include "xenia/base/string_util.h"
+
 namespace cvar {
 
 namespace toml {
@@ -204,7 +217,9 @@ inline void AddCommandVar(ICommandVar* cv) {
   if (!CmdVars) CmdVars = new std::map<std::string, ICommandVar*>();
   CmdVars->insert(std::pair<std::string, ICommandVar*>(cv->name(), cv));
 }
-void ParseLaunchArguments(int argc, char** argv);
+void ParseLaunchArguments(int argc, char** argv,
+                          const std::string& positional_help,
+                          const std::vector<std::string>& positional_options);
 
 template <typename T>
 T* define_configvar(const char* name, T* default_value, const char* description,
@@ -221,14 +236,15 @@ T* define_cmdvar(const char* name, T* default_value, const char* description) {
   AddCommandVar(cmdVar);
   return default_value;
 }
-#define DEFINE_double(name, default_value, description, category) \
-  DEFINE_CVar(name, default_value, description, category, false, double)
 
 #define DEFINE_int32(name, default_value, description, category) \
   DEFINE_CVar(name, default_value, description, category, false, int32_t)
 
 #define DEFINE_uint64(name, default_value, description, category) \
   DEFINE_CVar(name, default_value, description, category, false, uint64_t)
+
+#define DEFINE_double(name, default_value, description, category) \
+  DEFINE_CVar(name, default_value, description, category, false, double)
 
 #define DEFINE_string(name, default_value, description, category) \
   DEFINE_CVar(name, default_value, description, category, false, std::string)
@@ -275,4 +291,5 @@ T* define_cmdvar(const char* name, T* default_value, const char* description) {
   }
 
 }  // namespace cvar
+
 #endif  // XENIA_CVAR_H_

--- a/src/xenia/base/main.h
+++ b/src/xenia/base/main.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2014 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "xenia/base/cvar.h"
 #include "xenia/base/platform.h"
 
 namespace xe {
@@ -24,14 +25,19 @@ bool has_console_attached();
 // launch.
 struct EntryInfo {
   std::wstring name;
-  std::wstring usage;
+  std::string positional_usage;
+  std::vector<std::string> positional_options;
   int (*entry_point)(const std::vector<std::wstring>& args);
 };
 EntryInfo GetEntryInfo();
 
-#define DEFINE_ENTRY_POINT(name, usage, entry_point)  \
-  xe::EntryInfo xe::GetEntryInfo() {                  \
-    return xe::EntryInfo({name, usage, entry_point}); \
+#define DEFINE_ENTRY_POINT(name, entry_point, positional_usage, ...)       \
+  xe::EntryInfo xe::GetEntryInfo() {                                       \
+    std::initializer_list<std::string> positional_options = {__VA_ARGS__}; \
+    return xe::EntryInfo(                                                  \
+        {name, positional_usage,                                           \
+         std::vector<std::string>(std::move(positional_options)),          \
+         entry_point});                                                    \
   }
 
 }  // namespace xe

--- a/src/xenia/base/main_posix.cc
+++ b/src/xenia/base/main_posix.cc
@@ -22,7 +22,8 @@ bool has_console_attached() { return true; }
 extern "C" int main(int argc, char** argv) {
   auto entry_info = xe::GetEntryInfo();
 
-  cvar::ParseLaunchArguments(argc, argv);
+  cvar::ParseLaunchArguments(argc, argv, entry_info.positional_usage,
+                             entry_info.positional_options);
 
   std::vector<std::wstring> args;
   for (int n = 0; n < argc; n++) {

--- a/src/xenia/base/main_win.cc
+++ b/src/xenia/base/main_win.cc
@@ -105,7 +105,8 @@ int Main() {
     std::wcstombs(argva[n], argv[n], len + 1);
   }
 
-  cvar::ParseLaunchArguments(argca, argva);
+  cvar::ParseLaunchArguments(argca, argva, entry_info.positional_usage,
+                             entry_info.positional_options);
 
   // Widen all remaining flags and convert to usable strings.
   std::vector<std::wstring> args;

--- a/src/xenia/cpu/ppc/testing/ppc_testing_main.cc
+++ b/src/xenia/cpu/ppc/testing/ppc_testing_main.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2014 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -27,6 +27,7 @@ DEFINE_string(test_path, "src/xenia/cpu/ppc/testing/",
               "Directory scanned for test files.", "Other");
 DEFINE_string(test_bin_path, "src/xenia/cpu/ppc/testing/bin/",
               "Directory with binary outputs of the test files.", "Other");
+DEFINE_transient_string(test_name, "", "Specifies test name.", "General");
 
 namespace xe {
 namespace cpu {
@@ -472,5 +473,5 @@ int main(const std::vector<std::wstring>& args) {
 }  // namespace cpu
 }  // namespace xe
 
-DEFINE_ENTRY_POINT(L"xenia-cpu-ppc-test", L"xenia-cpu-ppc-test [test name]",
-                   xe::cpu::test::main);
+DEFINE_ENTRY_POINT(L"xenia-cpu-ppc-test", xe::cpu::test::main, "[test name]",
+                   "test_name");

--- a/src/xenia/gpu/shader_compiler_main.cc
+++ b/src/xenia/gpu/shader_compiler_main.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2015 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -179,6 +179,5 @@ int shader_compiler_main(const std::vector<std::wstring>& args) {
 }  // namespace gpu
 }  // namespace xe
 
-DEFINE_ENTRY_POINT(L"xenia-gpu-shader-compiler",
-                   L"xenia-gpu-shader-compiler shader.bin",
-                   xe::gpu::shader_compiler_main);
+DEFINE_ENTRY_POINT(L"xenia-gpu-shader-compiler", xe::gpu::shader_compiler_main,
+                   "shader.bin", "shader_input");

--- a/src/xenia/gpu/vulkan/vulkan_trace_dump_main.cc
+++ b/src/xenia/gpu/vulkan/vulkan_trace_dump_main.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2016 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -36,5 +36,5 @@ int trace_dump_main(const std::vector<std::wstring>& args) {
 }  // namespace xe
 
 DEFINE_ENTRY_POINT(L"xenia-gpu-vulkan-trace-dump",
-                   L"xenia-gpu-vulkan-trace-dump some.trace",
-                   xe::gpu::vulkan::trace_dump_main);
+                   xe::gpu::vulkan::trace_dump_main, "some.trace",
+                   "target_trace_file");

--- a/src/xenia/gpu/vulkan/vulkan_trace_viewer_main.cc
+++ b/src/xenia/gpu/vulkan/vulkan_trace_viewer_main.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2016 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -72,5 +72,5 @@ int trace_viewer_main(const std::vector<std::wstring>& args) {
 }  // namespace xe
 
 DEFINE_ENTRY_POINT(L"xenia-gpu-vulkan-trace-viewer",
-                   L"xenia-gpu-vulkan-trace-viewer some.trace",
-                   xe::gpu::vulkan::trace_viewer_main);
+                   xe::gpu::vulkan::trace_viewer_main, "some.trace",
+                   "target_trace_file");

--- a/src/xenia/hid/hid_demo.cc
+++ b/src/xenia/hid/hid_demo.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2017 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -215,5 +215,4 @@ void DrawInputStatus() {
 }  // namespace hid
 }  // namespace xe
 
-DEFINE_ENTRY_POINT(L"xenia-hid-demo", L"xenia-hid-demo",
-                   xe::hid::hid_demo_main);
+DEFINE_ENTRY_POINT(L"xenia-hid-demo", xe::hid::hid_demo_main, "");

--- a/src/xenia/ui/vulkan/vulkan_window_demo.cc
+++ b/src/xenia/ui/vulkan/vulkan_window_demo.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2016 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -26,5 +26,5 @@ std::unique_ptr<GraphicsProvider> CreateDemoGraphicsProvider(Window* window) {
 }  // namespace ui
 }  // namespace xe
 
-DEFINE_ENTRY_POINT(L"xenia-ui-window-vulkan-demo",
-                   L"xenia-ui-window-vulkan-demo", xe::ui::window_demo_main);
+DEFINE_ENTRY_POINT(L"xenia-ui-window-vulkan-demo", xe::ui::window_demo_main,
+                   "");

--- a/src/xenia/vfs/vfs_dump.cc
+++ b/src/xenia/vfs/vfs_dump.cc
@@ -21,9 +21,15 @@
 namespace xe {
 namespace vfs {
 
+DEFINE_transient_string(source, "", "Specifies the file to dump from.",
+                        "General");
+
+DEFINE_transient_string(dump_path, "",
+                        "Specifies the directory to dump files to.", "General");
+
 int vfs_dump_main(const std::vector<std::wstring>& args) {
   if (args.size() <= 2) {
-    XELOGE("Usage: %s [source] [dump_path]", args[0].c_str());
+    XELOGE("Usage: %S [source] [dump_path]", args[0].c_str());
     return 1;
   }
 
@@ -107,5 +113,5 @@ int vfs_dump_main(const std::vector<std::wstring>& args) {
 }  // namespace vfs
 }  // namespace xe
 
-DEFINE_ENTRY_POINT(L"xenia-vfs-dump", L"xenia-vfs-dump",
-                   xe::vfs::vfs_dump_main);
+DEFINE_ENTRY_POINT(L"xenia-vfs-dump", xe::vfs::vfs_dump_main,
+                   "[source] [dump_path]", "source", "dump_path");

--- a/tools/build/src/test_suite_main.cc
+++ b/tools/build/src/test_suite_main.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2015 Ben Vanik. All rights reserved.                             *
+ * Copyright 2019 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -23,7 +23,7 @@ bool has_console_attached() { return true; }
 
 // Used in console mode apps; automatically picked based on subsystem.
 int Main(int argc, char* argv[]) {
-  cvar::ParseLaunchArguments(argc, argv);
+  cvar::ParseLaunchArguments(argc, argv, "", std::vector<std::string>());
 
   // Run Catch.
   int result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
- Fix up handling of positional options in cvar handling so that executables other than app can handle them properly.
- Fix command-line arguments for xenia-vfs-dump.