### PR TITLE
[imgui] Update to latest upstream master.

### DIFF
--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -321,7 +321,7 @@ void DebugWindow::DrawSourcePane() {
   //   address start - end
   //   name text box (editable)
   //   combo for interleaved + [ppc, hir, opt hir, x64 + byte with sizes]
-  ImGui::AlignFirstTextHeightToWidgets();
+  ImGui::AlignTextToFramePadding();
   ImGui::Text("%s", function->module()->name().c_str());
   ImGui::SameLine();
   ImGui::Dummy(ImVec2(4, 0));
@@ -868,7 +868,7 @@ void DebugWindow::DrawRegistersPane() {
       }
       ImGui::BeginChild("##guest_general");
       ImGui::BeginGroup();
-      ImGui::AlignFirstTextHeightToWidgets();
+      ImGui::AlignTextToFramePadding();
       ImGui::Text(" lr");
       ImGui::SameLine();
       ImGui::Dummy(ImVec2(4, 0));
@@ -877,7 +877,7 @@ void DebugWindow::DrawRegistersPane() {
           DrawRegisterTextBox(100, &thread_info->guest_context.lr);
       ImGui::EndGroup();
       ImGui::BeginGroup();
-      ImGui::AlignFirstTextHeightToWidgets();
+      ImGui::AlignTextToFramePadding();
       ImGui::Text("ctr");
       ImGui::SameLine();
       ImGui::Dummy(ImVec2(4, 0));
@@ -891,7 +891,7 @@ void DebugWindow::DrawRegistersPane() {
       // VSCR
       for (int i = 0; i < 32; ++i) {
         ImGui::BeginGroup();
-        ImGui::AlignFirstTextHeightToWidgets();
+        ImGui::AlignTextToFramePadding();
         ImGui::Text(i < 10 ? " r%d" : "r%d", i);
         ImGui::SameLine();
         ImGui::Dummy(ImVec2(4, 0));
@@ -909,7 +909,7 @@ void DebugWindow::DrawRegistersPane() {
       ImGui::BeginChild("##guest_float");
       for (int i = 0; i < 32; ++i) {
         ImGui::BeginGroup();
-        ImGui::AlignFirstTextHeightToWidgets();
+        ImGui::AlignTextToFramePadding();
         ImGui::Text(i < 10 ? " f%d" : "f%d", i);
         ImGui::SameLine();
         ImGui::Dummy(ImVec2(4, 0));
@@ -927,7 +927,7 @@ void DebugWindow::DrawRegistersPane() {
       ImGui::BeginChild("##guest_vector");
       for (int i = 0; i < 128; ++i) {
         ImGui::BeginGroup();
-        ImGui::AlignFirstTextHeightToWidgets();
+        ImGui::AlignTextToFramePadding();
         ImGui::Text(i < 10 ? "  v%d" : (i < 100 ? " v%d" : "v%d"), i);
         ImGui::SameLine();
         ImGui::Dummy(ImVec2(4, 0));
@@ -943,7 +943,7 @@ void DebugWindow::DrawRegistersPane() {
       for (int i = 0; i < 18; ++i) {
         auto reg = static_cast<X64Register>(i);
         ImGui::BeginGroup();
-        ImGui::AlignFirstTextHeightToWidgets();
+        ImGui::AlignTextToFramePadding();
         ImGui::Text("%3s", X64Context::GetRegisterName(reg));
         ImGui::SameLine();
         ImGui::Dummy(ImVec2(4, 0));
@@ -968,7 +968,7 @@ void DebugWindow::DrawRegistersPane() {
         auto reg =
             static_cast<X64Register>(static_cast<int>(X64Register::kXmm0) + i);
         ImGui::BeginGroup();
-        ImGui::AlignFirstTextHeightToWidgets();
+        ImGui::AlignTextToFramePadding();
         ImGui::Text("%5s", X64Context::GetRegisterName(reg));
         ImGui::SameLine();
         ImGui::Dummy(ImVec2(4, 0));
@@ -1017,7 +1017,7 @@ void DebugWindow::DrawThreadsPane() {
     }
     ImGui::PushID(thread_info);
     if (is_current_thread) {
-      ImGui::SetNextTreeNodeOpened(true, ImGuiSetCond_Always);
+      ImGui::SetNextTreeNodeOpen(true, ImGuiCond_Always);
     }
     const char* state_label = "?";
     if (thread->can_debugger_suspend()) {
@@ -1037,8 +1037,9 @@ void DebugWindow::DrawThreadsPane() {
                   thread->is_guest_thread() ? "guest" : "host", state_label,
                   thread->thread_id(), thread->handle(),
                   thread->name().c_str());
-    if (ImGui::CollapsingHeader(thread_label, nullptr, true,
-                                is_current_thread)) {
+    if (ImGui::CollapsingHeader(
+            thread_label,
+            is_current_thread ? ImGuiTreeNodeFlags_DefaultOpen : 0)) {
       //   |     (log button) detail of kernel call categories
       // log button toggles only logging that thread
       ImGui::BulletText("Call Stack");
@@ -1133,7 +1134,7 @@ void DebugWindow::DrawBreakpointsPane() {
   if (ImGui::BeginPopup("##add_code_breakpoint")) {
     ++add_code_popup_render_count;
 
-    ImGui::AlignFirstTextHeightToWidgets();
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("PPC");
     ImGui::SameLine();
     ImGui::Dummy(ImVec2(2, 0));
@@ -1158,7 +1159,7 @@ void DebugWindow::DrawBreakpointsPane() {
     ImGui::PopItemWidth();
     ImGui::Dummy(ImVec2(0, 2));
 
-    ImGui::AlignFirstTextHeightToWidgets();
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("x64");
     ImGui::SameLine();
     ImGui::Dummy(ImVec2(2, 0));

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -140,7 +140,7 @@ void DebugWindow::DrawFrame() {
   float top_panes_height =
       ImGui::GetContentRegionAvail().y - bottom_panes_height;
   float log_pane_width =
-      ImGui::GetContentRegionAvailWidth() - breakpoints_pane_width;
+      ImGui::GetContentRegionAvail().x - breakpoints_pane_width;
 
   ImGui::BeginChild("##toolbar", ImVec2(0, 25), true);
   DrawToolbar();
@@ -237,11 +237,9 @@ void DebugWindow::DrawFrame() {
   ImGui::PopStyleVar();
 
   if (cvars::imgui_debug) {
-    ImGui::ShowTestWindow();
+    ImGui::ShowDemoWindow();
     ImGui::ShowMetricsWindow();
   }
-
-  ImGui::Render();
 
   // Continuous paint.
   window_->Invalidate();
@@ -340,7 +338,7 @@ void DebugWindow::DrawSourcePane() {
   ImGui::SameLine();
   char name[256];
   std::strcpy(name, function->name().c_str());
-  ImGui::PushItemWidth(ImGui::GetContentRegionAvailWidth() - 10);
+  ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 10);
   if (ImGui::InputText("##name", name, sizeof(name),
                        ImGuiInputTextFlags_AutoSelectAll)) {
     function->set_name(name);
@@ -623,7 +621,7 @@ void DebugWindow::DrawBreakpointGutterButton(
 void DebugWindow::ScrollToSourceIfPcChanged() {
   if (state_.has_changed_pc) {
     // TODO(benvanik): not so annoying scroll.
-    ImGui::SetScrollHere();
+    ImGui::SetScrollHereY(0.5f);
     state_.has_changed_pc = false;
   }
 }
@@ -1006,7 +1004,7 @@ void DebugWindow::DrawThreadsPane() {
       continue;
     }
     if (is_current_thread && state_.has_changed_thread) {
-      ImGui::SetScrollHere();
+      ImGui::SetScrollHereY(0.5f);
       state_.has_changed_thread = false;
     }
     if (!is_current_thread) {
@@ -1017,7 +1015,7 @@ void DebugWindow::DrawThreadsPane() {
     }
     ImGui::PushID(thread_info);
     if (is_current_thread) {
-      ImGui::SetNextTreeNodeOpen(true, ImGuiCond_Always);
+      ImGui::SetNextItemOpen(true, ImGuiCond_Always);
     }
     const char* state_label = "?";
     if (thread->can_debugger_suspend()) {

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -192,7 +192,7 @@ void TraceViewer::DrawMultilineString(const std::string& str) {
 }
 
 void TraceViewer::DrawUI() {
-  // ImGui::ShowTestWindow();
+  // ImGui::ShowDemoWindow();
 
   DrawControllerUI();
   DrawCommandListUI();
@@ -538,7 +538,7 @@ void TraceViewer::DrawCommandListUI() {
   }
   ImGui::PopID();
   if (did_seek && target_command == -1) {
-    ImGui::SetScrollHereY();
+    ImGui::SetScrollHereY(0.5f);
   }
 
   auto id = RecursiveDrawCommandBufferUI(frame, frame->command_tree.get());

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -201,8 +201,9 @@ void TraceViewer::DrawUI() {
 }
 
 void TraceViewer::DrawControllerUI() {
-  ImGui::SetNextWindowPos(ImVec2(5, 5), ImGuiSetCond_FirstUseEver);
-  if (!ImGui::Begin("Controller", nullptr, ImVec2(340, 60))) {
+  ImGui::SetNextWindowPos(ImVec2(5, 5), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(340, 60));
+  if (!ImGui::Begin("Controller", nullptr)) {
     ImGui::End();
     return;
   }
@@ -248,10 +249,11 @@ void TraceViewer::DrawControllerUI() {
 }
 
 void TraceViewer::DrawPacketDisassemblerUI() {
-  ImGui::SetNextWindowCollapsed(true, ImGuiSetCond_FirstUseEver);
+  ImGui::SetNextWindowCollapsed(true, ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowPos(ImVec2(float(window_->width()) - 500 - 5, 5),
-                          ImGuiSetCond_FirstUseEver);
-  if (!ImGui::Begin("Packet Disassembler", nullptr, ImVec2(500, 300))) {
+                          ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(500, 300));
+  if (!ImGui::Begin("Packet Disassembler", nullptr)) {
     ImGui::End();
     return;
   }
@@ -456,8 +458,9 @@ int TraceViewer::RecursiveDrawCommandBufferUI(
 }
 
 void TraceViewer::DrawCommandListUI() {
-  ImGui::SetNextWindowPos(ImVec2(5, 70), ImGuiSetCond_FirstUseEver);
-  if (!ImGui::Begin("Command List", nullptr, ImVec2(200, 640))) {
+  ImGui::SetNextWindowPos(ImVec2(5, 70), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(200, 640));
+  if (!ImGui::Begin("Command List", nullptr)) {
     ImGui::End();
     return;
   }
@@ -535,7 +538,7 @@ void TraceViewer::DrawCommandListUI() {
   }
   ImGui::PopID();
   if (did_seek && target_command == -1) {
-    ImGui::SetScrollPosHere();
+    ImGui::SetScrollHereY();
   }
 
   auto id = RecursiveDrawCommandBufferUI(frame, frame->command_tree.get());
@@ -1052,8 +1055,9 @@ void TraceViewer::DrawStateUI() {
   auto& regs = *graphics_system_->register_file();
 
   ImGui::SetNextWindowPos(ImVec2(float(window_->width()) - 500 - 5, 30),
-                          ImGuiSetCond_FirstUseEver);
-  if (!ImGui::Begin("State", nullptr, ImVec2(500, 680))) {
+                          ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(500, 680));
+  if (!ImGui::Begin("State", nullptr)) {
     ImGui::End();
     return;
   }
@@ -1330,7 +1334,8 @@ void TraceViewer::DrawStateUI() {
       ImGui::BulletText("Blend Color: (%.2f,%.2f,%.2f,%.2f)", blend_color.x,
                         blend_color.y, blend_color.z, blend_color.w);
       ImGui::SameLine();
-      ImGui::ColorButton(blend_color, true);
+      // TODO small_height (was true) parameter was removed
+      ImGui::ColorButton(nullptr, blend_color);
 
       uint32_t rb_color_mask = regs[XE_GPU_REG_RB_COLOR_MASK].u32;
       uint32_t color_info[4] = {

--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -34,21 +34,18 @@ ImGuiDrawer::ImGuiDrawer(xe::ui::Window* window)
 }
 
 ImGuiDrawer::~ImGuiDrawer() {
-  auto previous_state = ImGui::GetInternalState();
-  ImGui::SetInternalState(internal_state_.data());
-  ImGui::Shutdown();
-  if (previous_state != internal_state_.data()) {
-    ImGui::SetInternalState(previous_state);
+  if (internal_state_) {
+    ImGui::DestroyContext(internal_state_);
+    internal_state_ = nullptr;
   }
-
   current_drawer_ = nullptr;
 }
 
 void ImGuiDrawer::Initialize() {
   // Setup ImGui internal state.
   // This will give us state we can swap to the ImGui globals when in use.
-  internal_state_.resize(ImGui::GetInternalStateSize());
-  ImGui::SetInternalState(internal_state_.data(), true);
+  internal_state_ = ImGui::CreateContext();
+
   current_drawer_ = this;
 
   auto& io = ImGui::GetIO();
@@ -66,7 +63,6 @@ void ImGuiDrawer::Initialize() {
 
   auto& style = ImGui::GetStyle();
   style.ScrollbarRounding = 0;
-  style.WindowFillAlphaDefault = 1.0f;
   style.WindowRounding = 0;
   style.Colors[ImGuiCol_Text] = ImVec4(0.89f, 0.90f, 0.90f, 1.00f);
   style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
@@ -87,7 +83,7 @@ void ImGuiDrawer::Initialize() {
       ImVec4(0.00f, 1.00f, 0.15f, 0.62f);
   style.Colors[ImGuiCol_ScrollbarGrabActive] =
       ImVec4(0.00f, 0.91f, 0.09f, 0.40f);
-  style.Colors[ImGuiCol_ComboBg] = ImVec4(0.20f, 0.20f, 0.20f, 0.99f);
+  style.Colors[ImGuiCol_PopupBg] = ImVec4(0.20f, 0.20f, 0.20f, 0.99f);
   style.Colors[ImGuiCol_CheckMark] = ImVec4(0.74f, 0.90f, 0.72f, 0.50f);
   style.Colors[ImGuiCol_SliderGrab] = ImVec4(1.00f, 1.00f, 1.00f, 0.30f);
   style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.34f, 0.75f, 0.11f, 1.00f);
@@ -97,23 +93,18 @@ void ImGuiDrawer::Initialize() {
   style.Colors[ImGuiCol_Header] = ImVec4(0.00f, 0.40f, 0.00f, 0.71f);
   style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.00f, 0.60f, 0.26f, 0.80f);
   style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.00f, 0.75f, 0.00f, 0.80f);
-  style.Colors[ImGuiCol_Column] = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
-  style.Colors[ImGuiCol_ColumnHovered] = ImVec4(0.36f, 0.89f, 0.38f, 1.00f);
-  style.Colors[ImGuiCol_ColumnActive] = ImVec4(0.13f, 0.50f, 0.11f, 1.00f);
+  style.Colors[ImGuiCol_Separator] = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+  style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.36f, 0.89f, 0.38f, 1.00f);
+  style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.13f, 0.50f, 0.11f, 1.00f);
   style.Colors[ImGuiCol_ResizeGrip] = ImVec4(1.00f, 1.00f, 1.00f, 0.30f);
   style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(1.00f, 1.00f, 1.00f, 0.60f);
   style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(1.00f, 1.00f, 1.00f, 0.90f);
-  style.Colors[ImGuiCol_CloseButton] = ImVec4(0.00f, 0.72f, 0.00f, 0.96f);
-  style.Colors[ImGuiCol_CloseButtonHovered] =
-      ImVec4(0.38f, 1.00f, 0.42f, 0.60f);
-  style.Colors[ImGuiCol_CloseButtonActive] = ImVec4(0.56f, 1.00f, 0.64f, 1.00f);
   style.Colors[ImGuiCol_PlotLines] = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
   style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
   style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
   style.Colors[ImGuiCol_PlotHistogramHovered] =
       ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
   style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.00f, 1.00f, 0.00f, 0.21f);
-  style.Colors[ImGuiCol_TooltipBg] = ImVec4(0.05f, 0.05f, 0.10f, 0.90f);
   style.Colors[ImGuiCol_ModalWindowDarkening] =
       ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
 
@@ -231,7 +222,7 @@ void ImGuiDrawer::RenderDrawLists(ImDrawData* data) {
 
 ImGuiIO& ImGuiDrawer::GetIO() {
   current_drawer_ = this;
-  ImGui::SetInternalState(internal_state_.data());
+  ImGui::SetCurrentContext(internal_state_);
   return ImGui::GetIO();
 }
 

--- a/src/xenia/ui/imgui_drawer.h
+++ b/src/xenia/ui/imgui_drawer.h
@@ -18,6 +18,7 @@
 
 struct ImDrawData;
 struct ImFontAtlas;
+struct ImGuiContext;
 struct ImGuiIO;
 
 namespace xe {
@@ -56,7 +57,7 @@ class ImGuiDrawer : public WindowListener {
   Window* window_ = nullptr;
   GraphicsContext* graphics_context_ = nullptr;
 
-  std::vector<uint8_t> internal_state_;
+  ImGuiContext* internal_state_ = nullptr;
   std::unique_ptr<ImFontAtlas> font_atlas_;
   std::unique_ptr<ImmediateTexture> font_texture_;
 };

--- a/src/xenia/ui/imgui_drawer.h
+++ b/src/xenia/ui/imgui_drawer.h
@@ -17,7 +17,6 @@
 #include "xenia/ui/window_listener.h"
 
 struct ImDrawData;
-struct ImFontAtlas;
 struct ImGuiContext;
 struct ImGuiIO;
 
@@ -35,6 +34,7 @@ class ImGuiDrawer : public WindowListener {
   void SetupDefaultInput() {}
 
   ImGuiIO& GetIO();
+  void RenderDrawLists();
 
   static const uint64_t kIgnoreAlpha = (1ull << 63);
 
@@ -58,7 +58,6 @@ class ImGuiDrawer : public WindowListener {
   GraphicsContext* graphics_context_ = nullptr;
 
   ImGuiContext* internal_state_ = nullptr;
-  std::unique_ptr<ImFontAtlas> font_atlas_;
   std::unique_ptr<ImmediateTexture> font_texture_;
 };
 

--- a/src/xenia/ui/window.cc
+++ b/src/xenia/ui/window.cc
@@ -210,6 +210,7 @@ void Window::OnPaint(UIEvent* e) {
 
   // Flush ImGui buffers before we swap.
   ImGui::Render();
+  imgui_drawer_->RenderDrawLists();
 
   ForEachListener([e](auto listener) { listener->OnPainted(e); });
   on_painted(e);

--- a/src/xenia/ui/window_demo.cc
+++ b/src/xenia/ui/window_demo.cc
@@ -102,7 +102,7 @@ int window_demo_main(const std::vector<std::wstring>& args) {
   window->on_painting.AddListener([&](xe::ui::UIEvent* e) {
     auto& io = window->imgui_drawer()->GetIO();
 
-    ImGui::ShowTestWindow();
+    ImGui::ShowDemoWindow();
     ImGui::ShowMetricsWindow();
 
     // Continuous paint.

--- a/third_party/imgui.lua
+++ b/third_party/imgui.lua
@@ -18,9 +18,10 @@ project("imgui")
     "imgui/imgui_draw.cpp",
     "imgui/imgui_demo.cpp",
     "imgui/imgui_internal.h",
-    "imgui/stb_rect_pack.h",
-    "imgui/stb_textedit.h",
-    "imgui/stb_truetype.h",
+    "imgui/imgui_widgets.cpp",
+    "imgui/imstb_rectpack.h",
+    "imgui/imstb_textedit.h",
+    "imgui/imstb_truetype.h",
   })
 
   filter("platforms:Windows")


### PR DESCRIPTION
- Submodule is updated.
- All removed APIs are replaced.
- All APIs that have been deprecated are replaced.
- Biggest code changes are that ownership of the font atlas is now handled by imgui itself (xenia could do it as well but there is no benefit in that) and how the draw lists are processed (they are now processed once by the window class after all painting callbacks are returned because the old imgui callback mechanism is deprecated)

I tested this with the hid and ui demo, the profiler and guest debugger.
I didn't test trace viewers, please report if you find any regressions.