### PR TITLE
[Kernel/XAM] Implemented XamContentCreateInternal

### DIFF
--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -333,6 +333,16 @@ dword_result_t XamContentCreate(dword_t user_index, lpstring_t root_name,
 }
 DECLARE_XAM_EXPORT1(XamContentCreate, kContent, kImplemented);
 
+dword_result_t XamContentCreateInternal(
+    lpstring_t root_name, lpvoid_t content_data_ptr, dword_t flags,
+    lpdword_t disposition_ptr, lpdword_t license_mask_ptr, dword_t cache_size,
+    qword_t content_size, lpvoid_t overlapped_ptr) {
+  return XamContentCreateEx(0xFE, root_name, content_data_ptr, flags,
+                            disposition_ptr, license_mask_ptr, cache_size,
+                            content_size, overlapped_ptr);
+}
+DECLARE_XAM_EXPORT1(XamContentCreateInternal, kContent, kImplemented);
+
 dword_result_t XamContentOpenFile(dword_t user_index, lpstring_t root_name,
                                   lpstring_t path, dword_t flags,
                                   lpdword_t disposition_ptr,


### PR DESCRIPTION
Few games for some reason use XamContentCreateInternal for creating savefiles

XamContentCreateInternal vs XamContentCreateEx comparation:
(To see differences in function arguments)

``XamContentCreateInternal`` code:
```mr        r10, r26      # int
stw       r24, 0xB0+var_54(r1) # int
mr        r9, r27       # int
std       r25, 0xB0+var_60(r1) # __int64
mr        r8, r28       # int
mr        r7, r29       # int
li        r6, 0x200     # int
mr        r5, r31       # int
mr        r4, r30       # int
li        r3, 0xFE      # int
bl        sub_818BFBD8 
```

``XamContentCreateEx `` Code:
```lwz       r11, 0xB0+arg_54(r1)
mr        r10, r25      # int
mr        r9, r26       # int
std       r24, 0xB0+var_60(r1) # __int64
mr        r8, r27       # int
mr        r7, r28       # int
li        r6, 0x134     # int
mr        r5, r31       # int
stw       r11, 0xB0+var_54(r1) # int
mr        r4, r29       # int
mr        r3, r30       # int
bl        sub_818BFBD8
```

Both of them uses the same internal function, the only difference between them is lack of user_index (for internal it is hardcoded to 0xFE. Maybe it's like actual user or any user?) and different flags, but we don't care about them anyway.

# Benefits
This allows some EA games to create savefiles (e.g Fifa series), however there is still bug somewhere else that causes first save creation to fail (probably OpenFile functionNtWriteFile function as it doesn't support async write and is_synchronous() returns false), but I don't want to mix different things in PR. (according to the rule: one PR, one thing)