### PR TITLE
[XAM/Network] Implemented NetDll___WSAFDIsSet

### DIFF
--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -941,6 +941,17 @@ dword_result_t NetDll_sendto(dword_t caller, dword_t socket_handle,
 }
 DECLARE_XAM_EXPORT1(NetDll_sendto, kNetworking, kImplemented);
 
+dword_result_t NetDll___WSAFDIsSet(dword_t socket_handle,
+                                   pointer_t<x_fd_set> fd_set) {
+  for (uint32_t i = 0; i < fd_set->fd_count.value; i++) {
+    if (fd_set->fd_array[i] == socket_handle) {
+      return 1;
+    }
+  }
+  return 0;
+}
+DECLARE_XAM_EXPORT1(NetDll___WSAFDIsSet, kNetworking, kImplemented);
+
 void RegisterNetExports(xe::cpu::ExportResolver* export_resolver,
                         KernelState* kernel_state) {
   SHIM_SET_MAPPING("xam.xex", NetDll_XNetQosServiceLookup, state);


### PR DESCRIPTION
### Overview

This is based on description from [this site](https://www.intervalzero.com/library/RTX/WebHelp/Content/PROJECTS/SDK%20Reference/WinsockRef/WSAFDIsSet.htm) as Microsoft don't provide information about return value.

~~I marked it as _Sketchy_. Documentation says that it returns integer when socket was found in _fd_set_, but it does not specifies what value (is it 1 or provided socket).~~

Update: Thanks RedMadKnight for providing info about returned value


### Benefits:
_Renegade Ops_ goes ingame
_Test Drive Unlimited 2_ might go further
