### PR TITLE
[Kernel/IO] Return error when creating directory with non-directory flag in NtCreateFile

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -142,7 +142,8 @@ dword_result_t NtCreateFile(lpdword_t handle_out, dword_t desired_access,
   X_STATUS result = kernel_state()->file_system()->OpenFile(
       root_entry, target_path,
       vfs::FileDisposition((uint32_t)creation_disposition), desired_access,
-      (create_options & CreateOptions::FILE_DIRECTORY_FILE) != 0, &vfs_file,
+      (create_options & CreateOptions::FILE_DIRECTORY_FILE) != 0,
+      (create_options & CreateOptions::FILE_NON_DIRECTORY_FILE) != 0, &vfs_file,
       &file_action);
   object_ref<XFile> file = nullptr;
 

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -266,7 +266,7 @@ object_ref<XFile> XFile::Restore(KernelState* kernel_state,
   vfs::FileAction action;
   auto res = kernel_state->file_system()->OpenFile(
       nullptr, abs_path, vfs::FileDisposition::kOpen, access, is_directory,
-      &vfs_file, &action);
+      false, &vfs_file, &action);
   if (XFAILED(res)) {
     XELOGE("Failed to open XFile: error {:08X}", res);
     return object_ref<XFile>(file);

--- a/src/xenia/vfs/virtual_file_system.cc
+++ b/src/xenia/vfs/virtual_file_system.cc
@@ -172,7 +172,8 @@ X_STATUS VirtualFileSystem::OpenFile(Entry* root_entry,
                                      const std::string_view path,
                                      FileDisposition creation_disposition,
                                      uint32_t desired_access, bool is_directory,
-                                     File** out_file, FileAction* out_action) {
+                                     bool is_non_directory, File** out_file,
+                                     FileAction* out_action) {
   // TODO(gibbed): should 'is_directory' remain as a bool or should it be
   // flipped to a generic FileAttributeFlags?
 
@@ -205,6 +206,12 @@ X_STATUS VirtualFileSystem::OpenFile(Entry* root_entry,
     entry = parent_entry->GetChild(file_name);
   } else {
     entry = !root_entry ? ResolvePath(path) : root_entry->GetChild(path);
+  }
+
+  if (entry) {
+    if (entry->attributes() & kFileAttributeDirectory && is_non_directory) {
+      return X_STATUS_FILE_IS_A_DIRECTORY;
+    }
   }
 
   // Check if exists (if we need it to), or that it doesn't (if it shouldn't).

--- a/src/xenia/vfs/virtual_file_system.h
+++ b/src/xenia/vfs/virtual_file_system.h
@@ -43,7 +43,8 @@ class VirtualFileSystem {
 
   X_STATUS OpenFile(Entry* root_entry, const std::string_view path,
                     FileDisposition creation_disposition,
-                    uint32_t desired_access, bool is_directory, File** out_file,
+                    uint32_t desired_access, bool is_directory,
+                    bool is_non_directory, File** out_file,
                     FileAction* out_action);
 
  private:

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -64,6 +64,7 @@ typedef uint32_t X_STATUS;
 #define X_STATUS_PROCEDURE_NOT_FOUND                    ((X_STATUS)0xC000007AL)
 #define X_STATUS_INSUFFICIENT_RESOURCES                 ((X_STATUS)0xC000009AL)
 #define X_STATUS_MEMORY_NOT_ALLOCATED                   ((X_STATUS)0xC00000A0L)
+#define X_STATUS_FILE_IS_A_DIRECTORY                    ((X_STATUS)0xC00000BAL)
 #define X_STATUS_NOT_SUPPORTED                          ((X_STATUS)0xC00000BBL)
 #define X_STATUS_INVALID_PARAMETER_1                    ((X_STATUS)0xC00000EFL)
 #define X_STATUS_INVALID_PARAMETER_2                    ((X_STATUS)0xC00000F0L)


### PR DESCRIPTION
Different title suggestions will be appreciated 👍 

I found out that fifa 07 tries to do this:

```
d> 00000028 NtOpenFile(7018F590(00000000), 00100001, 7018F5B0(FFFFFFFD,D:\,00000040), 7018F5A8, 00000003)
.
.
.
d> 00000088 RtlInitAnsiString(701EF8E8, 701EF990(D:\))
d> 00000088 NtCreateFile(701EF8E0(FFFFFFFF), 80100080, 701EF8F8(FFFFFFFD,D:\,00000040), 701EF8F0, 00000000, 00000080, 00000001, 00000001, 00000060)

```

For the first case it's fine it should return 0, but for second not so fast. 
It receives only D:\ (checked also during debugging) as a target_path without any file name with flag 0x40 (FILE_NON_DIRECTORY_FILE)

In such case we should return X_STATUS_FILE_IS_A_DIRECTORY instead of 0.