### PR TITLE
Syscall rework.

### DIFF
--- a/src/xenia/cpu/ppc/ppc_decode_data.h
+++ b/src/xenia/cpu/ppc/ppc_decode_data.h
@@ -42,7 +42,20 @@ static inline uint64_t XEMASK(uint32_t mstart, uint32_t mstop) {
 }
 
 struct PPCDecodeData {
-  struct FormatSC {};
+  struct FormatSC {
+    uint32_t LEV() const { return bits_.LEV; }
+
+   private:
+    uint32_t address_;
+    union {
+      uint32_t value_;
+      struct {
+        uint32_t : 5;
+        uint32_t LEV : 7;
+        uint32_t : 20;
+      } bits_;
+    };
+  };
   struct FormatD {
     uint32_t RT() const { return bits_.RT; }
     uint32_t RD() const { return RT(); }

--- a/src/xenia/cpu/ppc/ppc_emit_control.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_control.cc
@@ -423,8 +423,15 @@ int InstrEmit_mcrf(PPCHIRBuilder& f, const InstrData& i) {
 // System linkage (A-24)
 
 int InstrEmit_sc(PPCHIRBuilder& f, const InstrData& i) {
-  f.CallExtern(f.function());
-  return 0;
+  // Game code should only ever use LEV=0.
+  // LEV=2 is to signify 'call import' from Xenia.
+  // TODO(gibbed): syscalls!
+  if (i.SC.LEV == 2) {
+    f.CallExtern(f.function());
+    return 0;
+  }
+  XEINSTRNOTIMPLEMENTED();
+  return 1;
 }
 
 // Trap (A-25)

--- a/src/xenia/cpu/ppc/ppc_instr.h
+++ b/src/xenia/cpu/ppc/ppc_instr.h
@@ -49,6 +49,11 @@ struct InstrData {
     } B;
 
     // kXEPPCInstrFormatSC
+    struct {
+      uint32_t : 5;
+      uint32_t LEV : 7;
+      uint32_t : 20;
+    } SC;
     // kXEPPCInstrFormatD
     struct {
       uint32_t DS : 16;

--- a/src/xenia/cpu/ppc/ppc_opcode_disasm_gen.cc
+++ b/src/xenia/cpu/ppc/ppc_opcode_disasm_gen.cc
@@ -1977,10 +1977,11 @@ void PrintDisasm_rlwnmx(const PPCDecodeData& d, StringBuffer* str) {
   str->AppendFormat("%d", d.M.ME());
 }
 void PrintDisasm_sc(const PPCDecodeData& d, StringBuffer* str) {
-  // sc
+  // sc [LEV]
   size_t str_start = str->length();
   str->Append("sc");
   PadStringBuffer(str, str_start, kNamePad);
+  if (d.SC.LEV()) str->AppendFormat("%d", d.SC.LEV());
 }
 void PrintDisasm_sldx(const PPCDecodeData& d, StringBuffer* str) {
   // sld[Rc] [RA], [RS], [RB]
@@ -5131,7 +5132,7 @@ PPCOpcodeDisasmInfo ppc_opcode_disasm_table[] = {
   INSTRUCTION(0x50000000, "rlwimix"     , kM      , kI, kGeneral, "Rotate Left Word Immediate then Mask Insert"                                , (PPCOpcodeField::kRS,PPCOpcodeField::kSH,PPCOpcodeField::kMB,PPCOpcodeField::kME), (PPCOpcodeField::kRA,PPCOpcodeField::kCRcond), PrintDisasm_rlwimix),
   INSTRUCTION(0x54000000, "rlwinmx"     , kM      , kI, kGeneral, "Rotate Left Word Immediate then AND with Mask"                              , (PPCOpcodeField::kRS,PPCOpcodeField::kSH,PPCOpcodeField::kMB,PPCOpcodeField::kME), (PPCOpcodeField::kRA,PPCOpcodeField::kCRcond), PrintDisasm_rlwinmx),
   INSTRUCTION(0x5c000000, "rlwnmx"      , kM      , kI, kGeneral, "Rotate Left Word then AND with Mask"                                        , (PPCOpcodeField::kRS,PPCOpcodeField::kRB,PPCOpcodeField::kMB,PPCOpcodeField::kME), (PPCOpcodeField::kRA,PPCOpcodeField::kCRcond), PrintDisasm_rlwnmx),
-  INSTRUCTION(0x44000002, "sc"          , kSC     , kB, kSync   , "System Call"                                                                , (), (), PrintDisasm_sc),
+  INSTRUCTION(0x44000002, "sc"          , kSC     , kB, kSync   , "System Call"                                                                , (PPCOpcodeField::kLEV), (), PrintDisasm_sc),
   INSTRUCTION(0x7c000036, "sldx"        , kX      , kI, kGeneral, "Shift Left Doubleword"                                                      , (PPCOpcodeField::kRS,PPCOpcodeField::kRB), (PPCOpcodeField::kRA,PPCOpcodeField::kCRcond), PrintDisasm_sldx),
   INSTRUCTION(0x7c000030, "slwx"        , kX      , kI, kGeneral, "Shift Left Word"                                                            , (PPCOpcodeField::kRS,PPCOpcodeField::kRB), (PPCOpcodeField::kRA,PPCOpcodeField::kCRcond), PrintDisasm_slwx),
   INSTRUCTION(0x7c000674, "sradix"      , kXS     , kI, kGeneral, "Shift Right Algebraic Doubleword Immediate"                                 , (PPCOpcodeField::kRS,PPCOpcodeField::kSH), (PPCOpcodeField::kRA,PPCOpcodeField::kCRcond,PPCOpcodeField::kCA), PrintDisasm_sradix),

--- a/src/xenia/cpu/ppc/ppc_opcode_info.h
+++ b/src/xenia/cpu/ppc/ppc_opcode_info.h
@@ -131,6 +131,7 @@ enum class PPCOpcodeField : uint32_t {
   kME,
   kMB,
   kTO,
+  kLEV,
 };
 
 struct PPCOpcodeDisasmInfo {

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -1225,15 +1225,17 @@ bool XexModule::SetupLibraryImports(const char* name,
         //     bctr
         // Real consoles rewrite this with some code that sets r11.
         // If we did that we'd still have to put a thunk somewhere and do the
-        // dynamic lookup. Instead, we rewrite it to use syscalls, as they
-        // aren't used on the 360. CPU backends can either take the syscall
-        // or do something smarter.
-        //     sc
+        // dynamic lookup. Instead, we rewrite it to use syscalls.
+        // We use sc with a LEV operand of 2, which is reserved usage and
+        // should never see actual usage outside of our rewrite.
+        // CPU backends can either take the special form syscall or do
+        // something smarter.
+        //     sc 2
         //     blr
         //     nop
         //     nop
         uint8_t* p = memory()->TranslateVirtual(record_addr);
-        xe::store_and_swap<uint32_t>(p + 0x0, 0x44000002);
+        xe::store_and_swap<uint32_t>(p + 0x0, 0x44000042);
         xe::store_and_swap<uint32_t>(p + 0x4, 0x4E800020);
         xe::store_and_swap<uint32_t>(p + 0x8, 0x60000000);
         xe::store_and_swap<uint32_t>(p + 0xC, 0x60000000);

--- a/tools/ppc-instructions.xml
+++ b/tools/ppc-instructions.xml
@@ -1083,7 +1083,8 @@
     <disasm>rlwnm[Rc] [RA], [RS], [RB], [MB], [ME]</disasm>
   </insn>
   <insn mnem="sc"           opcode="44000002" form="SC"       group="b" desc="System Call" sync="true">
-    <disasm>sc</disasm>
+    <in field="LEV" />
+    <disasm>sc [LEV]</disasm>
   </insn>
   <insn mnem="sldx"         opcode="7c000036" form="X"        group="i" desc="Shift Left Doubleword">
     <in field="RS" />

--- a/tools/ppc-table-gen
+++ b/tools/ppc-table-gen
@@ -270,6 +270,8 @@ def generate_token_append(i, token):
     return 'str->AppendFormat(d.%s.%s() < 0 ? "-0x%%X" : "0x%%X", std::abs(d.%s.%s()));' % (i.o_form, token, i.o_form, token)
   elif token == 'ADDR':
     return 'str->AppendFormat("0x%%X", d.%s.%s());' % (i.o_form, token)
+  elif token == 'LEV':
+    return 'if (d.%s.%s()) str->AppendFormat("%%d", d.%s.%s());' % (i.o_form, token, i.o_form, token)
   return 'str->AppendFormat("(UNHANDLED %s)");' % token
 
 


### PR DESCRIPTION
This adjusts Xenia's internal usage of the syscall instruction (`sc`) to use a reserved form, so that when some titles— Xbox 1 emulation, XNA, Internet Explorer, etc (notably all from Microsoft) that actually use the syscall instruction will be picked up properly instead of being mistaken for Xenia's usage of syscalls.

This will allow us to lay in the groundwork to eventually have proper syscall handling.