### PR TITLE
[CPU] Increased maximum function count

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_code_cache.h
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.h
@@ -82,7 +82,7 @@ class X64CodeCache : public CodeCache {
   // This is picked to be high enough to cover whatever we can reasonably
   // expect. If we hit issues with this it probably means some corner case
   // in analysis triggering.
-  static const size_t kMaximumFunctionCount = 50000;
+  static const size_t kMaximumFunctionCount = 100000;
 
   struct UnwindReservation {
     size_t data_size = 0;


### PR DESCRIPTION
Few games have function count higher than 50k.
Ghidra and IDA reports the same number of functions.

Confirmed titles: _Watch Dogs_, _Far Cry 3_

Benefits: It allows FC3 go a little bit further, but still crashes.

Screen from IDA (FC3): https://media.discordapp.net/attachments/440280035056943104/675094290426494984/unknown.png
