### PR TITLE
Added new 0xFE app message

### DIFF
--- a/src/xenia/kernel/xam/apps/unknown_fe_app.cc
+++ b/src/xenia/kernel/xam/apps/unknown_fe_app.cc
@@ -41,6 +41,18 @@ X_RESULT UnknownFEApp::DispatchMessageSync(uint32_t message,
              (uint32_t)data->unk_48);
       return X_ERROR_SUCCESS;
     }
+    case 0x00022005: {
+      struct message_data {
+        xe::be<uint32_t> unk_00;  // ? output_ptr ?
+        xe::be<uint32_t> unk_04;  // ? value/jump to? ?
+      }* data = reinterpret_cast<message_data*>(buffer);
+      assert_true(buffer_length == sizeof(message_data));
+      auto unk = memory_->TranslateVirtual<xe::be<uint32_t>*>(data->unk_00);
+      auto adr = *unk;
+      XELOGD("UnknownFEApp(0x00022005)(%.8X, %.8X)", (uint32_t)data->unk_00,
+             (uint32_t)data->unk_04);
+      return X_ERROR_SUCCESS;
+    }
   }
   XELOGE(
       "Unimplemented 0xFE message app=%.8X, msg=%.8X, arg1=%.8X, "

--- a/src/xenia/kernel/xam/apps/unknown_fe_app.cc
+++ b/src/xenia/kernel/xam/apps/unknown_fe_app.cc
@@ -41,6 +41,10 @@ X_RESULT UnknownFEApp::DispatchMessageSync(uint32_t message,
              (uint32_t)data->unk_48);
       return X_ERROR_SUCCESS;
     }
+    case 0x00021012: {
+      XELOGD("UnknownFEApp(0x00021012)");
+      return X_ERROR_SUCCESS;
+    }
     case 0x00022005: {
       struct message_data {
         xe::be<uint32_t> unk_00;  // ? output_ptr ?


### PR DESCRIPTION
### Overview:
Sometimes games uses not defined xam exports as a 0xFE app with different msgid.

Usually lack of even dummy support for such action causes game to return I/O Error or crash.

### Affected Games (by msgid):
0x21012:
- _FUSE_

0x22005: most EGO engine games
- _Grid 2_
- _Grid Autosport_
- _Toybox Turbos_