### PR TITLE
[XB] Fix python not expecting UTF-8 for the output of vswhere

### DIFF
--- a/xenia-build
+++ b/xenia-build
@@ -96,7 +96,7 @@ def import_vs_environment():
     install_path = None
     env_tool_args = None
 
-    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -prerelease -format json -utf8', shell=False, universal_newlines=True)
+    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -prerelease -format json -utf8', shell=False, universal_newlines=True, encoding="utf-8")
     if vswhere:
         vswhere = json.loads(vswhere)
     if vswhere and len(vswhere) > 0:


### PR DESCRIPTION
On some languages of Windows (mine is Japanese), python will expect the default text encoding to be the system encoding. This does not work when parsing the output of vswhere set to output in UTF-8 when the system encoding is not UTF-8.

Fixes #1479 