### PR TITLE
[ImGui] Fix context initialization.

### DIFF
--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -41,6 +41,7 @@ void ImGuiDrawer::Initialize() {
   // Setup ImGui internal state.
   // This will give us state we can swap to the ImGui globals when in use.
   internal_state_ = ImGui::CreateContext();
+  ImGui::SetCurrentContext(internal_state_);
 
   auto& io = ImGui::GetIO();
 


### PR DESCRIPTION
Every context after the first wasn't initialized properly.
So things like special keys (e.g. enter) where not working in any other window than the main window.