### PR TITLE
[GTK UI] Fix GTK submenus

### DIFF
--- a/src/xenia/ui/window_gtk.cc
+++ b/src/xenia/ui/window_gtk.cc
@@ -416,14 +416,20 @@ GTKMenuItem::~GTKMenuItem() {
 
 void GTKMenuItem::OnChildAdded(MenuItem* generic_child_item) {
   auto child_item = static_cast<GTKMenuItem*>(generic_child_item);
+  GtkWidget* submenu = nullptr;
   switch (child_item->type()) {
     case MenuItem::Type::kNormal:
       // Nothing special.
       break;
     case MenuItem::Type::kPopup:
       if (GTK_IS_MENU_ITEM(menu_)) {
-        assert(gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu_)) == nullptr);
-        gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_), child_item->handle());
+        submenu = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu_));
+        // Get sub menu and if it doesn't exist create it
+        if (submenu == nullptr) {
+          submenu = gtk_menu_new();
+          gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_), submenu);
+        }
+        gtk_menu_shell_append(GTK_MENU_SHELL(submenu), child_item->handle());
       } else {
         gtk_menu_shell_append(GTK_MENU_SHELL(menu_), child_item->handle());
       }
@@ -432,7 +438,7 @@ void GTKMenuItem::OnChildAdded(MenuItem* generic_child_item) {
     case MenuItem::Type::kString:
       assert(GTK_IS_MENU_ITEM(menu_));
       // Get sub menu and if it doesn't exist create it
-      GtkWidget* submenu = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu_));
+      submenu = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu_));
       if (submenu == nullptr) {
         submenu = gtk_menu_new();
         gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_), submenu);


### PR DESCRIPTION
If one were to set a kPopup as a child of a kPopup (as ObsidianNA does in #1396), GTK will assert that the parent kPopup is not a submenu and refuse to set the child.

This changes the current behaviour by creating an intermediary submenu when one sets a kPopup as a child of a kPopup so that the menuing works as intended.