### PR TITLE
[Kernel/XAM] XNotifyGetNext: Check for nullptr for param_ptr

### DIFF
--- a/src/xenia/kernel/xam/xam_notify.cc
+++ b/src/xenia/kernel/xam/xam_notify.cc
@@ -67,10 +67,14 @@ dword_result_t XNotifyGetNext(dword_t handle, dword_t match_id,
 
   if (dequeued) {
     *id_ptr = id;
-    *param_ptr = param;
+    if (param_ptr) {
+      *param_ptr = param;
+    }
   } else {
     *id_ptr = 0;
-    *param_ptr = 0;
+    if (param_ptr) {
+      *param_ptr = 0;
+    }
   }
 
   return dequeued ? 1 : 0;


### PR DESCRIPTION
Based on dissasembled **_Ghost Recon AW2 Demo_**
I attached fragment from IDA to have confirmation that such situation might occur.

IDA proof: 
![image](https://user-images.githubusercontent.com/153369/77259678-7f458700-6c83-11ea-9484-5c8ec1e45d82.png)