### PR TITLE
[Base] Wrap to_utf functions with try catch block

### DIFF
--- a/src/xenia/base/string.cc
+++ b/src/xenia/base/string.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/base/string.h"
+#include "xenia/base/logging.h"
 
 #include <algorithm>
 #include <locale>
@@ -20,11 +21,16 @@ namespace utfcpp = utf8;
 namespace xe {
 
 std::string to_utf8(const std::u16string_view source) {
-  return utfcpp::utf16to8(source);
+  try {
+    return utfcpp::utf16to8(source);
+  } catch (const utfcpp::invalid_utf16& e) {
+    XELOGW("Invalid to_utf8 conversion: {} - {:04X}", e.what(), e.utf16_word());
+    return std::string();
+  }
 }
 
 std::u16string to_utf16(const std::string_view source) {
-  return utfcpp::utf8to16(source);
+  return utfcpp::utf8to16(utfcpp::replace_invalid(source));
 }
 
 }  // namespace xe


### PR DESCRIPTION
Right now some games due to poor or even garbage thread naming (looking at shadowrun) likes to crash on utf conversion.

I wrapped that function around try-catch block to prevent such situation.

However I'm not sure if returning empty string is good idea and what about broken paths?

Also I was thinking about adding some log message just in case