### PR TITLE
Use std::filesystem for simple queries and operations

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -351,7 +351,7 @@ void EmulatorWindow::ShowContentDirectory() {
     target_path = package_root;
   }
 
-  if (!xe::filesystem::PathExists(target_path)) {
+  if (!std::filesystem::exists(target_path)) {
     xe::filesystem::CreateFolder(target_path);
   }
 

--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -352,7 +352,7 @@ void EmulatorWindow::ShowContentDirectory() {
   }
 
   if (!std::filesystem::exists(target_path)) {
-    xe::filesystem::CreateFolder(target_path);
+    std::filesystem::create_directories(target_path);
   }
 
   LaunchFileExplorer(target_path);

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -215,7 +215,7 @@ int xenia_main(const std::vector<std::string>& args) {
   std::filesystem::path storage_root = cvars::storage_root;
   if (storage_root.empty()) {
     storage_root = xe::filesystem::GetExecutableFolder();
-    if (!xe::filesystem::PathExists(storage_root / "portable.txt")) {
+    if (!std::filesystem::exists(storage_root / "portable.txt")) {
       storage_root = xe::filesystem::GetUserFolder();
 #if defined(XE_PLATFORM_WIN32) || defined(XE_PLATFORM_LINUX)
       storage_root = storage_root / "Xenia";

--- a/src/xenia/base/filesystem.cc
+++ b/src/xenia/base/filesystem.cc
@@ -17,7 +17,7 @@ namespace filesystem {
 bool CreateParentFolder(const std::filesystem::path& path) {
   if (path.has_parent_path()) {
     auto parent_path = path.parent_path();
-    if (!PathExists(parent_path)) {
+    if (!std::filesystem::exists(parent_path)) {
       return CreateFolder(parent_path);
     }
   }

--- a/src/xenia/base/filesystem.cc
+++ b/src/xenia/base/filesystem.cc
@@ -18,7 +18,7 @@ bool CreateParentFolder(const std::filesystem::path& path) {
   if (path.has_parent_path()) {
     auto parent_path = path.parent_path();
     if (!std::filesystem::exists(parent_path)) {
-      return CreateFolder(parent_path);
+      return std::filesystem::create_directories(parent_path);
     }
   }
   return true;

--- a/src/xenia/base/filesystem.h
+++ b/src/xenia/base/filesystem.h
@@ -59,10 +59,6 @@ int64_t Tell(FILE* file);
 // undefined.
 bool TruncateStdioFile(FILE* file, uint64_t length);
 
-// Deletes the file at the given path.
-// Returns true if the file was found and removed.
-bool DeleteFile(const std::filesystem::path& path);
-
 struct FileAccess {
   // Implies kFileReadData.
   static const uint32_t kGenericRead = 0x80000000;

--- a/src/xenia/base/filesystem.h
+++ b/src/xenia/base/filesystem.h
@@ -41,10 +41,6 @@ std::filesystem::path GetUserFolder();
 // attempting to create it.
 bool CreateParentFolder(const std::filesystem::path& path);
 
-// Recursively deletes the files and folders at the specified path.
-// Returns true if the path was found and removed.
-bool DeleteFolder(const std::filesystem::path& path);
-
 // Creates an empty file at the given path.
 bool CreateFile(const std::filesystem::path& path);
 

--- a/src/xenia/base/filesystem.h
+++ b/src/xenia/base/filesystem.h
@@ -41,10 +41,6 @@ std::filesystem::path GetUserFolder();
 // attempting to create it.
 bool CreateParentFolder(const std::filesystem::path& path);
 
-// Creates a folder at the specified path.
-// Returns true if the path was created.
-bool CreateFolder(const std::filesystem::path& path);
-
 // Recursively deletes the files and folders at the specified path.
 // Returns true if the path was found and removed.
 bool DeleteFolder(const std::filesystem::path& path);

--- a/src/xenia/base/filesystem.h
+++ b/src/xenia/base/filesystem.h
@@ -52,9 +52,6 @@ bool CreateFolder(const std::filesystem::path& path);
 // Returns true if the path was found and removed.
 bool DeleteFolder(const std::filesystem::path& path);
 
-// Returns true if the given path exists and is a folder.
-bool IsFolder(const std::filesystem::path& path);
-
 // Creates an empty file at the given path.
 bool CreateFile(const std::filesystem::path& path);
 

--- a/src/xenia/base/filesystem.h
+++ b/src/xenia/base/filesystem.h
@@ -36,9 +36,6 @@ std::filesystem::path GetExecutableFolder();
 // Get user folder.
 std::filesystem::path GetUserFolder();
 
-// Returns true of the specified path exists as either a directory or file.
-bool PathExists(const std::filesystem::path& path);
-
 // Creates the parent folder of the specified path if needed.
 // This can be used to ensure the destination path for a new file exists before
 // attempting to create it.

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -77,11 +77,6 @@ std::filesystem::path GetUserFolder() {
   return std::filesystem::path(home) / ".local" / "share";
 }
 
-bool PathExists(const std::filesystem::path& path) {
-  struct stat st;
-  return stat(path.c_str(), &st) == 0;
-}
-
 FILE* OpenFile(const std::filesystem::path& path, const std::string_view mode) {
   return fopen(path.c_str(), std::string(mode).c_str());
 }

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -106,10 +106,6 @@ bool TruncateStdioFile(FILE* file, uint64_t length) {
   return true;
 }
 
-bool CreateFolder(const std::filesystem::path& path) {
-  return mkdir(path.c_str(), 0774);
-}
-
 static int removeCallback(const char* fpath, const struct stat* sb,
                           int typeflag, struct FTW* ftwbuf) {
   int rv = remove(fpath);

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -112,12 +112,6 @@ static int removeCallback(const char* fpath, const struct stat* sb,
   return rv;
 }
 
-bool DeleteFolder(const std::filesystem::path& path) {
-  return nftw(path.c_str(), removeCallback, 64, FTW_DEPTH | FTW_PHYS) == 0
-             ? true
-             : false;
-}
-
 static uint64_t convertUnixtimeToWinFiletime(time_t unixtime) {
   // Linux uses number of seconds since 1/1/1970, and Windows uses
   // number of nanoseconds since 1/1/1601

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -131,11 +131,6 @@ bool CreateFile(const std::filesystem::path& path) {
   return false;
 }
 
-bool DeleteFile(const std::filesystem::path& path) {
-  // TODO: proper implementation.
-  return (path.c_str()) == 0 ? true : false;
-}
-
 class PosixFileHandle : public FileHandle {
  public:
   PosixFileHandle(std::filesystem::path path, int handle)

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -137,14 +137,6 @@ static uint64_t convertUnixtimeToWinFiletime(time_t unixtime) {
   return filetime;
 }
 
-bool IsFolder(const std::filesystem::path& path) {
-  struct stat st;
-  if (stat(path.c_str(), &st) == 0) {
-    if (S_ISDIR(st.st_mode)) return true;
-  }
-  return false;
-}
-
 bool CreateFile(const std::filesystem::path& path) {
   int file = creat(path.c_str(), 0774);
   if (file >= 0) {

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -61,15 +61,6 @@ std::filesystem::path GetUserFolder() {
   return result;
 }
 
-bool CreateFolder(const std::filesystem::path& path) {
-  std::filesystem::path create_path;
-  for (auto it = path.begin(); it != path.end(); ++it) {
-    create_path /= *it;
-    CreateDirectoryW(create_path.c_str(), nullptr);
-  }
-  return std::filesystem::exists(path);
-}
-
 bool DeleteFolder(const std::filesystem::path& path) {
   auto double_null_path = path.wstring() + std::wstring(L"\0", 1);
   SHFILEOPSTRUCT op = {0};

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -61,15 +61,6 @@ std::filesystem::path GetUserFolder() {
   return result;
 }
 
-bool DeleteFolder(const std::filesystem::path& path) {
-  auto double_null_path = path.wstring() + std::wstring(L"\0", 1);
-  SHFILEOPSTRUCT op = {0};
-  op.wFunc = FO_DELETE;
-  op.pFrom = double_null_path.c_str();
-  op.fFlags = FOF_NO_UI;
-  return SHFileOperation(&op) == 0;
-}
-
 bool CreateFile(const std::filesystem::path& path) {
   auto handle = CreateFileW(path.c_str(), 0, 0, nullptr, CREATE_ALWAYS,
                             FILE_ATTRIBUTE_NORMAL, nullptr);

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -61,18 +61,13 @@ std::filesystem::path GetUserFolder() {
   return result;
 }
 
-bool PathExists(const std::filesystem::path& path) {
-  DWORD attrib = GetFileAttributes(path.c_str());
-  return attrib != INVALID_FILE_ATTRIBUTES;
-}
-
 bool CreateFolder(const std::filesystem::path& path) {
   std::filesystem::path create_path;
   for (auto it = path.begin(); it != path.end(); ++it) {
     create_path /= *it;
     CreateDirectoryW(create_path.c_str(), nullptr);
   }
-  return PathExists(path);
+  return std::filesystem::exists(path);
 }
 
 bool DeleteFolder(const std::filesystem::path& path) {

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -84,12 +84,6 @@ bool DeleteFolder(const std::filesystem::path& path) {
   return SHFileOperation(&op) == 0;
 }
 
-bool IsFolder(const std::filesystem::path& path) {
-  DWORD attrib = GetFileAttributes(path.c_str());
-  return attrib != INVALID_FILE_ATTRIBUTES &&
-         (attrib & FILE_ATTRIBUTE_DIRECTORY) == FILE_ATTRIBUTE_DIRECTORY;
-}
-
 bool CreateFile(const std::filesystem::path& path) {
   auto handle = CreateFileW(path.c_str(), 0, 0, nullptr, CREATE_ALWAYS,
                             FILE_ATTRIBUTE_NORMAL, nullptr);

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -13,7 +13,6 @@
 #include <string>
 
 #undef CreateFile
-#undef DeleteFile
 
 #include "xenia/base/filesystem.h"
 #include "xenia/base/logging.h"
@@ -102,10 +101,6 @@ bool TruncateStdioFile(FILE* file, uint64_t length) {
     }
   }
   return true;
-}
-
-bool DeleteFile(const std::filesystem::path& path) {
-  return DeleteFileW(path.c_str()) ? true : false;
 }
 
 class Win32FileHandle : public FileHandle {

--- a/src/xenia/base/main_win.cc
+++ b/src/xenia/base/main_win.cc
@@ -13,7 +13,6 @@
 #include <cstdlib>
 
 #include "xenia/base/cvar.h"
-#include "xenia/base/filesystem.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/main.h"
 #include "xenia/base/platform_win.h"

--- a/src/xenia/config.cc
+++ b/src/xenia/config.cc
@@ -114,7 +114,7 @@ void SaveConfig() {
     output << fmt::format("\t# {}\n", config_var->description());
   }
 
-  if (xe::filesystem::PathExists(config_path)) {
+  if (std::filesystem::exists(config_path)) {
     std::ifstream existingConfigStream(config_path);
     const std::string existingConfig(
         (std::istreambuf_iterator<char>(existingConfigStream)),
@@ -136,7 +136,7 @@ void SetupConfig(const std::filesystem::path& config_folder) {
   // check if the user specified a specific config to load
   if (!cvars::config.empty()) {
     config_path = xe::to_path(cvars::config);
-    if (xe::filesystem::PathExists(config_path)) {
+    if (std::filesystem::exists(config_path)) {
       ReadConfig(config_path);
       return;
     }
@@ -145,7 +145,7 @@ void SetupConfig(const std::filesystem::path& config_folder) {
   // let's also load the default config
   if (!config_folder.empty()) {
     config_path = config_folder / config_name;
-    if (xe::filesystem::PathExists(config_path)) {
+    if (std::filesystem::exists(config_path)) {
       ReadConfig(config_path);
     }
     // we only want to save the config if the user is using the default
@@ -158,7 +158,7 @@ void LoadGameConfig(const std::string_view title_id) {
   const auto game_config_folder = config_folder / "config";
   const auto game_config_path =
       game_config_folder / (std::string(title_id) + game_config_suffix);
-  if (xe::filesystem::PathExists(game_config_path)) {
+  if (std::filesystem::exists(game_config_path)) {
     ReadGameConfig(game_config_path);
   }
 }

--- a/src/xenia/gpu/d3d12/pipeline_cache.cc
+++ b/src/xenia/gpu/d3d12/pipeline_cache.cc
@@ -202,7 +202,7 @@ void PipelineCache::InitializeShaderStorage(
   // cost - though D3D's internal validation would possibly be enough to ensure
   // they are up to date).
   auto shader_storage_shareable_root = shader_storage_root / "shareable";
-  if (!xe::filesystem::CreateFolder(shader_storage_shareable_root)) {
+  if (!std::filesystem::create_directories(shader_storage_shareable_root)) {
     return;
   }
 

--- a/src/xenia/gpu/shader.cc
+++ b/src/xenia/gpu/shader.cc
@@ -47,7 +47,7 @@ std::pair<std::filesystem::path, std::filesystem::path> Shader::Dump(
   auto target_path = base_path;
   if (!target_path.empty()) {
     target_path = std::filesystem::absolute(target_path);
-    xe::filesystem::CreateFolder(target_path);
+    std::filesystem::create_directories(target_path);
   }
 
   auto base_name =

--- a/src/xenia/gpu/trace_writer.cc
+++ b/src/xenia/gpu/trace_writer.cc
@@ -16,6 +16,7 @@
 
 #include "build/version.h"
 #include "xenia/base/assert.h"
+#include "xenia/base/filesystem.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/string.h"
 

--- a/src/xenia/gpu/trace_writer.cc
+++ b/src/xenia/gpu/trace_writer.cc
@@ -33,7 +33,7 @@ bool TraceWriter::Open(const std::filesystem::path& path, uint32_t title_id) {
   auto canonical_path = std::filesystem::absolute(path);
   if (canonical_path.has_parent_path()) {
     auto base_path = canonical_path.parent_path();
-    xe::filesystem::CreateFolder(base_path);
+    std::filesystem::create_directories(base_path);
   }
 
   file_ = xe::filesystem::OpenFile(canonical_path, "wb");

--- a/src/xenia/gpu/trace_writer.h
+++ b/src/xenia/gpu/trace_writer.h
@@ -10,10 +10,10 @@
 #ifndef XENIA_GPU_TRACE_WRITER_H_
 #define XENIA_GPU_TRACE_WRITER_H_
 
+#include <filesystem>
 #include <set>
 #include <string>
 
-#include "xenia/base/filesystem.h"
 #include "xenia/gpu/trace_protocol.h"
 
 namespace xe {

--- a/src/xenia/hid/sdl/sdl_input_driver.cc
+++ b/src/xenia/hid/sdl/sdl_input_driver.cc
@@ -121,7 +121,7 @@ X_STATUS SDLInputDriver::Setup() {
     sdl_gamecontroller_initialized_ = true;
 
     if (!cvars::mappings_file.empty()) {
-      if (!filesystem::PathExists(cvars::mappings_file)) {
+      if (!std::filesystem::exists(cvars::mappings_file)) {
         XELOGW("SDL GameControllerDB: file '{}' does not exist.",
                xe::path_to_utf8(cvars::mappings_file));
       } else {

--- a/src/xenia/kernel/xam/content_manager.cc
+++ b/src/xenia/kernel/xam/content_manager.cc
@@ -243,8 +243,7 @@ X_RESULT ContentManager::DeleteContent(const XCONTENT_DATA& data) {
   auto global_lock = global_critical_region_.Acquire();
 
   auto package_path = ResolvePackagePath(data);
-  if (std::filesystem::exists(package_path)) {
-    xe::filesystem::DeleteFolder(package_path);
+  if (std::filesystem::remove_all(package_path) > 0) {
     return X_ERROR_SUCCESS;
   } else {
     return X_ERROR_FILE_NOT_FOUND;

--- a/src/xenia/kernel/xam/content_manager.cc
+++ b/src/xenia/kernel/xam/content_manager.cc
@@ -153,7 +153,7 @@ X_RESULT ContentManager::CreateContent(const std::string_view root_name,
     return X_ERROR_ALREADY_EXISTS;
   }
 
-  if (!xe::filesystem::CreateFolder(package_path)) {
+  if (!std::filesystem::create_directories(package_path)) {
     return X_ERROR_ACCESS_DENIED;
   }
 
@@ -227,7 +227,7 @@ X_RESULT ContentManager::SetContentThumbnail(const XCONTENT_DATA& data,
                                              std::vector<uint8_t> buffer) {
   auto global_lock = global_critical_region_.Acquire();
   auto package_path = ResolvePackagePath(data);
-  xe::filesystem::CreateFolder(package_path);
+  std::filesystem::create_directories(package_path);
   if (std::filesystem::exists(package_path)) {
     auto thumb_path = package_path / kThumbnailFileName;
     auto file = xe::filesystem::OpenFile(thumb_path, "wb");

--- a/src/xenia/kernel/xam/content_manager.cc
+++ b/src/xenia/kernel/xam/content_manager.cc
@@ -122,7 +122,7 @@ std::vector<XCONTENT_DATA> ContentManager::ListContent(uint32_t device_id,
 std::unique_ptr<ContentPackage> ContentManager::ResolvePackage(
     const std::string_view root_name, const XCONTENT_DATA& data) {
   auto package_path = ResolvePackagePath(data);
-  if (!xe::filesystem::PathExists(package_path)) {
+  if (!std::filesystem::exists(package_path)) {
     return nullptr;
   }
 
@@ -135,7 +135,7 @@ std::unique_ptr<ContentPackage> ContentManager::ResolvePackage(
 
 bool ContentManager::ContentExists(const XCONTENT_DATA& data) {
   auto path = ResolvePackagePath(data);
-  return xe::filesystem::PathExists(path);
+  return std::filesystem::exists(path);
 }
 
 X_RESULT ContentManager::CreateContent(const std::string_view root_name,
@@ -148,7 +148,7 @@ X_RESULT ContentManager::CreateContent(const std::string_view root_name,
   }
 
   auto package_path = ResolvePackagePath(data);
-  if (xe::filesystem::PathExists(package_path)) {
+  if (std::filesystem::exists(package_path)) {
     // Exists, must not!
     return X_ERROR_ALREADY_EXISTS;
   }
@@ -175,7 +175,7 @@ X_RESULT ContentManager::OpenContent(const std::string_view root_name,
   }
 
   auto package_path = ResolvePackagePath(data);
-  if (!xe::filesystem::PathExists(package_path)) {
+  if (!std::filesystem::exists(package_path)) {
     // Does not exist, must be created.
     return X_ERROR_FILE_NOT_FOUND;
   }
@@ -209,7 +209,7 @@ X_RESULT ContentManager::GetContentThumbnail(const XCONTENT_DATA& data,
   auto global_lock = global_critical_region_.Acquire();
   auto package_path = ResolvePackagePath(data);
   auto thumb_path = package_path / kThumbnailFileName;
-  if (xe::filesystem::PathExists(thumb_path)) {
+  if (std::filesystem::exists(thumb_path)) {
     auto file = xe::filesystem::OpenFile(thumb_path, "rb");
     fseek(file, 0, SEEK_END);
     size_t file_len = ftell(file);
@@ -228,7 +228,7 @@ X_RESULT ContentManager::SetContentThumbnail(const XCONTENT_DATA& data,
   auto global_lock = global_critical_region_.Acquire();
   auto package_path = ResolvePackagePath(data);
   xe::filesystem::CreateFolder(package_path);
-  if (xe::filesystem::PathExists(package_path)) {
+  if (std::filesystem::exists(package_path)) {
     auto thumb_path = package_path / kThumbnailFileName;
     auto file = xe::filesystem::OpenFile(thumb_path, "wb");
     fwrite(buffer.data(), 1, buffer.size(), file);
@@ -243,7 +243,7 @@ X_RESULT ContentManager::DeleteContent(const XCONTENT_DATA& data) {
   auto global_lock = global_critical_region_.Acquire();
 
   auto package_path = ResolvePackagePath(data);
-  if (xe::filesystem::PathExists(package_path)) {
+  if (std::filesystem::exists(package_path)) {
     xe::filesystem::DeleteFolder(package_path);
     return X_ERROR_SUCCESS;
   } else {

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -158,7 +158,7 @@ void UserProfile::SaveSetting(UserProfile::Setting* setting) {
     auto serialized_setting = setting->Serialize();
     auto content_dir =
         kernel_state()->content_manager()->ResolveGameUserContentPath();
-    xe::filesystem::CreateFolder(content_dir);
+    std::filesystem::create_directories(content_dir);
     auto setting_id = fmt::format("{:08X}", setting->setting_id);
     auto file_path = content_dir / setting_id;
     auto file = xe::filesystem::OpenFile(file_path, "wb");

--- a/src/xenia/kernel/xfile.h
+++ b/src/xenia/kernel/xfile.h
@@ -12,7 +12,6 @@
 
 #include <string>
 
-#include "xenia/base/filesystem.h"
 #include "xenia/kernel/xevent.h"
 #include "xenia/kernel/xiocompletion.h"
 #include "xenia/kernel/xobject.h"

--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -11,7 +11,6 @@
 
 #include "third_party/imgui/imgui.h"
 #include "xenia/base/assert.h"
-#include "xenia/base/filesystem.h"
 #include "xenia/base/logging.h"
 #include "xenia/ui/window.h"
 
@@ -136,7 +135,7 @@ void ImGuiDrawer::SetupFont() {
   // TODO(benvanik): jp font on other platforms?
   // https://github.com/Koruri/kibitaki looks really good, but is 1.5MiB.
   const char* jp_font_path = "C:\\Windows\\Fonts\\msgothic.ttc";
-  if (xe::filesystem::PathExists(jp_font_path)) {
+  if (std::filesystem::exists(jp_font_path)) {
     ImFontConfig jp_font_config;
     jp_font_config.MergeMode = true;
     jp_font_config.OversampleH = jp_font_config.OversampleV = 1;

--- a/src/xenia/vfs/devices/disc_image_entry.h
+++ b/src/xenia/vfs/devices/disc_image_entry.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "xenia/base/filesystem.h"
 #include "xenia/base/mapped_memory.h"
 #include "xenia/vfs/entry.h"
 

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -29,7 +29,7 @@ bool HostPathDevice::Initialize() {
   if (!std::filesystem::exists(host_path_)) {
     if (!read_only_) {
       // Create the path.
-      xe::filesystem::CreateFolder(host_path_);
+      std::filesystem::create_directories(host_path_);
     } else {
       XELOGE("Host path does not exist");
       return false;

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -26,7 +26,7 @@ HostPathDevice::HostPathDevice(const std::string_view mount_path,
 HostPathDevice::~HostPathDevice() = default;
 
 bool HostPathDevice::Initialize() {
-  if (!xe::filesystem::PathExists(host_path_)) {
+  if (!std::filesystem::exists(host_path_)) {
     if (!read_only_) {
       // Create the path.
       xe::filesystem::CreateFolder(host_path_);

--- a/src/xenia/vfs/devices/host_path_entry.cc
+++ b/src/xenia/vfs/devices/host_path_entry.cc
@@ -99,7 +99,7 @@ bool HostPathEntry::DeleteEntryInternal(Entry* entry) {
   auto full_path = host_path_ / xe::to_path(entry->name());
   if (entry->attributes() & kFileAttributeDirectory) {
     // Delete entire directory and contents.
-    return xe::filesystem::DeleteFolder(full_path);
+    return std::filesystem::remove_all(full_path);
   } else {
     // Delete file.
     return xe::filesystem::DeleteFile(full_path);

--- a/src/xenia/vfs/devices/host_path_entry.cc
+++ b/src/xenia/vfs/devices/host_path_entry.cc
@@ -77,7 +77,7 @@ std::unique_ptr<Entry> HostPathEntry::CreateEntryInternal(
     const std::string_view name, uint32_t attributes) {
   auto full_path = host_path_ / xe::to_path(name);
   if (attributes & kFileAttributeDirectory) {
-    if (!xe::filesystem::CreateFolder(full_path)) {
+    if (!std::filesystem::create_directories(full_path)) {
       return nullptr;
     }
   } else {

--- a/src/xenia/vfs/devices/host_path_entry.cc
+++ b/src/xenia/vfs/devices/host_path_entry.cc
@@ -102,7 +102,8 @@ bool HostPathEntry::DeleteEntryInternal(Entry* entry) {
     return std::filesystem::remove_all(full_path);
   } else {
     // Delete file.
-    return xe::filesystem::DeleteFile(full_path);
+    return !std::filesystem::is_directory(full_path) &&
+           std::filesystem::remove(full_path);
   }
 }
 

--- a/src/xenia/vfs/devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/stfs_container_device.cc
@@ -61,7 +61,7 @@ StfsContainerDevice::~StfsContainerDevice() = default;
 
 bool StfsContainerDevice::Initialize() {
   // Resolve a valid STFS file if a directory is given.
-  if (filesystem::IsFolder(host_path_) && !ResolveFromFolder(host_path_)) {
+  if (std::filesystem::is_directory(host_path_) && !ResolveFromFolder(host_path_)) {
     XELOGE("Could not resolve an STFS container given path {}",
            xe::path_to_utf8(host_path_));
     return false;

--- a/src/xenia/vfs/devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/stfs_container_device.cc
@@ -61,13 +61,14 @@ StfsContainerDevice::~StfsContainerDevice() = default;
 
 bool StfsContainerDevice::Initialize() {
   // Resolve a valid STFS file if a directory is given.
-  if (std::filesystem::is_directory(host_path_) && !ResolveFromFolder(host_path_)) {
+  if (std::filesystem::is_directory(host_path_) &&
+      !ResolveFromFolder(host_path_)) {
     XELOGE("Could not resolve an STFS container given path {}",
            xe::path_to_utf8(host_path_));
     return false;
   }
 
-  if (!filesystem::PathExists(host_path_)) {
+  if (!std::filesystem::exists(host_path_)) {
     XELOGE("Path to STFS container does not exist: {}",
            xe::path_to_utf8(host_path_));
     return false;
@@ -120,7 +121,7 @@ StfsContainerDevice::Error StfsContainerDevice::MapFiles() {
   // If the STFS package is multi-file, it is an SVOD system. We need to map
   // the files in the .data folder and can discard the header.
   auto data_fragment_path = host_path_ / ".data";
-  if (!filesystem::PathExists(data_fragment_path)) {
+  if (!std::filesystem::exists(data_fragment_path)) {
     XELOGE("STFS container is multi-file, but path {} does not exist.",
            xe::path_to_utf8(data_fragment_path));
     return Error::kErrorFileMismatch;

--- a/src/xenia/vfs/devices/stfs_container_entry.h
+++ b/src/xenia/vfs/devices/stfs_container_entry.h
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 
-#include "xenia/base/filesystem.h"
 #include "xenia/base/mapped_memory.h"
 #include "xenia/vfs/entry.h"
 #include "xenia/vfs/file.h"

--- a/src/xenia/vfs/vfs_dump.cc
+++ b/src/xenia/vfs/vfs_dump.cc
@@ -62,7 +62,7 @@ int vfs_dump_main(const std::vector<std::string>& args) {
     XELOGI("{}", entry->path());
     auto dest_name = base_path / xe::to_path(entry->path());
     if (entry->attributes() & kFileAttributeDirectory) {
-      xe::filesystem::CreateFolder(dest_name);
+      std::filesystem::create_directories(dest_name);
       continue;
     }
 

--- a/src/xenia/vfs/virtual_file_system.cc
+++ b/src/xenia/vfs/virtual_file_system.cc
@@ -9,7 +9,6 @@
 
 #include "xenia/vfs/virtual_file_system.h"
 
-#include "xenia/base/filesystem.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/string.h"
 #include "xenia/kernel/xfile.h"


### PR DESCRIPTION
With C++17 filesystem implemented, some of the `xe::filesystem` functions have become obsolete platform implementations of what the standard library already provides.

This PR removes `xe::filesystem::IsFolder`,  `xe::filesystem::PathExists`,  `xe::filesystem::CreateFolder`,  `xe::filesystem::DeleteFolder` and  `xe::filesystem::DeleteFile` and replaces them with their `std::filesystem` counterparts in the place where they are called.

This has the added bonus of implementing those functionalities in Posix as well.