### PR TITLE
[Kernel] Improve XexUnloadImage and module refcounts

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -405,6 +405,39 @@ object_ref<UserModule> KernelState::LoadUserModule(const char* raw_name,
   return module;
 }
 
+void KernelState::UnloadUserModule(const object_ref<UserModule>& module,
+                                   bool call_entry) {
+  auto global_lock = global_critical_region_.Acquire();
+
+  if (module->is_dll_module() && module->entry_point() && call_entry) {
+    // Call DllMain(DLL_PROCESS_DETACH):
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682583%28v=vs.85%29.aspx
+    uint64_t args[] = {
+        module->handle(),
+        0,  // DLL_PROCESS_DETACH
+        0,  // 0 for now, assume XexUnloadImage is like FreeLibrary
+    };
+    auto thread_state = XThread::GetCurrentThread()->thread_state();
+    processor()->Execute(thread_state, module->entry_point(), args,
+                         xe::countof(args));
+  }
+
+  auto iter = std::find_if(
+      user_modules_.begin(), user_modules_.end(),
+      [&module](const auto& e) { return e->path() == module->path(); });
+  assert_true(iter != user_modules_.end());  // Unloading an unregistered module
+                                             // is probably really bad
+  user_modules_.erase(iter);
+
+  // Ensure this module was not somehow registered twice
+  assert_true(std::find_if(user_modules_.begin(), user_modules_.end(),
+                           [&module](const auto& e) {
+                             return e->path() == module->path();
+                           }) == user_modules_.end());
+
+  object_table()->ReleaseHandle(module->handle());
+}
+
 void KernelState::TerminateTitle() {
   XELOGD("KernelState::TerminateTitle");
   auto global_lock = global_critical_region_.Acquire();

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -131,6 +131,8 @@ class KernelState {
   void SetExecutableModule(object_ref<UserModule> module);
   object_ref<UserModule> LoadUserModule(const char* name,
                                         bool call_entry = true);
+  void UnloadUserModule(const object_ref<UserModule>& module,
+                        bool call_entry = true);
 
   object_ref<KernelModule> GetKernelModule(const char* name);
   template <typename T>

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
@@ -231,7 +231,8 @@ dword_result_t XexUnloadImage(lpvoid_t hmodule) {
     if (--ldr_data->load_count == 0) {
       // No more references, free it.
       module->Release();
-      kernel_state()->object_table()->RemoveHandle(module->handle());
+      kernel_state()->UnloadUserModule(object_ref<UserModule>(
+          reinterpret_cast<UserModule*>(module.release())));
     }
   }
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
@@ -198,8 +198,10 @@ dword_result_t XexLoadImage(lpstring_t module_name, dword_t module_flags,
     // Not found; attempt to load as a user module.
     auto user_module = kernel_state()->LoadUserModule(module_name);
     if (user_module) {
-      user_module->Retain();
-      hmodule = user_module->hmodule_ptr();
+      // Give up object ownership, this reference will be released by the last
+      // XexUnloadImage call
+      auto user_module_raw = user_module.release();
+      hmodule = user_module_raw->hmodule_ptr();
       result = X_STATUS_SUCCESS;
     }
   }


### PR DESCRIPTION
This PR consists of two fairly separate parts:

1) The first commit corrects a few places in XEX loader where modules were incorrectly reference counted. Most notably, `object_ref`, which refcounts objects automatically, was used alongside manual `Retain()` calls. This probably caused handle leaks - there might be more to go, but at least some of them are fixed now.
2) The second commit fixes implementation flaws in `XexUnloadImage`. Previously, releasing the last reference to a module performed only a partial cleanup. This resulted in issues such as:
  - Attempting to notify an inexistant module when sending `DLL_THREAD_ATTACH` and `DLL_THREAD_DETACH` events. In my experience those were non-fatal but results may vary per game.
  - Not loading a XEX module fully after a chain of `Load` -> `Unload` -> `Load` calls. This actually was the main culprit of crashes I was trying to tackle.

When combined with #1461, this PR allows Forza Horizon to proceed past the first race, potentially making a good part of the game reachable and playable!
![image](https://user-images.githubusercontent.com/7947461/64133647-01e62200-cdd8-11e9-81be-53289d44330d.png)
