### PR TITLE
[Kernel] Add XamGetLocale and XamGetLocaleEx stub

### DIFF
--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -426,6 +426,25 @@ dword_result_t XamQueryLiveHiveW(lpwstring_t name, lpvoid_t out_buf,
 }
 DECLARE_XAM_EXPORT1(XamQueryLiveHiveW, kNone, kStub);
 
+dword_result_t XamGetLocaleEx(unknown_t unk1, unknown_t unk2) {
+  if (unk1 == 0x6F && unk2 == 0x2B) {
+    // This seems to be locale you can select from the dashboard,
+    // same as obtained from XamGetLocale
+    // and according to Forza Horizon 2 it has 0x2C possible values
+    return 0;
+  }
+
+  XELOGE("XamGetLocaleEx(unk1=%.8X, unk2=%.8X)", unk1, unk2);
+  return X_ERROR_INVALID_PARAMETER;
+}
+DECLARE_XAM_EXPORT1(XamGetLocaleEx, kNone, kStub);
+
+dword_result_t XamGetLocale() {
+  // That's how xam.xex implements XamGetLocale
+  return XamGetLocaleEx(0x6F, 0x2B);
+}
+DECLARE_XAM_EXPORT1(XamGetLocale, kNone, kImplemented);
+
 void RegisterInfoExports(xe::cpu::ExportResolver* export_resolver,
                          KernelState* kernel_state) {}
 


### PR DESCRIPTION
This PR fully implements `XamGetLocale` and stubs `XamGetLocaleEx`.

`XamGetLocale` is implemented in kernel as `XamGetLocaleEx(0x6F, 0x2B)`, so this implementation can be considered "complete". `XamGetLocaleEx` seems to return a numerical locale identifier which has 0x2C possible values (Forza Horizon 2 considers anything over that as an error), but I haven't been able to match those to any constants I am aware of.

Are those values maybe documented in any homebrew XDK? I feel returning constant 0 is cutting corners there, but I was unable to do better despite poking Forza. However, I at least could determine what locale values are tested with different languages:

- Language 1 (English): **0x1, 0x5, 0x12, 0x18, 0x23, 0x24**
- Language 2 (Japanese): **0x14**
- Language 3 (German): **0xD**
- Language 4 (French): **0x5, 0xC**
- Language 5 (Spanish): **0x16, 0x1F**
- Language 6 (Italian): **0x13**

Basing on this list, those are my guesses:
- 0x5 is tested with both English and French - so it's likely `LOCALE_CANADA`.
- 0xC is likely `LOCALE_FRANCE`, because it's tested with French.
- 0xD is either `LOCALE_GERMANY` or `LOCALE_AUSTRIA`.
- 0x13 is `LOCALE_ITALY`, since it's tested only with Italian language.
- 0x14 is `LOCALE_JAPAN`, since it's tested only with Japanese language.
- 0x16 and 0x1F are likely `LOCALE_SPAIN` and `LOCALE_MEXICO`, but no idea which is which.

When combined with #1461 and #1465, stubbed `XamGetLocaleEx` allows **Forza Horizon 2** to go ingame.
![image](https://user-images.githubusercontent.com/7947461/64284561-2c5fe880-cf5a-11e9-9965-535fff193706.png)

