### PR TITLE
[UI] Disable saving of imgui INI file.

### DIFF
--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -45,6 +45,11 @@ void ImGuiDrawer::Initialize() {
 
   auto& io = ImGui::GetIO();
 
+  // TODO(gibbed): disable imgui.ini saving for now,
+  // imgui assumes paths are char* so we can't throw a good path at it on
+  // Windows.
+  io.IniFilename = nullptr;
+
   SetupFont();
 
   io.DeltaTime = 1.0f / 60.0f;


### PR DESCRIPTION
By default imgui saves an INI file named `imgui.ini` to the current directory, which is undesired behavior.
Until we can properly specify a full path to a good location, disable saving of the INI file.