### PR TITLE
[Kernel/Thread] Changed default stack location

### DIFF
--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -226,7 +226,7 @@ void XThread::InitializeGuestObject() {
 }
 
 bool XThread::AllocateStack(uint32_t size) {
-  auto heap = memory()->LookupHeap(0x40000000);
+  auto heap = memory()->LookupHeap(kStackAddressRangeBegin);
 
   auto alignment = heap->page_size();
   auto padding = heap->page_size() * 2;  // Guard page size * 2
@@ -234,10 +234,10 @@ bool XThread::AllocateStack(uint32_t size) {
   auto actual_size = size + padding;
 
   uint32_t address = 0;
-  if (!heap->AllocRange(0x40000000, 0x7F000000, actual_size, alignment,
-                        kMemoryAllocationReserve | kMemoryAllocationCommit,
-                        kMemoryProtectRead | kMemoryProtectWrite, false,
-                        &address)) {
+  if (!heap->AllocRange(
+          kStackAddressRangeBegin, kStackAddressRangeEnd, actual_size,
+          alignment, kMemoryAllocationReserve | kMemoryAllocationCommit,
+          kMemoryProtectRead | kMemoryProtectWrite, false, &address)) {
     return false;
   }
 
@@ -258,7 +258,7 @@ bool XThread::AllocateStack(uint32_t size) {
 
 void XThread::FreeStack() {
   if (stack_alloc_base_) {
-    auto heap = memory()->LookupHeap(0x40000000);
+    auto heap = memory()->LookupHeap(kStackAddressRangeBegin);
     heap->Release(stack_alloc_base_);
 
     stack_alloc_base_ = 0;

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -145,6 +145,9 @@ class XThread : public XObject, public cpu::Thread {
  public:
   static const XObject::Type kObjectType = XObject::Type::Thread;
 
+  static constexpr uint32_t kStackAddressRangeBegin = 0x70000000;
+  static constexpr uint32_t kStackAddressRangeEnd = 0x7F000000;
+
   struct CreationParams {
     uint32_t stack_size;
     uint32_t xapi_thread_startup;


### PR DESCRIPTION
<Naming still to decide, suggestions are welcome 🐑 >

### TL;DR

It seems like actual thread stack allocation location is not valid

### Nier Case
After spending a while why it fixed Nier it seems like Nier overwrites actual thread stack space with it's own data.

I spent while checking if it affects other games (around 30+ titles). It looks like it's not, but as we can see some games might be affected.