### PR TITLE
[XAM] Modify default user XUID.

### DIFF
--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -20,7 +20,11 @@ namespace kernel {
 namespace xam {
 
 UserProfile::UserProfile() {
-  xuid_ = 0xBABEBABEBABEBABE;
+  // NeoGeo Battle Coliseum checks the user XUID against a mask of
+  // 0x00C0000000000000 (3<<54), if non-zero, it prevents the user from playing
+  // the game.
+  // "You do not have permissions to perform this operation."
+  xuid_ = 0xB13EBABEBABEBABE;
   name_ = "User";
 
   // https://cs.rin.ru/forum/viewtopic.php?f=38&t=60668&hilit=gfwl+live&start=195


### PR DESCRIPTION
[XAM] Modify default user XUID. Fixes behavior in NeoGeo Battle Coliseum and possibly others. ("You do not have permissions to perform this operation.")