### PR TITLE
[Kernel] Ignore page size with base address allocations.

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
@@ -96,10 +96,17 @@ dword_result_t NtAllocateVirtualMemory(lpdword_t base_addr_ptr,
     XELOGW("Game setting EXECUTE bit on allocation");
   }
 
-  // Adjust size.
-  uint32_t page_size = 4096;
-  if (alloc_type & X_MEM_LARGE_PAGES) {
-    page_size = 64 * 1024;
+  uint32_t page_size;
+  if (*base_addr_ptr != 0) {
+    // ignore specified page size when base address is specified.
+    auto heap = kernel_memory()->LookupHeap(*base_addr_ptr);
+    page_size = heap->page_size();
+  } else {
+    // Adjust size.
+    page_size = 4 * 1024;
+    if (alloc_type & X_MEM_LARGE_PAGES) {
+      page_size = 64 * 1024;
+    }
   }
 
   // Round the base address down to the nearest page boundary.


### PR DESCRIPTION
Changes `NtAllocateVirtualMemory` so that it ignores specified page size when a base address is specified.

Fixes a crash seen in N3 demo boot.