### PR TITLE
[Discord] Add Time elapsed and description text

### DIFF
--- a/src/xenia/app/discord/discord_presence.cc
+++ b/src/xenia/app/discord/discord_presence.cc
@@ -8,6 +8,7 @@
 */
 
 #include "discord_presence.h"
+#include <ctime>
 #include "third_party/discord-rpc/include/discord_rpc.h"
 #include "xenia/base/string.h"
 
@@ -35,6 +36,8 @@ void DiscordPresence::NotPlaying() {
   discordPresence.state = "Idle";
   discordPresence.details = "Standby";
   discordPresence.largeImageKey = "app";
+  discordPresence.largeImageText = "Xenia - Experimental Xbox 360 Emulator";
+  discordPresence.startTimestamp = time(0);
   discordPresence.instance = 1;
   Discord_UpdatePresence(&discordPresence);
 }
@@ -47,6 +50,8 @@ void DiscordPresence::PlayingTitle(const std::string_view game_title) {
   // discordPresence.smallImageKey = "app";
   // discordPresence.largeImageKey = "state_ingame";
   discordPresence.largeImageKey = "app";
+  discordPresence.largeImageText = "Xenia - Experimental Xbox 360 Emulator";
+  discordPresence.startTimestamp = time(0);
   discordPresence.instance = 1;
   Discord_UpdatePresence(&discordPresence);
 }


### PR DESCRIPTION
Display Time elapsed when idle or playing a game
Display description when hovering over the icon
Example: 
![ ](https://cdn.discordapp.com/attachments/570608724205502464/615051226865860608/unknown.png)