### PR TITLE
[Kernel] Fixup GetProcAddressByOrdinal

### DIFF
--- a/src/xenia/cpu/export_resolver.cc
+++ b/src/xenia/cpu/export_resolver.cc
@@ -58,7 +58,7 @@ Export* ExportResolver::GetExportByOrdinal(const std::string_view module_name,
                                            uint16_t ordinal) {
   for (const auto& table : tables_) {
     if (xe::utf8::starts_with_case(module_name, table.module_name())) {
-      if (ordinal > table.exports_by_ordinal().size()) {
+      if (ordinal >= table.exports_by_ordinal().size()) {
         return nullptr;
       }
       return table.exports_by_ordinal().at(ordinal);

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -127,7 +127,7 @@ uint32_t XexModule::GetProcAddress(uint16_t ordinal) const {
         xex_security_info()->export_table);
 
     ordinal -= export_table->base;
-    if (ordinal > export_table->count) {
+    if (ordinal >= export_table->count) {
       XELOGE("GetProcAddress({:03X}): ordinal out of bounds", ordinal);
       return 0;
     }

--- a/src/xenia/kernel/kernel_module.cc
+++ b/src/xenia/kernel/kernel_module.cc
@@ -107,12 +107,12 @@ uint32_t KernelModule::GetProcAddressByOrdinal(uint16_t ordinal) {
   } else {
     if (export_entry->function_data.trampoline ||
         export_entry->function_data.shim) {
-      global_critical_region_.Acquire();
+      auto global_lock = global_critical_region_.Acquire();
 
       // See if the function has been generated already.
-      if (guest_trampoline_map_.find(ordinal) != guest_trampoline_map_.end()) {
-        auto entry = guest_trampoline_map_.find(ordinal);
-        return entry->second;
+      auto item = guest_trampoline_map_.find(ordinal);
+      if (item != guest_trampoline_map_.end()) {
+        return item->second;
       }
 
       cpu::GuestFunction::ExternHandler handler = nullptr;
@@ -131,7 +131,7 @@ uint32_t KernelModule::GetProcAddressByOrdinal(uint16_t ordinal) {
              export_entry->name, guest_addr);
 
       // Register the function in our map.
-      guest_trampoline_map_[ordinal] = guest_addr;
+      guest_trampoline_map_.emplace(ordinal, guest_addr);
       return guest_addr;
     } else {
       // Not implemented.


### PR DESCRIPTION
A minor fix eyeballed while discussing related functionality. Fixes two tiny issues in `KernelModule::GetProcAddressByOrdinal`:

1. Now properly takes a global lock. Previously return value from `global_critical_region_.Acquire()` was discarded, which effectively locked and immediately unlocked the global lock.
2. Cases where a trampoline for ordinal was already created called `guest_trampoline_map_.find(ordinal)` twice for no reason. Now it's only called once - potentially a micro-optimization.

Chance of affecting games in any measurable way is near zero, unless there is a game which furiously calls `XexGetProcedureAddress` on the same module **concurrently** - in which case this pre-emptively prevents a race condition on populating the guest trampolines map.