### PR TITLE
[CI] Add GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  push:
+    branches-ignore: gh-pages
+    paths-ignore:
+      - '.github/*'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'docs/**'
+      - '*.md'
+      - '*.yml'
+      - 'LICENSE'
+  pull_request:
+    branches-ignore: gh-pages
+    paths-ignore:
+      - '.github/*'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'docs/**'
+      - '*.md'
+      - '*.yml'
+      - 'LICENSE'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Release, Checked, Debug]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup
+      run: .\xb setup
+    - name: Build
+      run: .\xb build --config=${{ matrix.configuration }} --target=src\xenia-app --target=tests\xenia-base-tests --target=tests\xenia-cpu-ppc-tests --target=src\xenia-vfs-dump
+    - name: Tests
+      run: |
+        .\xb gentests
+        .\xb test --config=${{ matrix.configuration }} --no_build
+    - name: Prepare artifacts
+      run: |
+        robocopy . build\bin\${{ runner.os }}\${{ matrix.configuration }}                                                                LICENSE /r:0 /w:0
+        robocopy   build\bin\${{ runner.os }}\${{ matrix.configuration }} artifacts\xenia          xenia.exe          xenia.pdb          LICENSE /r:0 /w:0
+        robocopy   build\bin\${{ runner.os }}\${{ matrix.configuration }} artifacts\xenia-vfs-dump xenia-vfs-dump.exe xenia-vfs-dump.pdb LICENSE /r:0 /w:0
+        If ($LastExitCode -le 7) { echo "LastExitCode = $LastExitCode";$LastExitCode = 0 }
+    - name: Upload xenia-cpu-ppc-test log
+      uses: actions/upload-artifact@v2
+      with:
+        name: xenia-cpu-ppc-test log_${{ matrix.configuration }}
+        path: xenia-cpu-ppc-test.log
+    - name: Upload xenia-vfs-dump artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: xenia-vfs-dump_${{ matrix.configuration }}
+        path: artifacts\xenia-vfs-dump
+    - name: Upload xenia artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: xenia_${{ matrix.configuration }}
+        path: artifacts\xenia
+
+  build-linux:
+    runs-on: ubuntu-18.04
+    env:
+      LIBVULKAN_VERSION: 1.1.70
+      CC: clang-9
+      CXX: clang++-9
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Release, Checked, Debug]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
+        sudo apt-get update
+        sudo apt-get install -y clang-9 llvm-9-dev g++-8 python3 libc++-dev libc++abi-dev libgtk-3-dev libpthread-stubs0-dev libsdl2-dev libx11-dev liblz4-dev
+        $CXX --version
+        python3 --version
+        wget https://mirrors.kernel.org/ubuntu/pool/universe/v/vulkan/libvulkan1_$LIBVULKAN_VERSION+dfsg1-1_amd64.deb
+        wget https://mirrors.kernel.org/ubuntu/pool/universe/v/vulkan/libvulkan-dev_$LIBVULKAN_VERSION+dfsg1-1_amd64.deb
+        sudo dpkg -i libvulkan1_$LIBVULKAN_VERSION+dfsg1-1_amd64.deb libvulkan-dev_$LIBVULKAN_VERSION+dfsg1-1_amd64.deb
+        ./xenia-build setup
+    - name: Build
+      run: |
+        ./xenia-build build -j$(nproc) --config=${{ matrix.configuration }} --target=xenia-base-tests
+        ./build/bin/Linux/${{ matrix.configuration }}/xenia-base-tests
+        ./xenia-build build -j$(nproc) --config=${{ matrix.configuration }} --target=xenia-cpu-ppc-tests
+        ./xenia-build build -j$(nproc) --config=${{ matrix.configuration }}
+
+  lint:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
+        sudo apt-get update
+        sudo apt-get install -y clang-format-9
+        clang-format-9 --version
+        clang-format-9 -style=file -dump-config
+        ./xenia-build setup
+    - name: Lint
+      run: ./xenia-build lint --all

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Discussing illegal activities will get you banned.
 
 Buildbot | Status
 -------- | ------
-[Windows](https://ci.appveyor.com/project/benvanik/xenia/branch/master) | [![Build status](https://ci.appveyor.com/api/projects/status/ftqiy86kdfawyx3a/branch/master?svg=true)](https://ci.appveyor.com/project/benvanik/xenia/branch/master)
-[Linux](https://travis-ci.org/xenia-project/xenia) | [![Build status](https://travis-ci.org/xenia-project/xenia.svg?branch=master)](https://travis-ci.org/xenia-project/xenia)
+[Windows](https://ci.appveyor.com/project/benvanik/xenia/branch/master) | [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/ftqiy86kdfawyx3a/branch/master?svg=true)](https://ci.appveyor.com/project/benvanik/xenia/branch/master) [![GitHub Actions status](https://github.com/xenia-project/xenia/workflows/CI/badge.svg?branch=master)](https://github.com/xenia-project/xenia/actions?query=branch:master)
+[Linux](https://travis-ci.org/xenia-project/xenia) | [![Travis Build status](https://travis-ci.org/xenia-project/xenia.svg?branch=master)](https://travis-ci.org/xenia-project/xenia) [![GitHub Actions status](https://github.com/xenia-project/xenia/workflows/CI/badge.svg?branch=master)](https://github.com/xenia-project/xenia/actions?query=branch:master)
 
 Quite a few real games run. Quite a few don't.
 See the [Game compatibility list](https://github.com/xenia-project/game-compatibility/issues)


### PR DESCRIPTION
Example run: https://github.com/Margen67/xenia/actions/runs/106069905

This PR adds automatic Windows and Linux builds, and Linting via GitHub Actions, and adds a badge to README.md.

### Pros:
  * Builds multiple configurations at a time. Therefore, the Debug configuration can be added without additional building time.

### Cons:
  * Artifacts:
      * Doesn't have a direct link to latest artifacts.
        This is possible with releases, but is messy.
      * Can't use ~~wildcards~~/regex, or upload files without zipping them.
        As a consequence, checked builds cannot be passworded without being double-zipped.
        This is also why multiple robocopy commands have to be done instead of one 7z command.
  * Can't delete builds/runs.

---

tl;dr Add this because AppVeyor is slow.