### PR TITLE
[Kernel] Implemented NtQueueApcThread

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -970,12 +970,24 @@ void KfLowerIrql(dword_t old_value) {
 DECLARE_XBOXKRNL_EXPORT2(KfLowerIrql, kThreading, kImplemented, kHighFrequency);
 
 void NtQueueApcThread(dword_t thread_handle, lpvoid_t apc_routine,
-                      lpvoid_t arg1, lpvoid_t arg2, lpvoid_t arg3) {
-  // Alloc APC object (from somewhere) and insert.
+                      lpvoid_t apc_routine_context, lpvoid_t arg1,
+                      lpvoid_t arg2) {
+  auto thread =
+      kernel_state()->object_table()->LookupObject<XThread>(thread_handle);
 
-  assert_always("not implemented");
+  if (!thread) {
+    XELOGE("NtQueueApcThread: Incorrect thread handle! Might cause crash");
+    return;
+  }
+
+  if (!apc_routine) {
+    XELOGE("NtQueueApcThread: Incorrect apc routine! Might cause crash");
+    return;
+  }
+
+  thread->EnqueueApc(apc_routine, apc_routine_context, arg1, arg2);
 }
-// DECLARE_XBOXKRNL_EXPORT1(NtQueueApcThread, kThreading, kStub);
+DECLARE_XBOXKRNL_EXPORT1(NtQueueApcThread, kThreading, kImplemented);
 
 void KeInitializeApc(pointer_t<XAPC> apc, lpvoid_t thread_ptr,
                      lpvoid_t kernel_routine, lpvoid_t rundown_routine,


### PR DESCRIPTION
### Overview:

Based on description on this site: [link](http://undocumented.ntinternals.net/index.html?page=UserMode%2FUndocumented%20Functions%2FAPC%2FNtQueueApcThread.html)


> Function adds user defined routine to thread's APC queue. This routine will be executed when thread will be signaled.

I've found that we have function that does exactly "that" which is called: `EnqueueApc`.
I also added some stuff to log, but we might talk about if it is really required here.

### Benefits:
I tested it on SW:TFU and instead of stucking on loading it goes ingame and work quite nicely.



