### PR TITLE
Rooted path fixes.

### DIFF
--- a/src/xenia/base/utf8.cc
+++ b/src/xenia/base/utf8.cc
@@ -485,7 +485,7 @@ std::vector<std::string_view> split_path(const std::string_view path) {
 }
 
 std::string join_paths(const std::string_view left_path,
-                       const std::string_view right_path, char32_t sep) {
+                       const std::string_view right_path, char32_t separator) {
   if (!left_path.length()) {
     return std::string(right_path);
   } else if (!right_path.length()) {
@@ -495,31 +495,33 @@ std::string join_paths(const std::string_view left_path,
   auto [it, end] = make_criter(left_path);
 
   std::string result = std::string(left_path);
-  if (*it != static_cast<uint32_t>(sep)) {
-    utfcpp::append(sep, result);
+  if (*it != static_cast<uint32_t>(separator)) {
+    utfcpp::append(separator, result);
   }
   return result + std::string(right_path);
 }
 
-std::string join_paths(std::vector<std::string_view> paths, char32_t sep) {
+std::string join_paths(std::vector<std::string_view> paths,
+                       char32_t separator) {
   std::string result;
   auto it = paths.cbegin();
   if (it != paths.cend()) {
     result = *it++;
     for (; it != paths.cend(); ++it) {
-      result = join_paths(result, *it, sep);
+      result = join_paths(result, *it, separator);
     }
   }
   return result;
 }
 
-std::string fix_path_separators(const std::string_view path, char32_t new_sep) {
+std::string fix_path_separators(const std::string_view path,
+                                char32_t new_separator) {
   if (path.empty()) {
     return std::string();
   }
 
   // Swap all separators to new_sep.
-  const char32_t old_sep = new_sep == U'\\' ? U'/' : U'\\';
+  const char32_t old_separator = new_separator == U'\\' ? U'/' : U'\\';
 
   auto [path_begin, path_end] = make_citer(path);
 
@@ -527,7 +529,7 @@ std::string fix_path_separators(const std::string_view path, char32_t new_sep) {
   auto it = path_begin;
   auto last = it;
   for (;;) {
-    it = std::find(it, path_end, uint32_t(old_sep));
+    it = std::find(it, path_end, uint32_t(old_separator));
     if (it == path_end) {
       break;
     }
@@ -536,7 +538,7 @@ std::string fix_path_separators(const std::string_view path, char32_t new_sep) {
       auto offset = byte_length(path_begin, last);
       auto length = byte_length(path_begin, it) - offset;
       result += path.substr(offset, length);
-      utfcpp::append(new_sep, result);
+      utfcpp::append(new_separator, result);
     }
 
     ++it;
@@ -555,7 +557,8 @@ std::string fix_path_separators(const std::string_view path, char32_t new_sep) {
   return result;
 }
 
-std::string find_name_from_path(const std::string_view path, char32_t sep) {
+std::string find_name_from_path(const std::string_view path,
+                                char32_t separator) {
   if (path.empty()) {
     return std::string();
   }
@@ -564,7 +567,7 @@ std::string find_name_from_path(const std::string_view path, char32_t sep) {
 
   auto it = begin;
   size_t padding = 0;
-  if (*it == uint32_t(sep)) {
+  if (*it == uint32_t(separator)) {
     ++it;
     padding = 1;
   }
@@ -573,7 +576,7 @@ std::string find_name_from_path(const std::string_view path, char32_t sep) {
     return std::string();
   }
 
-  it = std::find(it, end, uint32_t(sep));
+  it = std::find(it, end, uint32_t(separator));
   if (it == end) {
     return std::string(path.substr(0, path.size() - padding));
   }
@@ -584,8 +587,8 @@ std::string find_name_from_path(const std::string_view path, char32_t sep) {
 }
 
 std::string find_base_name_from_path(const std::string_view path,
-                                     char32_t sep) {
-  auto name = find_name_from_path(path, sep);
+                                     char32_t separator) {
+  auto name = find_name_from_path(path, separator);
   if (!name.size()) {
     return std::string();
   }
@@ -606,7 +609,7 @@ std::string find_base_name_from_path(const std::string_view path,
   return std::string(name.substr(0, length));
 }
 
-std::string find_base_path(const std::string_view path, char32_t sep) {
+std::string find_base_path(const std::string_view path, char32_t separator) {
   if (path.empty()) {
     return std::string();
   }
@@ -614,11 +617,11 @@ std::string find_base_path(const std::string_view path, char32_t sep) {
   auto [begin, end] = make_criter(path);
 
   auto it = begin;
-  if (*it == uint32_t(sep)) {
+  if (*it == uint32_t(separator)) {
     ++it;
   }
 
-  it = std::find(it, end, uint32_t(sep));
+  it = std::find(it, end, uint32_t(separator));
   if (it == end) {
     return std::string();
   }
@@ -632,12 +635,12 @@ std::string find_base_path(const std::string_view path, char32_t sep) {
   return std::string(path.substr(0, length));
 }
 
-std::string canonicalize_path(const std::string_view path, char32_t sep) {
+std::string canonicalize_path(const std::string_view path, char32_t separator) {
   if (path.empty()) {
     return std::string();
   }
 
-  auto is_rooted = starts_with(path, sep);
+  auto is_rooted = starts_with(path, separator);
 
   auto parts = split_path(path);
   for (auto it = parts.begin(); it != parts.end();) {
@@ -659,8 +662,8 @@ std::string canonicalize_path(const std::string_view path, char32_t sep) {
     }
   }
 
-  return !is_rooted ? join_paths(parts, sep)
-                    : to_string(sep) + join_paths(parts, sep);
+  return !is_rooted ? join_paths(parts, separator)
+                    : to_string(separator) + join_paths(parts, separator);
 }
 
 }  // namespace xe::utf8

--- a/src/xenia/base/utf8.cc
+++ b/src/xenia/base/utf8.cc
@@ -500,8 +500,12 @@ std::string join_paths(const std::string_view left_path,
 
 std::string join_paths(std::vector<std::string_view> paths, char32_t sep) {
   std::string result;
-  for (const auto& path : paths) {
-    result = join_paths(result, path, sep);
+  auto it = paths.cbegin();
+  if (it != paths.cend()) {
+    result = *it++;
+    for (; it != paths.cend(); ++it) {
+      result = join_paths(result, *it, sep);
+    }
   }
   return result;
 }

--- a/src/xenia/base/utf8.cc
+++ b/src/xenia/base/utf8.cc
@@ -159,7 +159,8 @@ inline utf8_citer find_needle_case(utf8_citer haystack_it,
 }
 
 std::vector<std::string_view> split(const std::string_view haystack,
-                                    const std::string_view needles) {
+                                    const std::string_view needles,
+                                    bool remove_empty) {
   std::vector<std::string_view> result;
 
   auto [haystack_begin, haystack_end] = make_citer(haystack);
@@ -177,6 +178,8 @@ std::vector<std::string_view> split(const std::string_view haystack,
       auto offset = byte_length(haystack_begin, last);
       auto length = byte_length(haystack_begin, it) - offset;
       result.push_back(haystack.substr(offset, length));
+    } else if (!remove_empty) {
+      result.push_back("");
     }
 
     ++it;
@@ -478,7 +481,7 @@ bool ends_with_case(const std::string_view haystack,
 }
 
 std::vector<std::string_view> split_path(const std::string_view path) {
-  return split(path, u8"\\/");
+  return split(path, u8"\\/", true);
 }
 
 std::string join_paths(const std::string_view left_path,

--- a/src/xenia/base/utf8.h
+++ b/src/xenia/base/utf8.h
@@ -25,9 +25,9 @@ std::string upper_ascii(const std::string_view view);
 size_t hash_fnv1a(const std::string_view view);
 size_t hash_fnv1a_case(const std::string_view view);
 
-// Splits the given string on any delimiters and returns all parts.
-std::vector<std::string_view> split(const std::string_view path,
-                                    const std::string_view delimiters,
+// Splits the given haystack on any delimiters (needles) and returns all parts.
+std::vector<std::string_view> split(const std::string_view haystack,
+                                    const std::string_view needles,
                                     bool remove_empty = false);
 
 bool equal_z(const std::string_view left, const std::string_view right);
@@ -66,17 +66,17 @@ std::vector<std::string_view> split_path(const std::string_view path);
 // Joins two path segments with the given separator.
 std::string join_paths(const std::string_view left_path,
                        const std::string_view right_path,
-                       char32_t sep = kPathSeparator);
+                       char32_t separator = kPathSeparator);
 
 std::string join_paths(std::vector<std::string_view> paths,
-                       char32_t sep = kPathSeparator);
+                       char32_t separator = kPathSeparator);
 
 inline std::string join_paths(
     std::initializer_list<const std::string_view> paths,
-    char32_t sep = kPathSeparator) {
+    char32_t separator = kPathSeparator) {
   std::string result;
   for (auto path : paths) {
-    result = join_paths(result, path, sep);
+    result = join_paths(result, path, separator);
   }
   return result;
 }
@@ -98,7 +98,7 @@ inline std::string join_guest_paths(
 // Replaces all path separators with the given value and removes redundant
 // separators.
 std::string fix_path_separators(const std::string_view path,
-                                char32_t new_sep = kPathSeparator);
+                                char32_t new_separator = kPathSeparator);
 
 inline std::string fix_guest_path_separators(const std::string_view path) {
   return fix_path_separators(path, kGuestPathSeparator);
@@ -106,14 +106,14 @@ inline std::string fix_guest_path_separators(const std::string_view path) {
 
 // Find the top directory name or filename from a path.
 std::string find_name_from_path(const std::string_view path,
-                                char32_t sep = kPathSeparator);
+                                char32_t separator = kPathSeparator);
 
 inline std::string find_name_from_guest_path(const std::string_view path) {
   return find_name_from_path(path, kGuestPathSeparator);
 }
 
 std::string find_base_name_from_path(const std::string_view path,
-                                     char32_t sep = kPathSeparator);
+                                     char32_t separator = kPathSeparator);
 
 inline std::string find_base_name_from_guest_path(const std::string_view path) {
   return find_base_name_from_path(path, kGuestPathSeparator);
@@ -121,7 +121,7 @@ inline std::string find_base_name_from_guest_path(const std::string_view path) {
 
 // Get parent path of the given directory or filename.
 std::string find_base_path(const std::string_view path,
-                           char32_t sep = kPathSeparator);
+                           char32_t separator = kPathSeparator);
 
 inline std::string find_base_guest_path(const std::string_view path) {
   return find_base_path(path, kGuestPathSeparator);
@@ -129,7 +129,7 @@ inline std::string find_base_guest_path(const std::string_view path) {
 
 // Canonicalizes a path, removing ..'s.
 std::string canonicalize_path(const std::string_view path,
-                              char32_t sep = kPathSeparator);
+                              char32_t separator = kPathSeparator);
 
 inline std::string canonicalize_guest_path(const std::string_view path) {
   return canonicalize_path(path, kGuestPathSeparator);

--- a/src/xenia/base/utf8.h
+++ b/src/xenia/base/utf8.h
@@ -27,7 +27,8 @@ size_t hash_fnv1a_case(const std::string_view view);
 
 // Splits the given string on any delimiters and returns all parts.
 std::vector<std::string_view> split(const std::string_view path,
-                                    const std::string_view delimiters);
+                                    const std::string_view delimiters,
+                                    bool remove_empty = false);
 
 bool equal_z(const std::string_view left, const std::string_view right);
 

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -263,8 +263,8 @@ object_ref<XFile> XFile::Restore(KernelState* kernel_state,
   vfs::File* vfs_file = nullptr;
   vfs::FileAction action;
   auto res = kernel_state->file_system()->OpenFile(
-      abs_path, vfs::FileDisposition::kOpen, access, is_directory, &vfs_file,
-      &action);
+      nullptr, abs_path, vfs::FileDisposition::kOpen, access, is_directory,
+      &vfs_file, &action);
   if (XFAILED(res)) {
     XELOGE("Failed to open XFile: error {:08X}", res);
     return object_ref<XFile>(file);

--- a/src/xenia/vfs/devices/disc_image_device.cc
+++ b/src/xenia/vfs/devices/disc_image_device.cc
@@ -58,20 +58,8 @@ Entry* DiscImageDevice::ResolvePath(const std::string_view path) {
   // The filesystem will have stripped our prefix off already, so the path will
   // be in the form:
   // some\PATH.foo
-
   XELOGFS("DiscImageDevice::ResolvePath({})", path);
-
-  // Walk the path, one separator at a time.
-  auto entry = root_entry_.get();
-  for (const auto& part : xe::utf8::split_path(path)) {
-    entry = entry->GetChild(part);
-    if (!entry) {
-      // Not found.
-      return nullptr;
-    }
-  }
-
-  return entry;
+  return root_entry_->ResolvePath(path);
 }
 
 DiscImageDevice::Error DiscImageDevice::Verify(ParseState* state) {

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -53,21 +53,8 @@ Entry* HostPathDevice::ResolvePath(const std::string_view path) {
   // The filesystem will have stripped our prefix off already, so the path will
   // be in the form:
   // some\PATH.foo
-
   XELOGFS("HostPathDevice::ResolvePath({})", path);
-
-  // Walk the path, one separator at a time.
-  auto entry = root_entry_.get();
-  auto path_parts = xe::utf8::split_path(path);
-  for (auto& part : path_parts) {
-    entry = entry->GetChild(part);
-    if (!entry) {
-      // Not found.
-      return nullptr;
-    }
-  }
-
-  return entry;
+  return root_entry_->ResolvePath(path);
 }
 
 void HostPathDevice::PopulateEntry(HostPathEntry* parent_entry) {

--- a/src/xenia/vfs/devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/stfs_container_device.cc
@@ -165,21 +165,8 @@ Entry* StfsContainerDevice::ResolvePath(const std::string_view path) {
   // The filesystem will have stripped our prefix off already, so the path will
   // be in the form:
   // some\PATH.foo
-
   XELOGFS("StfsContainerDevice::ResolvePath({})", path);
-
-  // Walk the path, one separator at a time.
-  auto entry = root_entry_.get();
-  auto path_parts = xe::utf8::split_path(path);
-  for (auto& part : path_parts) {
-    entry = entry->GetChild(part);
-    if (!entry) {
-      // Not found.
-      return nullptr;
-    }
-  }
-
-  return entry;
+  return root_entry_->ResolvePath(path);
 }
 
 StfsContainerDevice::Error StfsContainerDevice::ReadPackageType(

--- a/src/xenia/vfs/entry.cc
+++ b/src/xenia/vfs/entry.cc
@@ -58,6 +58,19 @@ Entry* Entry::GetChild(const std::string_view name) {
   return (*it).get();
 }
 
+Entry* Entry::ResolvePath(const std::string_view path) {
+  // Walk the path, one separator at a time.
+  Entry* entry = this;
+  for (auto& part : xe::utf8::split_path(path)) {
+    entry = entry->GetChild(part);
+    if (!entry) {
+      // Not found.
+      return nullptr;
+    }
+  }
+  return entry;
+}
+
 Entry* Entry::IterateChildren(const xe::filesystem::WildcardEngine& engine,
                               size_t* current_index) {
   auto global_lock = global_critical_region_.Acquire();

--- a/src/xenia/vfs/entry.h
+++ b/src/xenia/vfs/entry.h
@@ -97,6 +97,7 @@ class Entry {
   bool is_read_only() const;
 
   Entry* GetChild(const std::string_view name);
+  Entry* ResolvePath(const std::string_view path);
 
   const std::vector<std::unique_ptr<Entry>>& children() const {
     return children_;

--- a/src/xenia/vfs/virtual_file_system.h
+++ b/src/xenia/vfs/virtual_file_system.h
@@ -37,12 +37,11 @@ class VirtualFileSystem {
   bool FindSymbolicLink(const std::string_view path, std::string& target);
 
   Entry* ResolvePath(const std::string_view path);
-  Entry* ResolveBasePath(const std::string_view path);
 
   Entry* CreatePath(const std::string_view path, uint32_t attributes);
   bool DeletePath(const std::string_view path);
 
-  X_STATUS OpenFile(const std::string_view path,
+  X_STATUS OpenFile(Entry* root_entry, const std::string_view path,
                     FileDisposition creation_disposition,
                     uint32_t desired_access, bool is_directory, File** out_file,
                     FileAction* out_action);


### PR DESCRIPTION
[Base] Fix canonicalize path for rooted paths.
[Base] Join paths better, so the first iteration isn't a join of an empty string with the first path part.
[Base] Add optional argument to allow empty parts in `utf8::split`.
[Base] Make utf8 arguments consistent. Fix `sep` to `separator`.
[VFS] Allow specifying root entry to open from with `OpenFile`.
[Kernel] `NtCreateFile` now opens from root entry when available instead of needlessly building a full path and resolving from that.
[VFS] Reduce code duplication by adding `Entry::ResolvePath`.
[VFS] Remove `ResolveBasePath` to avoid multiple calls to `find_base_guest_path`.