### PR TITLE
Invalid launch options no longer cause Xenia to exit silently

### DIFF
--- a/src/xenia/base/cvar.cc
+++ b/src/xenia/base/cvar.cc
@@ -14,6 +14,9 @@
 #define UTF_CPP_CPLUSPLUS 201703L
 #include "third_party/utfcpp/source/utf8.h"
 
+#include "xenia/base/logging.h"
+#include "xenia/base/main.h"
+
 namespace utfcpp = utf8;
 
 using u8_citer = utfcpp::iterator<std::string_view::const_iterator>;
@@ -61,7 +64,12 @@ void ParseLaunchArguments(int& argc, char**& argv,
 
     auto result = options.parse(argc, argv);
     if (result.count("help")) {
-      PrintHelpAndExit();
+      if (xe::has_console_attached()) {
+        PrintHelpAndExit();
+      } else {
+        xe::ShowInfoMessageBox(options.help({""}));
+        exit(0);
+      }
     }
 
     for (auto& it : *CmdVars) {
@@ -78,8 +86,15 @@ void ParseLaunchArguments(int& argc, char**& argv,
       }
     }
   } catch (const cxxopts::OptionException& e) {
-    std::cout << e.what() << std::endl;
-    PrintHelpAndExit();
+    if (xe::has_console_attached()) {
+      std::cout << e.what() << std::endl;
+      PrintHelpAndExit();
+    } else {
+      std::string m =
+          "Invalid launch options were given.\n" + options.help({""});
+      xe::ShowErrorMessageBox(m);
+      exit(0);
+    }
   }
 }
 

--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -363,4 +363,18 @@ void FatalError(const std::string_view str) {
   std::exit(1);
 }
 
+void ShowInfoMessageBox(std::string m) {
+#if XE_PLATFORM_WIN32
+  MessageBoxW(NULL, (LPCWSTR)xe::to_utf16(m).c_str(), L"Xenia Help",
+              MB_OK | MB_ICONINFORMATION | MB_APPLMODAL | MB_SETFOREGROUND);
+#endif  // WIN32
+}
+
+void ShowErrorMessageBox(std::string m) {
+#if XE_PLATFORM_WIN32
+  MessageBoxW(NULL, (LPCWSTR)xe::path_to_utf16(m).c_str(), L"Xenia Error",
+              MB_OK | MB_ICONERROR | MB_APPLMODAL | MB_SETFOREGROUND);
+#endif  // WIN32
+}
+
 }  // namespace xe

--- a/src/xenia/base/logging.h
+++ b/src/xenia/base/logging.h
@@ -95,6 +95,11 @@ void AppendLogLine(LogLevel log_level, const char prefix_char,
 // Logs a fatal error and aborts the program.
 void FatalError(const std::string_view str);
 
+// Shows error box
+void ShowErrorMessageBox(std::string m);
+
+// Show info box
+void ShowInfoMessageBox(std::string m);
 }  // namespace xe
 
 #if XE_OPTION_ENABLE_LOGGING

--- a/src/xenia/base/main_win.cc
+++ b/src/xenia/base/main_win.cc
@@ -38,8 +38,26 @@ bool has_console_attached_ = true;
 
 bool has_console_attached() { return has_console_attached_; }
 
+bool has_shell_environment_variable() {
+  size_t size = 0;
+  // Check if SHELL exists
+  // If it doesn't, then we are in a Windows Terminal
+  auto error = getenv_s(&size, nullptr, 0, "SHELL");
+  if (error) {
+    return false;
+  }
+  return !!size;
+}
+
 void AttachConsole() {
   if (!cvars::enable_console) {
+    return;
+  }
+
+  bool has_console = ::AttachConsole(ATTACH_PARENT_PROCESS) == TRUE;
+  if (!has_console || !has_shell_environment_variable()) {
+    // We weren't launched from a console, so just return.
+    has_console_attached_ = false;
     return;
   }
 


### PR DESCRIPTION
This pull request aims to fix issue #1445  .  The cause of this issue is that the PrintHelpAndExit function was only writing to stdout out instead of notifying the user via a Message Box or something similar. 

This function gets called under two circumstances.

1.) The user gave the --help argument to Xenia. 
2.) The user gave invalid launch options to Xenia.

In order to differentiate between these cases, a boolean was added as an input to the function. This allowed me to put in a different message box for each of these cases. The --help message box displays the usage information, and the invalid argument message box tells the user that they gave invalid launch options then displays the usage information. 

![image](https://user-images.githubusercontent.com/11417992/88491965-1fceef00-cf75-11ea-8394-3b5f746abe11.png)

![image](https://user-images.githubusercontent.com/11417992/88491990-4ee56080-cf75-11ea-840d-cdc168b5d3f3.png)

This is my first pull request to this project, so hopefully everything follows the contribution guidelines. I tried to be careful, but please let me know if I did something wrong.



 