### PR TITLE
Avoid using '#' format spec for X hex numbers.

### DIFF
--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -126,7 +126,7 @@ class Win32FileHandle : public FileHandle {
     } else {
       if (GetLastError() == ERROR_NOACCESS) {
         XELOGW(
-            "Win32FileHandle::Read(..., {}, {:#X}, ...) returned "
+            "Win32FileHandle::Read(..., {}, 0x{:X}, ...) returned "
             "ERROR_NOACCESS. Read-only memory?",
             buffer, buffer_length);
       }

--- a/src/xenia/cpu/elf_module.cc
+++ b/src/xenia/cpu/elf_module.cc
@@ -114,7 +114,7 @@ bool ElfModule::Load(const std::string_view name, const std::string_view path,
       // Allocate and copy into memory.
       // Base address @ 0x80000000
       if (phdr[i].p_vaddr < 0x80000000 || phdr[i].p_vaddr > 0x9FFFFFFF) {
-        XELOGE("ELF: Could not allocate memory for section @ address {:#08X}",
+        XELOGE("ELF: Could not allocate memory for section @ address 0x{:08X}",
                uint32_t(phdr[i].p_vaddr));
         return false;
       }

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -546,10 +546,11 @@ bool Emulator::ExceptionCallback(Exception* ex) {
   auto context = current_thread->thread_state()->context();
 
   XELOGE("==== CRASH DUMP ====");
-  XELOGE("Thread ID (Host: {:#08X} / Guest: {:#08X})",
+  XELOGE("Thread ID (Host: 0x{:08X} / Guest: 0x{:08X})",
          current_thread->thread()->system_id(), current_thread->thread_id());
-  XELOGE("Thread Handle: {:#08X}", current_thread->handle());
-  XELOGE("PC: {:#08X}", guest_function->MapMachineCodeToGuestAddress(ex->pc()));
+  XELOGE("Thread Handle: 0x{:08X}", current_thread->handle());
+  XELOGE("PC: 0x{:08X}",
+         guest_function->MapMachineCodeToGuestAddress(ex->pc()));
   XELOGE("Registers:");
   for (int i = 0; i < 32; i++) {
     XELOGE(" r{:-3d} = {:016X}", i, context->r[i]);
@@ -562,7 +563,7 @@ bool Emulator::ExceptionCallback(Exception* ex) {
   }
 
   for (int i = 0; i < 128; i++) {
-    XELOGE(" v{:-3d} = [{:#08X}, {:#08X}, {:#08X}, {:#08X}]", i,
+    XELOGE(" v{:-3d} = [0x{:08X}, 0x{:08X}, 0x{:08X}, 0x{:08X}]", i,
            context->v[i].u32[0], context->v[i].u32[1], context->v[i].u32[2],
            context->v[i].u32[3]);
   }

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -737,7 +737,7 @@ bool CommandProcessor::ExecutePacketType3(RingBuffer* reader, uint32_t packet) {
     }
 
     default:
-      XELOGGPU("Unimplemented GPU OPCODE: {:#02X}\t\tCOUNT: {}\n", opcode,
+      XELOGGPU("Unimplemented GPU OPCODE: 0x{:02X}\t\tCOUNT: {}\n", opcode,
                count);
       assert_always();
       reader->AdvanceRead(count * sizeof(uint32_t));

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -1488,7 +1488,7 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
     if (!shared_memory_->RequestRange(vfetch_constant.address << 2,
                                       vfetch_constant.size << 2)) {
       XELOGE(
-          "Failed to request vertex buffer at {:#08X} (size {}) in the shared "
+          "Failed to request vertex buffer at 0x{:08X} (size {}) in the shared "
           "memory",
           vfetch_constant.address << 2, vfetch_constant.size << 2);
       return false;
@@ -1590,7 +1590,7 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
     if (!shared_memory_->RequestRange(memexport_range.base_address_dwords << 2,
                                       memexport_range.size_dwords << 2)) {
       XELOGE(
-          "Failed to request memexport stream at {:#08X} (size {}) in the "
+          "Failed to request memexport stream at 0x{:08X} (size {}) in the "
           "shared memory",
           memexport_range.base_address_dwords << 2,
           memexport_range.size_dwords << 2);
@@ -1636,8 +1636,8 @@ bool D3D12CommandProcessor::IssueDraw(PrimitiveType primitive_type,
       uint32_t index_buffer_size = index_buffer_info->count * index_size;
       if (!shared_memory_->RequestRange(index_base, index_buffer_size)) {
         XELOGE(
-            "Failed to request index buffer at {:#08X} (size {}) in the shared "
-            "memory",
+            "Failed to request index buffer at 0x{:08X} (size {}) in the "
+            "shared memory",
             index_base, index_buffer_size);
         return false;
       }

--- a/src/xenia/gpu/d3d12/render_target_cache.cc
+++ b/src/xenia/gpu/d3d12/render_target_cache.cc
@@ -1340,7 +1340,7 @@ bool RenderTargetCache::ResolveCopy(SharedMemory* shared_memory,
   bool dest_swap = !is_depth && rb_copy_dest_info.copy_dest_swap;
 
   XELOGGPU(
-      "Resolve: Copying samples {} to {:#08X} ({}x{}, {}D), destination Z {}, "
+      "Resolve: Copying samples {} to 0x{:08X} ({}x{}, {}D), destination Z {}, "
       "destination format {}, exponent bias {}, red and blue {}swapped",
       uint32_t(sample_select), dest_address, dest_pitch, dest_height,
       rb_copy_dest_info.copy_dest_array ? '3' : '2', dest_z,

--- a/src/xenia/gpu/d3d12/texture_cache.cc
+++ b/src/xenia/gpu/d3d12/texture_cache.cc
@@ -2178,7 +2178,7 @@ void TextureCache::BindingInfoFromFetchConstant(
 void TextureCache::LogTextureKeyAction(TextureKey key, const char* action) {
   XELOGGPU(
       "{} {} {}{}x{}x{} {} {} texture with {} {}packed mip level{}, "
-      "base at {:#08X}, mips at {:#08X}",
+      "base at 0x{:08X}, mips at 0x{:08X}",
       action, key.tiled ? "tiled" : "linear",
       key.scaled_resolve ? "2x-scaled " : "", key.width, key.height, key.depth,
       dimension_names_[uint32_t(key.dimension)],
@@ -2191,7 +2191,7 @@ void TextureCache::LogTextureAction(const Texture* texture,
                                     const char* action) {
   XELOGGPU(
       "{} {} {}{}x{}x{} {} {} texture with {} {}packed mip level{}, "
-      "base at {:#08X} (size {}), mips at {:#08X} (size {})",
+      "base at 0x{:08X} (size {}), mips at 0x{:08X} (size {})",
       action, texture->key.tiled ? "tiled" : "linear",
       texture->key.scaled_resolve ? "2x-scaled " : "", texture->key.width,
       texture->key.height, texture->key.depth,

--- a/src/xenia/gpu/vulkan/render_cache.cc
+++ b/src/xenia/gpu/vulkan/render_cache.cc
@@ -232,7 +232,7 @@ VkResult CachedTileView::Initialize(VkCommandBuffer command_buffer) {
 
   device_->DbgSetObjectName(
       reinterpret_cast<uint64_t>(image), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-      fmt::format("RT(d): {:#08X} {:#08X}({}) {:#08X}({}) {} {} {}",
+      fmt::format("RT(d): 0x{:08X} 0x{:08X}({}) 0x{:08X}({}) {} {} {}",
                   uint32_t(key.tile_offset), uint32_t(key.tile_width),
                   uint32_t(key.tile_width), uint32_t(key.tile_height),
                   uint32_t(key.tile_height), uint32_t(key.color_or_depth),

--- a/src/xenia/gpu/vulkan/texture_cache.cc
+++ b/src/xenia/gpu/vulkan/texture_cache.cc
@@ -522,7 +522,7 @@ TextureCache::Texture* TextureCache::DemandResolveTexture(
       reinterpret_cast<uint64_t>(texture->image),
       VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
       fmt::format(
-          "RT: {:#08X} - {:#08X} ({}, {})", texture_info.memory.base_address,
+          "RT: 0x{:08X} - 0x{:08X} ({}, {})", texture_info.memory.base_address,
           texture_info.memory.base_address + texture_info.memory.base_size,
           texture_info.format_info()->name,
           get_dimension_name(texture_info.dimension)));
@@ -605,7 +605,7 @@ TextureCache::Texture* TextureCache::Demand(const TextureInfo& texture_info,
       reinterpret_cast<uint64_t>(texture->image),
       VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
       fmt::format(
-          "T: {:#08X} - {:#08X} ({}, {})", texture_info.memory.base_address,
+          "T: 0x{:08X} - 0x{:08X} ({}, {})", texture_info.memory.base_address,
           texture_info.memory.base_address + texture_info.memory.base_size,
           texture_info.format_info()->name,
           get_dimension_name(texture_info.dimension)));
@@ -1068,9 +1068,9 @@ bool TextureCache::UploadTexture(VkCommandBuffer command_buffer,
   size_t unpack_length = ComputeTextureStorage(src);
 
   XELOGGPU(
-      "Uploading texture @ {:#08X}/{:#08X} ({}x{}x{}, format: {}, dim: {}, "
+      "Uploading texture @ 0x{:08X}/0x{:08X} ({}x{}x{}, format: {}, dim: {}, "
       "levels: {} ({}-{}), stacked: {}, pitch: {}, tiled: {}, packed mips: {}, "
-      "unpack length: {:#X})",
+      "unpack length: 0x{:X})",
       src.memory.base_address, src.memory.mip_address, src.width + 1,
       src.height + 1, src.depth + 1, src.format_info()->name,
       get_dimension_name(src.dimension), src.mip_levels(), src.mip_min_level,
@@ -1097,7 +1097,7 @@ bool TextureCache::UploadTexture(VkCommandBuffer command_buffer,
     if (!staging_buffer_.CanAcquire(unpack_length)) {
       // The staging buffer isn't big enough to hold this texture.
       XELOGE(
-          "TextureCache staging buffer is too small! (uploading {:#X} bytes)",
+          "TextureCache staging buffer is too small! (uploading 0x{:X} bytes)",
           unpack_length);
       assert_always();
       return false;
@@ -1123,7 +1123,7 @@ bool TextureCache::UploadTexture(VkCommandBuffer command_buffer,
   }
 
   if (!valid) {
-    XELOGW("Warning: Texture @ {:#08X} is blank!", src.memory.base_address);
+    XELOGW("Warning: Texture @ 0x{:08X} is blank!", src.memory.base_address);
   }
 
   // Upload texture into GPU memory.
@@ -1147,7 +1147,7 @@ bool TextureCache::UploadTexture(VkCommandBuffer command_buffer,
     copy_regions[region].imageOffset = {0, 0, 0};
 
     /*
-    XELOGGPU("Mip {} {}x{}x{} @ {:#X}", mip,
+    XELOGGPU("Mip {} {}x{}x{} @ 0x{:X}", mip,
              copy_regions[region].imageExtent.width,
              copy_regions[region].imageExtent.height,
              copy_regions[region].imageExtent.depth, unpack_offset);

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -1121,7 +1121,7 @@ bool VulkanCommandProcessor::IssueCopy() {
                                         : static_cast<uint32_t>(depth_format);
   VkFilter filter = is_color_source ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
 
-  XELOGGPU("Resolve RT {:08X} {:08X}({}) -> {:#08X} ({}x{}, format: {})",
+  XELOGGPU("Resolve RT {:08X} {:08X}({}) -> 0x{:08X} ({}x{}, format: {})",
            edram_base, surface_pitch, surface_pitch, copy_dest_base,
            copy_dest_pitch, copy_dest_height, texture_info.format_info()->name);
   switch (copy_command) {

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_debug.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_debug.cc
@@ -136,8 +136,8 @@ DECLARE_XBOXKRNL_EXPORT2(RtlRaiseException, kDebug, kStub, kImportant);
 
 void KeBugCheckEx(dword_t code, dword_t param1, dword_t param2, dword_t param3,
                   dword_t param4) {
-  XELOGD("*** STOP: {:#08X} ({:#08X}, {:#08X}, {:#08X}, {:#08X})", code, param1,
-         param2, param3, param4);
+  XELOGD("*** STOP: 0x{:08X} (0x{:08X}, 0x{:08X}, 0x{:08X}, 0x{:08X})", code,
+         param1, param2, param3, param4);
   fflush(stdout);
   xe::debugging::Break();
   assert_always();

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_video.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_video.cc
@@ -370,7 +370,7 @@ void VdSwap(lpvoid_t buffer_ptr,  // ptr into primary ringbuffer
   assert_true(frontbuffer_address != UINT32_MAX);
   if (frontbuffer_address == UINT32_MAX) {
     // Xenia-specific safety check.
-    XELOGE("VdSwap: Invalid front buffer virtual address {:#08X}",
+    XELOGE("VdSwap: Invalid front buffer virtual address 0x{:08X}",
            fetch.base_address << 12);
     return;
   }

--- a/src/xenia/ui/vk/transient_objects.cc
+++ b/src/xenia/ui/vk/transient_objects.cc
@@ -94,7 +94,7 @@ bool UploadBufferChain::EnsureCurrentBufferAllocated() {
                      &upload_buffer.buffer) != VK_SUCCESS) {
     XELOGE(
         "Failed to create a Vulkan upload buffer with {} x {} bytes and "
-        "{:#08X} usage",
+        "0x{:08X} usage",
         buffer_create_info.size, VulkanContext::kQueuedFrames,
         static_cast<uint32_t>(usage_flags_));
     buffer_creation_failed_ = true;
@@ -112,7 +112,7 @@ bool UploadBufferChain::EnsureCurrentBufferAllocated() {
     if (memory_type_ == UINT32_MAX) {
       XELOGE(
           "Failed to find a memory type for an upload buffer with {} bytes "
-          "and {:#08X} usage",
+          "and 0x{:08X} usage",
           buffer_memory_requirements.size, usage_flags_);
       vkDestroyBuffer(device, upload_buffer.buffer, nullptr);
       buffer_creation_failed_ = true;

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -66,7 +66,7 @@ bool Win32Window::OnCreate() {
       auto spda = (decltype(&SetProcessDpiAwareness))SetProcessDpiAwareness_;
       auto res = spda(PROCESS_PER_MONITOR_DPI_AWARE);
       if (res != S_OK) {
-        XELOGW("Failed to set process DPI awareness. (code = {:#08X})", res);
+        XELOGW("Failed to set process DPI awareness. (code = 0x{:08X})", res);
       }
     }
 

--- a/src/xenia/vfs/devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/stfs_container_device.cc
@@ -643,7 +643,7 @@ StfsContainerDevice::BlockHash StfsContainerDevice::GetBlockHash(
 bool StfsVolumeDescriptor::Read(const uint8_t* p) {
   descriptor_size = xe::load_and_swap<uint8_t>(p + 0x00);
   if (descriptor_size != 0x24) {
-    XELOGE("STFS volume descriptor size mismatch, expected 0x24 but got {:#X}",
+    XELOGE("STFS volume descriptor size mismatch, expected 0x24 but got 0x{:X}",
            descriptor_size);
     return false;
   }
@@ -660,7 +660,7 @@ bool StfsVolumeDescriptor::Read(const uint8_t* p) {
 bool SvodVolumeDescriptor::Read(const uint8_t* p) {
   descriptor_size = xe::load<uint8_t>(p + 0x00);
   if (descriptor_size != 0x24) {
-    XELOGE("SVOD volume descriptor size mismatch, expected 0x24 but got {:#X}",
+    XELOGE("SVOD volume descriptor size mismatch, expected 0x24 but got 0x{:X}",
            descriptor_size);
     return false;
   }


### PR DESCRIPTION
Avoid using '#' format spec for X (uppercase) hex numbers, as it results in output like "0XABCDEF" instead of "0xABCDEF".