### PR TITLE
[GPU] Add workaround for occlusion queries.

### DIFF
--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -27,3 +27,10 @@ DEFINE_bool(
     "may be used to bypass fetch constant type errors in certain games until "
     "the real reason why they're invalid is found.",
     "GPU");
+
+DEFINE_int32(query_occlusion_fake_sample_count, 1000,
+             "If set to -1 no sample counts are written, games may hang. Else, "
+             "the sample count of every tile will be incremented on every "
+             "EVENT_WRITE_ZPD by this number. Setting this to 0 means "
+             "everything is reported as occluded.",
+             "GPU");

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -20,4 +20,6 @@ DECLARE_bool(vsync);
 
 DECLARE_bool(gpu_allow_invalid_fetch_constants);
 
+DECLARE_int32(query_occlusion_fake_sample_count);
+
 #endif  // XENIA_GPU_GPU_FLAGS_H_

--- a/src/xenia/gpu/xenos.h
+++ b/src/xenia/gpu/xenos.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2020 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -847,6 +847,20 @@ XEPACKEDUNION(xe_gpu_memexport_stream_t, {
     uint32_t dword_2;
     uint32_t dword_3;
   });
+});
+
+XEPACKEDSTRUCT(xe_gpu_depth_sample_counts, {
+  // This is little endian as it is swapped in D3D code.
+  // Corresponding A and B values are summed up by D3D.
+  // Occlusion there is calculated by substracting begin from end struct.
+  uint32_t Total_A;
+  uint32_t Total_B;
+  uint32_t ZFail_A;
+  uint32_t ZFail_B;
+  uint32_t ZPass_A;
+  uint32_t ZPass_B;
+  uint32_t StencilFail_A;
+  uint32_t StencilFail_B;
 });
 
 // Enum of event values used for VGT_EVENT_INITIATOR


### PR DESCRIPTION
Writes some fake data in response to occlusion queries.
cvar `query_occlusion_fake_sample_count` was added which determines the sample count that is reported as passed. This is set to 1000 at default since games which use occlusion culling become basically useless with 0 (everything occluded).
This should affect many games but most importantly allows Unreal Engine games to run since they block infinitely on query results.