### PR TITLE
Removal of MAX_PATH limit on Windows

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -291,9 +291,8 @@ bool EmulatorWindow::Initialize() {
   return true;
 }
 
-void EmulatorWindow::FileDrop(wchar_t* filename) {
-  std::wstring path = filename;
-  auto result = emulator_->LaunchPath(path);
+void EmulatorWindow::FileDrop(const wchar_t* filename) {
+  auto result = emulator_->LaunchPath(filename);
   if (XFAILED(result)) {
     // TODO: Display a message box.
     XELOGE("Failed to launch target: %.8X", result);

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -43,7 +43,7 @@ class EmulatorWindow {
 
   bool Initialize();
 
-  void FileDrop(wchar_t* filename);
+  void FileDrop(const wchar_t* filename);
   void FileOpen();
   void FileClose();
   void ShowContentDirectory();

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -31,12 +31,14 @@ std::wstring GetExecutableFolder() {
 }
 
 std::wstring GetUserFolder() {
-  wchar_t path[MAX_PATH];
-  if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_MYDOCUMENTS, nullptr,
-                                  SHGFP_TYPE_CURRENT, path))) {
-    return std::wstring();
+  std::wstring result;
+  PWSTR path;
+  if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_DEFAULT,
+                                     nullptr, &path))) {
+    result.assign(path);
+    CoTaskMemFree(path);
   }
-  return std::wstring(path);
+  return result;
 }
 
 bool PathExists(const std::wstring& path) {

--- a/src/xenia/base/platform.h
+++ b/src/xenia/base/platform.h
@@ -95,7 +95,6 @@ namespace xe {
 #if XE_PLATFORM_WIN32
 const char kPathSeparator = '\\';
 const wchar_t kWPathSeparator = L'\\';
-const size_t kMaxPath = 260;  // _MAX_PATH
 #else
 const char kPathSeparator = '/';
 const wchar_t kWPathSeparator = L'/';

--- a/src/xenia/base/string.cc
+++ b/src/xenia/base/string.cc
@@ -155,9 +155,13 @@ std::string::size_type find_first_of_case(const std::string& target,
 
 std::wstring to_absolute_path(const std::wstring& path) {
 #if XE_PLATFORM_WIN32
-  wchar_t buffer[kMaxPath];
-  _wfullpath(buffer, path.c_str(), sizeof(buffer) / sizeof(wchar_t));
-  return buffer;
+  std::wstring result;
+  wchar_t* buffer = _wfullpath(nullptr, path.c_str(), 0);
+  if (buffer != nullptr) {
+    result.assign(buffer);
+    free(buffer);
+  }
+  return result;
 #else
   char buffer[kMaxPath];
   realpath(xe::to_string(path).c_str(), buffer);

--- a/src/xenia/gpu/shader.cc
+++ b/src/xenia/gpu/shader.cc
@@ -49,12 +49,21 @@ std::pair<std::string, std::string> Shader::Dump(const std::string& base_path,
     xe::filesystem::CreateFolder(target_path);
   }
 
-  char txt_file_name[kMaxPath];
-  std::snprintf(txt_file_name, xe::countof(txt_file_name),
-                "%s/shader_%s_%.16" PRIX64 ".%s", base_path.c_str(),
-                path_prefix, ucode_data_hash_,
-                shader_type_ == ShaderType::kVertex ? "vert" : "frag");
-  FILE* f = fopen(txt_file_name, "wb");
+  const std::string file_name_no_extension =
+      xe::format_string("%s/shader_%s_%.16" PRIX64, base_path.c_str(),
+                        path_prefix, ucode_data_hash_);
+
+  std::string txt_file_name, bin_file_name;
+
+  if (shader_type_ == ShaderType::kVertex) {
+    txt_file_name = file_name_no_extension + ".vert";
+    bin_file_name = file_name_no_extension + ".bin.vert";
+  } else {
+    txt_file_name = file_name_no_extension + ".frag";
+    bin_file_name = file_name_no_extension + ".bin.frag";
+  }
+
+  FILE* f = fopen(txt_file_name.c_str(), "wb");
   if (f) {
     fwrite(translated_binary_.data(), 1, translated_binary_.size(), f);
     fprintf(f, "\n\n");
@@ -72,18 +81,13 @@ std::pair<std::string, std::string> Shader::Dump(const std::string& base_path,
     fclose(f);
   }
 
-  char bin_file_name[kMaxPath];
-  std::snprintf(bin_file_name, xe::countof(bin_file_name),
-                "%s/shader_%s_%.16" PRIX64 ".bin.%s", base_path.c_str(),
-                path_prefix, ucode_data_hash_,
-                shader_type_ == ShaderType::kVertex ? "vert" : "frag");
-  f = fopen(bin_file_name, "wb");
+  f = fopen(bin_file_name.c_str(), "wb");
   if (f) {
     fwrite(ucode_data_.data(), 4, ucode_data_.size(), f);
     fclose(f);
   }
 
-  return {std::string(txt_file_name), std::string(bin_file_name)};
+  return {std::move(txt_file_name), std::move(bin_file_name)};
 }
 
 }  //  namespace gpu

--- a/src/xenia/ui/ui_event.h
+++ b/src/xenia/ui/ui_event.h
@@ -28,14 +28,14 @@ class UIEvent {
 
 class FileDropEvent : public UIEvent {
  public:
-  FileDropEvent(Window* target, wchar_t* filename)
+  FileDropEvent(Window* target, const wchar_t* filename)
       : UIEvent(target), filename_(filename) {}
   ~FileDropEvent() override = default;
 
-  wchar_t* filename() const { return filename_; }
+  const wchar_t* filename() const { return filename_; }
 
  private:
-  wchar_t* filename_ = nullptr;
+  const wchar_t* filename_ = nullptr;
 };
 
 class KeyEvent : public UIEvent {

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -492,16 +492,19 @@ LRESULT Win32Window::WndProc(HWND hWnd, UINT message, WPARAM wParam,
 
   switch (message) {
     case WM_DROPFILES: {
-      TCHAR lpszFile[MAX_PATH] = {0};
-      UINT uFiles = 0;
-      HDROP hDrop = (HDROP)wParam;
-      // Get number of files dropped
-      uFiles = DragQueryFile(hDrop, -1, NULL, NULL);
+      HDROP hDrop = reinterpret_cast<HDROP>(wParam);
+      std::wstring path;
 
-      // Only getting first file dropped (other files ignored)
-      if (DragQueryFile(hDrop, 0, lpszFile, MAX_PATH)) {
-        auto e = FileDropEvent(this, lpszFile);
-        OnFileDrop(&e);
+      // Get required buffer size
+      UINT buf_size = DragQueryFileW(hDrop, 0, nullptr, 0);
+      if (buf_size > 0) {
+        path.resize(buf_size + 1);  // Give space for a null terminator
+
+        // Only getting first file dropped (other files ignored)
+        if (DragQueryFileW(hDrop, 0, &path[0], buf_size + 1)) {
+          auto e = FileDropEvent(this, path.c_str());
+          OnFileDrop(&e);
+        }
       }
 
       DragFinish(hDrop);


### PR DESCRIPTION
This PR lifts `MAX_PATH` limit from all code places which still used it. Most of current instances of it could be trivially removed either by calling functions twice (first to determine required buffer size, then to do actual work) or by replacing them with their memory-allocating counterparts.

The end result is a complete removal of `kMaxPath` constant on Windows. It's now unused and I think it's a good idea not to keep it to encourage not using any hardcoded constants for functions operating on paths.