### PR TITLE
[Kernel] Add PVR opcode (includes cvars support)

### DIFF
--- a/src/xenia/cpu/cpu_flags.cc
+++ b/src/xenia/cpu/cpu_flags.cc
@@ -48,3 +48,6 @@ DEFINE_bool(break_condition_truncate, true, "truncate value to 32-bits", "CPU");
 
 DEFINE_bool(break_on_debugbreak, true, "int3 on JITed __debugbreak requests.",
             "CPU");
+
+// Other:
+DEFINE_uint64(pvr, 0x710700, "Processor version & revision number.", "CPU");

--- a/src/xenia/cpu/cpu_flags.h
+++ b/src/xenia/cpu/cpu_flags.h
@@ -25,7 +25,7 @@ DECLARE_bool(trace_function_data);
 DECLARE_bool(disable_global_lock);
 
 DECLARE_bool(validate_hir);
-
+// Breakpoints:
 DECLARE_uint64(break_on_instruction);
 DECLARE_int32(break_condition_gpr);
 DECLARE_uint64(break_condition_value);
@@ -33,5 +33,6 @@ DECLARE_string(break_condition_op);
 DECLARE_bool(break_condition_truncate);
 
 DECLARE_bool(break_on_debugbreak);
-
+// Other:
+DECLARE_uint64(pvr);
 #endif  // XENIA_CPU_CPU_FLAGS_H_

--- a/src/xenia/cpu/ppc/ppc_emit_control.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_control.cc
@@ -609,6 +609,16 @@ int InstrEmit_mfspr(PPCHIRBuilder& f, const InstrData& i) {
       // TBU
       v = f.Shr(f.LoadClock(), 32);
       break;
+    case 287:
+      // [ Processor Version Register (PVR) ]
+      // PVR is a 32 bit, read-only register within the supervisor level.
+      // Bits 0 to 15 are the version number.
+      // Bits 16 to 31 are the revision number.
+      // Known Values: 0x710600?, 0x710700, 0x710800 (Corona?);
+      // Note: Some XEXs (such as mfgbootlauncher.xex) may check for a value
+      // that's less than 0x710700.
+      v = f.LoadConstantUint64(cvars::pvr);
+      break;
     default:
       XEINSTRNOTIMPLEMENTED();
       return 1;


### PR DESCRIPTION
Adds the PVR opcode to the list of recognized opcodes. Includes useful comments.