### PR TITLE
[xenia-build] Raise the minimum python version to 3.6

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -10,7 +10,7 @@ drivers.
 
 * Windows 7 or later
 * [Visual Studio 2019 or Visual Studio 2017](https://www.visualstudio.com/downloads/)
-* [Python 3.4+](https://www.python.org/downloads/)
+* [Python 3.6+](https://www.python.org/downloads/)
   * Ensure Python is in PATH.
 * Windows 10 SDK
 

--- a/xenia-build
+++ b/xenia-build
@@ -38,8 +38,8 @@ def main():
         sys.exit(1)
 
     # Check python version.
-    if not sys.version_info[:2] >= (3, 4):
-        print('ERROR: Python 3.4+ must be installed and on PATH')
+    if not sys.version_info[:2] >= (3, 6):
+        print('ERROR: Python 3.6+ must be installed and on PATH')
         sys.exit(1)
 
     # Grab Visual Studio version and execute shell to set up environment.


### PR DESCRIPTION
Xenia-build uses the "encoding" parameter of the subprocess module. This was introduced in Python 3.6.