### PR TITLE
[Kernel] Fixes to thread reference counters

### DIFF
--- a/src/xenia/kernel/util/object_table.cc
+++ b/src/xenia/kernel/util/object_table.cc
@@ -194,6 +194,7 @@ X_STATUS ObjectTable::RemoveHandle(X_HANDLE handle) {
   if (entry->object) {
     auto object = entry->object;
     entry->object = nullptr;
+    assert_zero(entry->handle_ref_count);
     entry->handle_ref_count = 0;
 
     // Walk the object's handles and remove this one.

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
@@ -69,7 +69,7 @@ dword_result_t ObLookupThreadByThreadId(dword_t thread_id,
   }
 
   // Retain the object. Will be released in ObDereferenceObject.
-  thread->Retain();
+  thread->RetainHandle();
   *out_object_ptr = thread->guest_object();
   return X_STATUS_SUCCESS;
 }
@@ -133,7 +133,7 @@ dword_result_t ObReferenceObjectByHandle(dword_t handle,
 
     // Caller takes the reference.
     // It's released in ObDereferenceObject.
-    object->Retain();
+    object->RetainHandle();
     if (out_object_ptr.guest_address()) {
       *out_object_ptr = native_ptr;
     }
@@ -169,7 +169,7 @@ dword_result_t ObDereferenceObject(dword_t native_ptr) {
   auto object = XObject::GetNativeObject<XObject>(
       kernel_state(), kernel_memory()->TranslateVirtual(native_ptr));
   if (object) {
-    object->Release();
+    object->ReleaseHandle();
   }
 
   return 0;

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -138,7 +138,6 @@ dword_result_t ExCreateThread(lpdword_t handle_ptr, dword_t stack_size,
       if (creation_flags & 0x80) {
         *handle_ptr = thread->guest_object();
       } else {
-        thread->RetainHandle();
         *handle_ptr = thread->handle();
       }
     }

--- a/src/xenia/kernel/xobject.cc
+++ b/src/xenia/kernel/xobject.cc
@@ -49,6 +49,7 @@ XObject::XObject(KernelState* kernel_state, Type type)
 }
 
 XObject::~XObject() {
+  assert_true(handles_.empty());
   assert_zero(pointer_ref_count_);
 
   if (allocated_guest_object_) {

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -364,7 +364,7 @@ X_STATUS XThread::Create() {
   InitializeGuestObject();
 
   // Always retain when starting - the thread owns itself until exited.
-  Retain();
+  RetainHandle();
 
   xe::threading::Thread::CreationParameters params;
   params.stack_size = 16 * 1024 * 1024;  // Allocate a big host stack.
@@ -405,7 +405,7 @@ X_STATUS XThread::Create() {
     xe::Profiler::ThreadExit();
 
     // Release the self-reference to the thread.
-    Release();
+    ReleaseHandle();
   });
 
   if (!thread_) {
@@ -464,7 +464,7 @@ X_STATUS XThread::Exit(int exit_code) {
   xe::Profiler::ThreadExit();
 
   running_ = false;
-  Release();
+  ReleaseHandle();
 
   // NOTE: this does not return!
   xe::threading::Thread::Exit(exit_code);
@@ -484,11 +484,11 @@ X_STATUS XThread::Terminate(int exit_code) {
 
   running_ = false;
   if (XThread::IsInThread(this)) {
-    Release();
+    ReleaseHandle();
     xe::threading::Thread::Exit(exit_code);
   } else {
     thread_->Terminate(exit_code);
-    Release();
+    ReleaseHandle();
   }
 
   return X_STATUS_SUCCESS;
@@ -991,7 +991,7 @@ object_ref<XThread> XThread::Restore(KernelState* kernel_state,
     context->vscr_sat = state.context.vscr_sat;
 
     // Always retain when starting - the thread owns itself until exited.
-    thread->Retain();
+    thread->RetainHandle();
 
     xe::threading::Thread::CreationParameters params;
     params.create_suspended = true;  // Not done restoring yet.
@@ -1033,7 +1033,7 @@ object_ref<XThread> XThread::Restore(KernelState* kernel_state,
       xe::Profiler::ThreadExit();
 
       // Release the self-reference to the thread.
-      thread->Release();
+      thread->ReleaseHandle();
     });
 
     // Notify processor we were recreated.


### PR DESCRIPTION
This PR consists of three parts:

1) The first commit adds some useful assertions which I used to debug issues fixed in later commits.
2) Second commit stops `ExCreateThread` from retaining the handle. Despite the comment from 64b2be92d64361c437c6ba1de6f82296200be75b, I believe this handle should **not** be retained, as the thread is supposed to be freed once it finishes executing **and** it's handle is closed. Since every `XObject` contains a handle to itself on creation, retaining the handle further on creation would result in always having this one handle linger, and thus not freeing thread objects.

I have not extensively tested this but I've noticed threads started being properly deleted after intro videos in Forza Horizon 2. According to @Gliniak, numerous lingering threads in Lost Odyssey now close properly too.

3) The last commit changes logic of `ObXXX` functions to retain and release handles. This ties down to 2) and the case there `ExCreateThread` was created with `creation_flags & 0x80`, which results in returning a guest pointer and not a handle. To describe the problem, consider a typical scenario how games seem to use threads created with this flag (pay attention to bolded parts):
- Thread gets created. **Handle to thread gets created and stored internally.** Returned guest pointer gets saved.
- Guest pointer gets used to eg. modify thread priorities.
- Thread gets unpaused.
- Code waits for thread to finish.
- Code releases reference to the thread by calling `ObDereferenceObject`. This releases reference to the thread, releasing it. **Internal thread's handle does not get freed.**

As a result, this handle lingers making the game prone to crashing any time it gets used - for example, when pausing all threads to show a guest crash prompt!

My change makes the code operate on handles instead, so `ObDereferenceObject` releases it gracefully. For cases where `ObDereferenceObject` is used to release a pointer created by `ObReferenceObjectByHandle` or related, retaining the handle and not `XObject` allows to keep the symmetry of those actions and seems to be handled gracefully as well.