### PR TITLE
[UI] Fix misc imgui things.

### DIFF
--- a/src/xenia/ui/window.cc
+++ b/src/xenia/ui/window.cc
@@ -199,13 +199,14 @@ void Window::OnPaint(UIEvent* e) {
   }
   io.DisplaySize = ImVec2(static_cast<float>(scaled_width()),
                           static_cast<float>(scaled_height()));
-  ImGui::NewFrame();
 
   context_->BeginSwap();
   if (context_->WasLost()) {
     on_context_lost(e);
     return;
   }
+
+  ImGui::NewFrame();
 
   ForEachListener([e](auto listener) { listener->OnPainting(e); });
   on_painting(e);

--- a/src/xenia/ui/window.cc
+++ b/src/xenia/ui/window.cc
@@ -173,12 +173,15 @@ void Window::OnPaint(UIEvent* e) {
 
   ++frame_count_;
   ++fps_frame_count_;
-  uint64_t now_ns = xe::Clock::QueryHostSystemTime();
-  if (now_ns > fps_update_time_ns_ + 1000 * 10000) {
+  static auto tick_frequency = Clock::QueryHostTickFrequency();
+  auto now_ticks = Clock::QueryHostTickCount();
+  // Average fps over 1 second.
+  if (now_ticks > fps_update_time_ticks_ + tick_frequency * 1) {
     fps_ = static_cast<uint32_t>(
         fps_frame_count_ /
-        (static_cast<double>(now_ns - fps_update_time_ns_) / 10000000.0));
-    fps_update_time_ns_ = now_ns;
+        (static_cast<double>(now_ticks - fps_update_time_ticks_) /
+         tick_frequency));
+    fps_update_time_ticks_ = now_ticks;
     fps_frame_count_ = 0;
   }
 
@@ -186,12 +189,13 @@ void Window::OnPaint(UIEvent* e) {
 
   // Prepare ImGui for use this frame.
   auto& io = imgui_drawer_->GetIO();
-  if (!last_paint_time_ns_) {
+  if (!last_paint_time_ticks_) {
     io.DeltaTime = 0.0f;
-    last_paint_time_ns_ = now_ns;
+    last_paint_time_ticks_ = now_ticks;
   } else {
-    io.DeltaTime = (now_ns - last_paint_time_ns_) / 10000000.0f;
-    last_paint_time_ns_ = now_ns;
+    io.DeltaTime = (now_ticks - last_paint_time_ticks_) /
+                   static_cast<float>(tick_frequency);
+    last_paint_time_ticks_ = now_ticks;
   }
   io.DisplaySize = ImVec2(static_cast<float>(scaled_width()),
                           static_cast<float>(scaled_height()));

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -180,9 +180,9 @@ class Window {
 
   uint32_t frame_count_ = 0;
   uint32_t fps_ = 0;
-  uint64_t fps_update_time_ns_ = 0;
+  uint64_t fps_update_time_ticks_ = 0;
   uint64_t fps_frame_count_ = 0;
-  uint64_t last_paint_time_ns_ = 0;
+  uint64_t last_paint_time_ticks_ = 0;
 
   bool modifier_shift_pressed_ = false;
   bool modifier_cntrl_pressed_ = false;


### PR DESCRIPTION
### Fixes these issues which mainly affect developers debugging:
- Because frame time is calculated based on `GetSystemTimeAsFileTime()` a time delta of zero is possible (Value is 100ns resolution but apparently not updated at that rate by the system).
![image](https://user-images.githubusercontent.com/5020972/69920351-42147980-1487-11ea-8c8a-baed3fe66990.png)
- A new imgui frame is created before it is verified the context isn't lost.
![image](https://user-images.githubusercontent.com/5020972/69920390-ac2d1e80-1487-11ea-9952-bb8efa9d48f7.png)
