### PR TITLE
[CPU] Implemented instructions: rldclx, rldcrx

### DIFF
--- a/src/xenia/cpu/ppc/ppc_emit_alu.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_alu.cc
@@ -858,13 +858,53 @@ int InstrEmit_xoris(PPCHIRBuilder& f, const InstrData& i) {
 // Integer rotate (A-6)
 
 int InstrEmit_rldclx(PPCHIRBuilder& f, const InstrData& i) {
-  XEINSTRNOTIMPLEMENTED();
-  return 1;
+  // n <- rB[58:63]
+  // r <- ROTL[64](rS, n)
+  // b <- mb[5] || mb[0:4]
+  // m <- MASK(b, 63)
+  // rA <- r & m
+  Value* n = f.And(f.Truncate(f.LoadGPR(i.MDS.RB), INT8_TYPE),
+                   f.LoadConstantInt8(0x3F));
+
+  uint32_t mb = (i.MDS.MB5 << 5) | i.MDS.MB;
+  uint64_t m = XEMASK(mb, 63);
+  Value* v = f.LoadGPR(i.MDS.RT);
+
+  v = f.RotateLeft(v, n);
+  if (m != 0xFFFFFFFFFFFFFFFF) {
+    v = f.And(v, f.LoadConstantUint64(m));
+  }
+
+  f.StoreGPR(i.MDS.RA, v);
+  if (i.MDS.Rc) {
+    f.UpdateCR(0, v);
+  }
+  return 0;
 }
 
 int InstrEmit_rldcrx(PPCHIRBuilder& f, const InstrData& i) {
-  XEINSTRNOTIMPLEMENTED();
-  return 1;
+  // n <- rB[58:63]
+  // r <- ROTL[64](rS, n)
+  // b <- mb[5] || mb[0:4]
+  // m <- MASK(0, b)
+  // rA <- r & m
+  Value* n = f.And(f.Truncate(f.LoadGPR(i.MDS.RB), INT8_TYPE),
+                   f.LoadConstantInt8(0x3F));
+
+  uint32_t mb = (i.MDS.MB5 << 5) | i.MDS.MB;
+  uint64_t m = XEMASK(0, mb);
+  Value* v = f.LoadGPR(i.MDS.RT);
+
+  v = f.RotateLeft(v, n);
+  if (m != 0xFFFFFFFFFFFFFFFF) {
+    v = f.And(v, f.LoadConstantUint64(m));
+  }
+
+  f.StoreGPR(i.MDS.RA, v);
+  if (i.MDS.Rc) {
+    f.UpdateCR(0, v);
+  }
+  return 0;
 }
 
 int InstrEmit_rldicx(PPCHIRBuilder& f, const InstrData& i) {


### PR DESCRIPTION
These opcodes are barely used. I implemented them, by looking at different, but similar instructions and merged what I needed.

If required I might split this commit in two. (commit per instruction)

**Disclaimer:** I cannot provide tests for them as I cannot check them on console.
FYI: other opcodes from this "group" don't have tests

**Usage:**
Only known titles that uses them are _Telltale_ games to decompress data.

Impact:
It makes _Telltale Batman_ startable and probably also few other _Telltale_ titles

![image](https://user-images.githubusercontent.com/153369/73677959-a508d380-46b7-11ea-8a06-54da314cb55f.png)



There is also Borat for your commitment
![image](https://user-images.githubusercontent.com/153369/73679184-37aa7200-46ba-11ea-8a93-f7b9bc601403.png)

# Resources
[Power ISA v3.0B](https://openpowerfoundation.org/?resource_lib=power-isa-version-3-0)