### PR TITLE
Make starting development on Linux easier.

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -10,7 +10,7 @@ drivers.
 
 * Windows 7 or later
 * [Visual Studio 2019 or Visual Studio 2017](https://www.visualstudio.com/downloads/)
-* [Python 3.4+](https://www.python.org/downloads/)
+* [Python 3.6+](https://www.python.org/downloads/)
   * Ensure Python is in PATH.
 * Windows 10 SDK
 
@@ -88,56 +88,20 @@ get helpful spacers/movs in the disassembly.
 
 Linux support is extremely experimental and presently incomplete.
 
-The build script uses LLVM/Clang 3.8. GCC should also work, but is not easily
-swappable right now.
+The build script uses LLVM/Clang 9. GCC while it should work in theory, is not easily
+interchangeable right now.
 
-[CodeLite](https://codelite.org) is the IDE of choice and `xb premake` will spit
-out files for that. Make also works via `xb build`.
+[CodeLite](https://codelite.org) is the supported IDE and `xb devenv` will generate a workspace and attempt to open it. Your distribution's version may be out of date so check their website.
+Normal building via `xb build` uses Make.
 
-To get the latest Clang on an Ubuntu system:
-```
-sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-curl -sSL "http://llvm.org/apt/llvm-snapshot.gpg.key" | sudo -E apt-key add -
-echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise main" | sudo tee -a /etc/apt/sources.list > /dev/null
-sudo -E apt-get -yq update &>> ~/apt-get-update.log
-sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-4.0 clang-format-4.0
-```
-
+Clang-9 or newer should be available from system repositories on all up to date distributions.
 You will also need some development libraries. To get them on an Ubuntu system:
 ```
-sudo apt-get install libgtk-3-dev libpthread-stubs0-dev liblz4-dev libx11-dev libvulkan-dev libc++-dev libc++abi-dev
+sudo apt-get install libgtk-3-dev libpthread-stubs0-dev liblz4-dev libx11-dev libvulkan-dev libsdl2-dev libiberty-dev libunwind-dev libc++-dev libc++abi-dev
 ```
 
-In addition, you will need the latest Vulkan libraries and drivers for your hardware.
-
-#### Linux NVIDIA Vulkan Drivers
-
-You'll need to install the latest NVIDIA drivers to enable Vulkan support on Linux.
-
-First, remove all existing NVIDIA drivers:
-```
-sudo apt-get purge nvidia*
-```
-
-Add the graphics-drivers PPA to your system:
-```
-sudo add-apt-repository ppa:graphics-drivers
-sudo apt update
-```
-
-Install the NVIDIA drivers (newer ones may be released after 387; check online):
-```
-sudo apt install nvidia-387
-```
-
-Either restart the computer, or inject the NVIDIA drivers:
-```
-sudo rmmod nouveau
-sudo modprobe nvidia
-```
+In addition, you will need up to date Vulkan libraries and drivers for your hardware, which most distributions have in their standard repositories nowadays.
 
 ## Running
 
-To make life easier you can use `--flagfile=myflags.txt` to specify all
-arguments, including using `--target=my.xex` to pick an executable. You
-can also specify `--log_file=stdout` to log to stdout rather than a file.
+To make life easier you can set the program startup arguments in your IDE to something like `--log_file=stdout /path/to/Default.xex` to log to console rather than a file and start up the emulator right away.

--- a/tools/build/premake
+++ b/tools/build/premake
@@ -146,7 +146,7 @@ def import_vs_environment():
   install_path = None
   env_tool_args = None
 
-  vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -format json', shell=False, universal_newlines=True)
+  vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -format json -utf8', shell=False, universal_newlines=True, encoding="utf-8")
   if vswhere:
     vswhere = json.loads(vswhere)
   if vswhere and len(vswhere) > 0:

--- a/xenia-build
+++ b/xenia-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2015 Ben Vanik. All Rights Reserved.
+# Copyright 2020 Ben Vanik. All Rights Reserved.
 
 """Main build script and tooling for xenia.
 
@@ -360,7 +360,7 @@ def run_premake_clean():
         return run_premake('linux', 'clean')
 
 
-def run_platform_premake(cc=None):
+def run_platform_premake(cc='clang', devenv=None):
     """Runs all gyp configurations.
     """
     if sys.platform == 'darwin':
@@ -372,9 +372,7 @@ def run_platform_premake(cc=None):
 
         return run_premake('windows', 'vs' + vs_version)
     else:
-        ret = run_premake('linux', 'gmake', cc)
-        ret = ret != 0 and run_premake('linux', 'codelite') or ret
-        return ret
+        return run_premake('linux', devenv == 'codelite' and devenv or 'gmake', cc)
 
 
 def run_premake_export_commands():
@@ -423,6 +421,7 @@ def discover_commands(subparsers):
         'pull': PullCommand(subparsers),
         'premake': PremakeCommand(subparsers),
         'build': BuildCommand(subparsers),
+        'devenv': DevenvCommand(subparsers),
         'genspirv': GenSpirvCommand(subparsers),
         'gentests': GenTestsCommand(subparsers),
         'test': TestCommand(subparsers),
@@ -435,7 +434,6 @@ def discover_commands(subparsers):
         'tidy': TidyCommand(subparsers),
         }
     if sys.platform == 'win32':
-        commands['devenv'] = DevenvCommand(subparsers)
         commands['buildhlsl'] = BuildHlslCommand(subparsers)
     return commands
 
@@ -565,12 +563,14 @@ class PremakeCommand(Command):
             *args, **kwargs)
         self.parser.add_argument(
             '--cc', default='clang', help='Compiler toolchain passed to premake')
+        self.parser.add_argument(
+            '--devenv', default=None, help='Development environment')
 
     def execute(self, args, pass_args, cwd):
         # Update premake. If no binary found, it will be built from source.
         print('Running premake...')
         print('')
-        if run_platform_premake(args['cc']) == 0:
+        if run_platform_premake(cc=args['cc'], devenv=args['devenv']) == 0:
             print('Success!')
 
         return 0
@@ -654,7 +654,7 @@ class BuildCommand(BaseBuildCommand):
         super(BuildCommand, self).__init__(
             subparsers,
             name='build',
-            help_short='Builds the project.',
+            help_short='Builds the project with the default toolchain.',
             *args, **kwargs)
 
     def execute(self, args, pass_args, cwd):
@@ -1436,21 +1436,32 @@ class DevenvCommand(Command):
         super(DevenvCommand, self).__init__(
             subparsers,
             name='devenv',
-            help_short='Launches Visual Studio with the sln.',
+            help_short='Launches the development environment.',
             *args, **kwargs)
 
     def execute(self, args, pass_args, cwd):
-        print('Launching Visual Studio...')
+        devenv = None
+        if sys.platform == 'win32':
+            print('Launching Visual Studio...')
+        else:
+            print('Launching CodeLite...')
+            devenv = 'codelite'
         print('')
 
         print('- running premake...')
-        run_platform_premake()
+        run_platform_premake(devenv=devenv)
         print('')
 
         print('- launching devenv...')
-        shell_call([
-            'devenv',
-            'build\\xenia.sln',
+        if sys.platform == 'win32':
+            shell_call([
+                'devenv',
+                'build\\xenia.sln',
+            ])
+        else:
+            shell_call([
+                'codelite',
+                'build/xenia.workspace',
             ])
         print('')
 

--- a/xenia-build
+++ b/xenia-build
@@ -372,7 +372,7 @@ def run_platform_premake(cc='clang', devenv=None):
 
         return run_premake('windows', 'vs' + vs_version)
     else:
-        return run_premake('linux', devenv == 'codelite' and devenv or 'gmake', cc)
+        return run_premake('linux', devenv == 'codelite' and devenv or 'gmake2', cc)
 
 
 def run_premake_export_commands():


### PR DESCRIPTION
- `xb devenv` command on Linux to generate CodeLite workspace and start it.
- Replace premake with upstream master revision, needed to fix CodeLite related bug. (Only change to our fork is making premake build on PowerPC - do we still need this?)
- Update building documentation.

With these changes getting an IDE and starting debugging is as easy as it is on Windows (At least on current *ubuntus). CodeLite may be inferior to CLion or others but automatic project file generation is key here.