### PR TITLE
[HID] Fix Demo for XInput

### DIFF
--- a/src/xenia/hid/hid_demo.cc
+++ b/src/xenia/hid/hid_demo.cc
@@ -42,18 +42,24 @@ std::vector<std::unique_ptr<hid::InputDriver>> CreateInputDrivers(
     drivers.emplace_back(xe::hid::nop::Create(window));
 #if XE_PLATFORM_WIN32
   } else if (cvars::hid.compare("winkey") == 0) {
-    drivers.emplace_back(xe::hid::winkey::Create(window));
+    auto driver = xe::hid::winkey::Create(window);
+    if (XSUCCEEDED(driver->Setup())) {
+      drivers.emplace_back(std::move(driver));
+    }
   } else if (cvars::hid.compare("xinput") == 0) {
-    drivers.emplace_back(xe::hid::xinput::Create(window));
+    auto driver = xe::hid::xinput::Create(window);
+    if (XSUCCEEDED(driver->Setup())) {
+      drivers.emplace_back(std::move(driver));
+    }
 #endif  // XE_PLATFORM_WIN32
   } else {
 #if XE_PLATFORM_WIN32
     auto xinput_driver = xe::hid::xinput::Create(window);
-    if (xinput_driver) {
+    if (xinput_driver && XSUCCEEDED(xinput_driver->Setup())) {
       drivers.emplace_back(std::move(xinput_driver));
     }
     auto winkey_driver = xe::hid::winkey::Create(window);
-    if (winkey_driver) {
+    if (winkey_driver && XSUCCEEDED(winkey_driver->Setup())) {
       drivers.emplace_back(std::move(winkey_driver));
     }
 #endif  // XE_PLATFORM_WIN32


### PR DESCRIPTION
Fixes #1490 
`Setup()` was not called on XInput driver.
This fix calls it on winkey driver as well to prevent future regressions.
(Although it is not needed right now but that should be up to the implementation to decide)