### PR TITLE
[Kernel/XAM] Fixes to resource locator

### DIFF
--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -113,7 +113,7 @@ dword_result_t keXamBuildResourceLocator(uint64_t module,
                                          uint32_t buffer_count) {
   std::u16string path;
   if (!module) {
-    path = fmt::format(u"file://media:/{0}.xzp#{0}", container, resource);
+    path = fmt::format(u"file://media:/{}.xzp#{}", container, resource);
     XELOGD(
         "XamBuildResourceLocator({0}) returning locator to local file {0}.xzp",
         xe::to_utf8(container));

--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -123,6 +123,8 @@ dword_result_t keXamBuildResourceLocator(uint64_t module,
   }
   auto copy_count = std::min(size_t(buffer_count), path.size());
   xe::copy_and_swap(buffer_ptr.as<char16_t*>(), path.c_str(), copy_count);
+  (buffer_ptr.as<char16_t*>())[copy_count] = 0;
+
   return 0;
 }
 


### PR DESCRIPTION
<blank due to reasons, ok I have nothing to write or describe here> 

I skipped checking for buffer_count size as it is used only in dashboard.