### PR TITLE
[XAM] Dequeue remain notification when match_id is incorrect

### DIFF
--- a/src/xenia/kernel/xam/xam_notify.cc
+++ b/src/xenia/kernel/xam/xam_notify.cc
@@ -18,10 +18,7 @@ namespace xe {
 namespace kernel {
 namespace xam {
 
-dword_result_t XamNotifyCreateListenerInternal(qword_t mask, dword_t unk,
-                                               dword_t one) {
-  // r4=1 may indicate user process?
-
+dword_result_t XamNotifyCreateListenerInternal(qword_t mask) {
   auto listener =
       object_ref<XNotifyListener>(new XNotifyListener(kernel_state()));
   listener->Initialize(mask);
@@ -31,11 +28,10 @@ dword_result_t XamNotifyCreateListenerInternal(qword_t mask, dword_t unk,
 
   return handle;
 }
-DECLARE_XAM_EXPORT2(XamNotifyCreateListenerInternal, kNone, kImplemented,
-                    kSketchy);
+DECLARE_XAM_EXPORT1(XamNotifyCreateListenerInternal, kNone, kImplemented);
 
-dword_result_t XamNotifyCreateListener(qword_t mask, dword_t one) {
-  return XamNotifyCreateListenerInternal(mask, 0, one);
+dword_result_t XamNotifyCreateListener(qword_t mask) {
+  return XamNotifyCreateListenerInternal(mask);
 }
 DECLARE_XAM_EXPORT1(XamNotifyCreateListener, kNone, kImplemented);
 
@@ -75,7 +71,7 @@ dword_result_t XNotifyGetNext(dword_t handle, dword_t match_id,
 
   return dequeued ? 1 : 0;
 }
-DECLARE_XAM_EXPORT2(XNotifyGetNext, kNone, kImplemented, kHighFrequency);
+DECLARE_XAM_EXPORT1(XNotifyGetNext, kNone, kImplemented);
 
 dword_result_t XNotifyDelayUI(dword_t delay_ms) {
   // Ignored.

--- a/src/xenia/kernel/xnotifylistener.cc
+++ b/src/xenia/kernel/xnotifylistener.cc
@@ -31,7 +31,8 @@ void XNotifyListener::Initialize(uint64_t mask) {
 
 void XNotifyListener::EnqueueNotification(XNotificationID id, uint32_t data) {
   // Ignore if the notification doesn't match our mask.
-  if ((mask_ & uint64_t(1ULL << (id >> 25))) == 0) {
+  // TODO(Gliniak): (confirm) mask 0x01 means accept all
+  if ((mask_ & ((id >> 25) & 0x3F)) == 0 && mask_ != 0x01) {
     return;
   }
 


### PR DESCRIPTION
UPDATE: This Commit is incorrect, however please do not close this PR. It will be updated in the future

Affected Games:
- Grid 2 (no more freezes)
- Skate. (Menu Soundtrack)
- Crackdown 2 Demo (no more ingame freezes)

Please add label: Needs Validation