### PR TITLE
[Kernel] Enable XEX1 loading

### DIFF
--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -43,6 +43,21 @@ class XexModule : public xe::cpu::Module {
     xe_xex2_version_t min_version;
     std::vector<ImportLibraryFn> imports;
   };
+  struct SecurityInfoContext {
+    const char* rsa_signature;
+    const char* aes_key;
+    uint32_t image_size;
+    uint32_t image_flags;
+    uint32_t export_table;
+    uint32_t load_address;
+    uint32_t page_descriptor_count;
+    const xex2_page_descriptor* page_descriptors;
+  };
+  enum XexFormat {
+    kFormatUnknown,
+    kFormatXex1,
+    kFormatXex2,
+  };
 
   XexModule(Processor* processor, kernel::KernelState* kernel_state);
   virtual ~XexModule();
@@ -51,8 +66,8 @@ class XexModule : public xe::cpu::Module {
   const xex2_header* xex_header() const {
     return reinterpret_cast<const xex2_header*>(xex_header_mem_.data());
   }
-  const xex2_security_info* xex_security_info() const {
-    return GetSecurityInfo(xex_header());
+  const SecurityInfoContext* xex_security_info() const {
+    return &security_info_;
   }
 
   uint32_t image_size() const {
@@ -112,7 +127,7 @@ class XexModule : public xe::cpu::Module {
     return GetOptHeader(key, reinterpret_cast<void**>(out_ptr));
   }
 
-  static const xex2_security_info* GetSecurityInfo(const xex2_header* header);
+  static const void* GetSecurityInfo(const xex2_header* header);
 
   const PESection* GetPESection(const char* name);
 
@@ -186,6 +201,9 @@ class XexModule : public xe::cpu::Module {
   uint32_t base_address_ = 0;
   uint32_t low_address_ = 0;
   uint32_t high_address_ = 0;
+
+  XexFormat xex_format_ = kFormatUnknown;
+  SecurityInfoContext security_info_ = {};
 };
 
 }  // namespace cpu

--- a/src/xenia/kernel/user_module.cc
+++ b/src/xenia/kernel/user_module.cc
@@ -135,7 +135,7 @@ X_STATUS UserModule::LoadFromMemory(const void* addr, const size_t length) {
   auto processor = kernel_state()->processor();
 
   auto magic = xe::load_and_swap<uint32_t>(addr);
-  if (magic == 'XEX2') {
+  if (magic == 'XEX2' || magic == 'XEX1') {
     module_format_ = kModuleFormatXex;
   } else if (magic == 0x7F454C46 /* 0x7F 'ELF' */) {
     module_format_ = kModuleFormatElf;

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -544,6 +544,23 @@ struct xex2_security_info {
   xex2_page_descriptor page_descriptors[1];  // 0x184
 };
 
+struct xex1_security_info {
+  xe::be<uint32_t> header_size;
+  xe::be<uint32_t> image_size;
+  char rsa_signature[0x100];
+  char image_digest[0x14];
+  char import_table_digest[0x14];
+  xe::be<uint32_t> load_address;
+  char aes_key[0x10];
+  char xgd2_media_id[0x10];
+  xe::be<uint32_t> region;
+  xe::be<uint32_t> image_flags;
+  xe::be<uint32_t> export_table;
+  xe::be<uint32_t> allowed_media_types;
+  xe::be<uint32_t> page_descriptor_count;
+  xex2_page_descriptor page_descriptors[1];
+};
+
 struct xex2_export_table {
   xe::be<uint32_t> magic[3];         // 0x0
   xe::be<uint32_t> modulenumber[2];  // 0xC


### PR DESCRIPTION
XEX1's are found in builds created before SDK 1888. Currently the only way to run them is by owning XeDK hardware (beta XDK), which aren't easy to come by. Though there still are more incompatibilities that need to be worked on, this allows them to be loaded and executed.

This fix is simple as the only difference appears to be in the security info structure (xex2_security_info). I just created a new structure named SecurityInfoContext which points to or loads all the info needed from the security info structure in the XEX header. 

Here are the changes made:
- Exception was made for the "XEX1" magic in `UserModule::LoadFromMemory()`.
- `xex1_security_info` structure was added to xex2_info.h
- `GetSecurityInfo()` now returns a void pointer which just points to either the XEX1 or XEX2 security info structure.
- Enum `XexFormat` was added to differentiate between XEX1 or XEX2, rather than relying on the magic.
- `SecurityInfoContext` was added to `XexModule`.
- `xex_security_info()` now returns the instance of `SecurityInfoContext`.

SecurityInfoContext's members share the same names as the security info structure, so no further changes were necessary within the rest of the loading process.

Here is a partial log provided as evidence of an XEX1 being loaded. Notice the SDK versions required are 1838: https://gist.github.com/aerosoul94/6ed631f38e041c16d8e11216bf9042f1