### PR TITLE
Fix broken lock guard

### DIFF
--- a/src/xenia/gpu/vulkan/texture_cache.cc
+++ b/src/xenia/gpu/vulkan/texture_cache.cc
@@ -967,7 +967,7 @@ void TextureCache::FlushPendingCommands(VkCommandBuffer command_buffer,
         vkQueueSubmit(device_queue_, 1, &submit_info, completion_fence);
     CheckResult(status, "vkQueueSubmit");
   } else {
-    std::lock_guard<std::mutex>(device_->primary_queue_mutex());
+    std::lock_guard<std::mutex> lock(device_->primary_queue_mutex());
 
     auto status = vkQueueSubmit(device_->primary_queue(), 1, &submit_info,
                                 completion_fence);
@@ -1350,7 +1350,7 @@ void TextureCache::WritebackTexture(Texture* texture) {
   // Submit the command buffer.
   // Submit commands and wait.
   {
-    std::lock_guard<std::mutex>(device_->primary_queue_mutex());
+    std::lock_guard<std::mutex> lock(device_->primary_queue_mutex());
     VkSubmitInfo submit_info = {
         VK_STRUCTURE_TYPE_SUBMIT_INFO,
         nullptr,


### PR DESCRIPTION
This commit fixes a bug where the lock guard (for concurrently accessing
the same scope from different threads) had basically no effect, due to
being bound to a temporary only.