### PR TITLE
[Core] Fix reading UTF-8 BOM config files

### DIFF
--- a/src/xenia/config.cc
+++ b/src/xenia/config.cc
@@ -15,6 +15,14 @@ std::shared_ptr<cpptoml::table> ParseFile(const std::wstring& filename) {
     throw cpptoml::parse_exception(xe::to_string(filename) +
                                    " could not be opened for parsing");
   }
+  // since cpptoml can't parse files with a UTF-8 BOM we need to skip them
+  char bom[3];
+  file.read(bom, sizeof(bom));
+  if (file.fail() || bom[0] != '\xEF' || bom[1] != '\xBB' || bom[2] != '\xBF') {
+    file.clear();
+    file.seekg(0);
+  }
+
   cpptoml::parser p(file);
   return p.parse();
 }


### PR DESCRIPTION
Since cpptoml appears to be dead I tried fixing #1419 by detecting and skipping a UTF-8 BOM before parsing the config file.