### PR TITLE
[Kernel] format_core string formatting fixes

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
@@ -727,7 +727,7 @@ class StringFormatData : public FormatData {
 
   void skip(int32_t count) {
     while (count-- > 0) {
-      if (!*input_) {
+      if (!get()) {
         break;
       }
     }
@@ -760,11 +760,11 @@ class WideStringFormatData : public FormatData {
     return xe::byte_swap(result);
   }
 
-  uint16_t peek(int32_t offset) { return input_[offset]; }
+  uint16_t peek(int32_t offset) { return xe::byte_swap(input_[offset]); }
 
   void skip(int32_t count) {
     while (count-- > 0) {
-      if (!*input_) {
+      if (!get()) {
         break;
       }
     }
@@ -794,11 +794,11 @@ class WideCountFormatData : public FormatData {
     return xe::byte_swap(result);
   }
 
-  uint16_t peek(int32_t offset) { return input_[offset]; }
+  uint16_t peek(int32_t offset) { return xe::byte_swap(input_[offset]); }
 
   void skip(int32_t count) {
     while (count-- > 0) {
-      if (!*input_) {
+      if (!get()) {
         break;
       }
     }

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
@@ -49,6 +49,7 @@ enum FormatFlags {
   FF_IsWide = 1 << 9,
   FF_IsSigned = 1 << 10,
   FF_ForceLeadingZero = 1 << 11,
+  FF_InvertWide = 1 << 12,
 };
 
 enum ArgumentSize {
@@ -316,16 +317,14 @@ int32_t format_core(PPCContext* ppc_context, FormatData& data, ArgList& args,
         // wide character
         switch (c) {
           case 'C': {
-            if (!(flags & (FF_IsShort | FF_IsLong | FF_IsWide))) {
-              flags |= FF_IsWide;
-            }
+            flags |= FF_InvertWide;
             // fall through
           }
 
           // character
           case 'c': {
             bool is_wide;
-            if (flags & FF_IsLong) {
+            if (flags & (FF_IsLong | FF_IsWide)) {
               // "An lc, lC, wc or wC type specifier is synonymous with C in
               // printf functions and with c in wprintf functions."
               is_wide = true;
@@ -334,7 +333,7 @@ int32_t format_core(PPCContext* ppc_context, FormatData& data, ArgList& args,
               // functions and with C in wprintf functions."
               is_wide = false;
             } else {
-              is_wide = ((flags & FF_IsWide) != 0) ^ wide;
+              is_wide = ((flags & FF_InvertWide) != 0) ^ wide;
             }
 
             auto value = args.get32();
@@ -521,9 +520,7 @@ int32_t format_core(PPCContext* ppc_context, FormatData& data, ArgList& args,
 
           // wide string
           case 'S': {
-            if (!(flags & (FF_IsShort | FF_IsLong | FF_IsWide))) {
-              flags |= FF_IsWide;
-            }
+            flags |= FF_InvertWide;
             // fall through
           }
 
@@ -540,7 +537,7 @@ int32_t format_core(PPCContext* ppc_context, FormatData& data, ArgList& args,
             } else {
               void* str = SHIM_MEM_ADDR(pointer);
               bool is_wide;
-              if (flags & FF_IsLong) {
+              if (flags & (FF_IsLong | FF_IsWide)) {
                 // "An ls, lS, ws or wS type specifier is synonymous with S in
                 // printf functions and with s in wprintf functions."
                 is_wide = true;
@@ -549,7 +546,7 @@ int32_t format_core(PPCContext* ppc_context, FormatData& data, ArgList& args,
                 // functions and with S in wprintf functions."
                 is_wide = false;
               } else {
-                is_wide = ((flags & (FF_IsWide)) != 0) ^ wide;
+                is_wide = ((flags & FF_InvertWide) != 0) ^ wide;
               }
               int32_t length;
 


### PR DESCRIPTION
This PR fixes some issues with string formatting, which mainly effects the dashboard (preventing it from displaying any achievement icons), but I guess could maybe be ran into with some games too.

The first commit fixes the \*FormatData classes: previously the peek() method of these didn't return values in the same endian as get(), which would break code that tries reading from a wide-string using peek() (eg. format_core when it encounters %I), since the value read via peek() would be in the wrong endian.
I've just changed peek() so that it byte-swaps the return value if the get() method also byte-swapped it, and now format_core can read wide chars using peek() fine.

There was also an issue with the skip() method, where it didn't actually advance the input and would just keep checking the same value without actually skipping anything.
I've changed that to use get() instead, which should make it advance the pointer as well.

The second commit solves an issue with wide-string formatting that uses "ws".
Previously when format_core encounters a "ws" format-parameter, it'd treat the string for it as the opposite encoding of whatever the format string is.
(So an ASCII format string would treat the string as a wide-character string, while a wide format string would treat it as ASCII)

From how dashboard uses it this seems incorrect though: dash uses a wide-string containing "ws", and then also provides a wide-string for the value of it.
So it seems "ws" should mean that it's always pointing to a wide-string, instead of just being the opposite of the format strings encoding.
(For this fix I had to add a new string-formatting flag though, not sure if that was really the best way, but I couldn't see any easier solution for it.)

Canary has had these changes for the past month or so and hasn't ran into any problems, so I don't think these should cause any issues.