### PR TITLE
[Kernel/Memory] Restrict Nt<whatever>VirtualMemory only to virtual memory range

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
@@ -101,6 +101,9 @@ dword_result_t NtAllocateVirtualMemory(lpdword_t base_addr_ptr,
   if (*base_addr_ptr != 0) {
     // ignore specified page size when base address is specified.
     auto heap = kernel_memory()->LookupHeap(*base_addr_ptr);
+    if (heap->heap_type() != HeapType::kGuestVirtual) {
+      return X_STATUS_INVALID_PARAMETER;
+    }
     page_size = heap->page_size();
   } else {
     // Adjust size.
@@ -192,7 +195,9 @@ dword_result_t NtProtectVirtualMemory(lpdword_t base_addr_ptr,
   }
 
   auto heap = kernel_memory()->LookupHeap(*base_addr_ptr);
-
+  if (heap->heap_type() != HeapType::kGuestVirtual) {
+    return X_STATUS_INVALID_PARAMETER;
+  }
   // Adjust the base downwards to the nearest page boundary.
   uint32_t adjusted_base =
       *base_addr_ptr - (*base_addr_ptr % heap->page_size());
@@ -240,6 +245,9 @@ dword_result_t NtFreeVirtualMemory(lpdword_t base_addr_ptr,
   }
 
   auto heap = kernel_state()->memory()->LookupHeap(base_addr_value);
+  if (heap->heap_type() != HeapType::kGuestVirtual) {
+    return X_STATUS_INVALID_PARAMETER;
+  }
   bool result = false;
   if (free_type == X_MEM_DECOMMIT) {
     // If zero, we may need to query size (free whole region).

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -122,14 +122,14 @@ X_STATUS XFile::Read(uint32_t buffer_guest_address, uint32_t buffer_length,
       const xe::BaseHeap* buffer_end_heap =
           memory()->LookupHeap(buffer_guest_high_address);
       if (!buffer_start_heap || !buffer_end_heap ||
-          buffer_start_heap->IsGuestPhysicalHeap() !=
-              buffer_end_heap->IsGuestPhysicalHeap() ||
-          (buffer_start_heap->IsGuestPhysicalHeap() &&
+          (buffer_start_heap->heap_type() == HeapType::kGuestPhysical) !=
+              (buffer_end_heap->heap_type() == HeapType::kGuestPhysical) ||
+          (buffer_start_heap->heap_type() == HeapType::kGuestPhysical &&
            buffer_start_heap != buffer_end_heap)) {
         result = X_STATUS_ACCESS_VIOLATION;
       } else {
         xe::PhysicalHeap* buffer_physical_heap =
-            buffer_start_heap->IsGuestPhysicalHeap()
+            buffer_start_heap->heap_type() == HeapType::kGuestPhysical
                 ? static_cast<xe::PhysicalHeap*>(buffer_start_heap)
                 : nullptr;
         if (buffer_physical_heap &&

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -376,7 +376,7 @@ uint32_t Memory::HostToGuestVirtualThunk(const void* context,
 
 uint32_t Memory::GetPhysicalAddress(uint32_t address) const {
   const BaseHeap* heap = LookupHeap(address);
-  if (!heap || !heap->IsGuestPhysicalHeap()) {
+  if (!heap || heap->heap_type() != HeapType::kGuestPhysical) {
     return UINT32_MAX;
   }
   return static_cast<const PhysicalHeap*>(heap)->GetPhysicalAddress(address);
@@ -452,7 +452,7 @@ bool Memory::AccessViolationCallback(
   }
   uint32_t virtual_address = HostToGuestVirtual(host_address);
   BaseHeap* heap = LookupHeap(virtual_address);
-  if (!heap->IsGuestPhysicalHeap()) {
+  if (heap->heap_type() != HeapType::kGuestPhysical) {
     return false;
   }
 
@@ -478,7 +478,7 @@ bool Memory::TriggerPhysicalMemoryCallbacks(
     uint32_t virtual_address, uint32_t length, bool is_write,
     bool unwatch_exact_range, bool unprotect) {
   BaseHeap* heap = LookupHeap(virtual_address);
-  if (heap->IsGuestPhysicalHeap()) {
+  if (heap->heap_type() == HeapType::kGuestPhysical) {
     auto physical_heap = static_cast<PhysicalHeap*>(heap);
     return physical_heap->TriggerCallbacks(std::move(global_lock_locked_once),
                                            virtual_address, length, is_write,

--- a/src/xenia/memory.h
+++ b/src/xenia/memory.h
@@ -187,9 +187,6 @@ class BaseHeap {
   xe::memory::PageAccess QueryRangeAccess(uint32_t low_address,
                                           uint32_t high_address);
 
-  // Whether the heap is a guest virtual memory mapping of the physical memory.
-  virtual bool IsGuestPhysicalHeap() const { return false; }
-
   bool Save(ByteStream* stream);
   bool Restore(ByteStream* stream);
 
@@ -264,7 +261,6 @@ class PhysicalHeap : public BaseHeap {
       uint32_t virtual_address, uint32_t length, bool is_write,
       bool unwatch_exact_range, bool unprotect = true);
 
-  bool IsGuestPhysicalHeap() const override { return true; }
   uint32_t GetPhysicalAddress(uint32_t address) const;
 
  protected:

--- a/src/xenia/memory.h
+++ b/src/xenia/memory.h
@@ -36,6 +36,13 @@ enum SystemHeapFlag : uint32_t {
   kSystemHeapDefault = kSystemHeapVirtual,
 };
 
+enum class HeapType : uint8_t {
+  kGuestVirtual,
+  kGuestXex,
+  kGuestPhysical,
+  kHostPhysical,
+};
+
 enum MemoryAllocationFlag : uint32_t {
   kMemoryAllocationReserve = 1 << 0,
   kMemoryAllocationCommit = 1 << 1,
@@ -105,6 +112,9 @@ class BaseHeap {
 
   // Size of each page within the heap range in bytes.
   uint32_t page_size() const { return page_size_; }
+
+  // Type of specified heap
+  HeapType heap_type() const { return heap_type_; }
 
   // Offset added to the virtual addresses to convert them to host addresses
   // (not including membase).
@@ -188,12 +198,13 @@ class BaseHeap {
  protected:
   BaseHeap();
 
-  void Initialize(Memory* memory, uint8_t* membase, uint32_t heap_base,
-                  uint32_t heap_size, uint32_t page_size,
+  void Initialize(Memory* memory, uint8_t* membase, HeapType heap_type,
+                  uint32_t heap_base, uint32_t heap_size, uint32_t page_size,
                   uint32_t host_address_offset = 0);
 
   Memory* memory_;
   uint8_t* membase_;
+  HeapType heap_type_;
   uint32_t heap_base_;
   uint32_t heap_size_;
   uint32_t page_size_;
@@ -209,8 +220,8 @@ class VirtualHeap : public BaseHeap {
   ~VirtualHeap() override;
 
   // Initializes the heap properties and allocates the page table.
-  void Initialize(Memory* memory, uint8_t* membase, uint32_t heap_base,
-                  uint32_t heap_size, uint32_t page_size);
+  void Initialize(Memory* memory, uint8_t* membase, HeapType heap_type,
+                  uint32_t heap_base, uint32_t heap_size, uint32_t page_size);
 };
 
 // A heap for ranges of memory that are mapped to physical ranges.
@@ -226,8 +237,8 @@ class PhysicalHeap : public BaseHeap {
   ~PhysicalHeap() override;
 
   // Initializes the heap properties and allocates the page table.
-  void Initialize(Memory* memory, uint8_t* membase, uint32_t heap_base,
-                  uint32_t heap_size, uint32_t page_size,
+  void Initialize(Memory* memory, uint8_t* membase, HeapType heap_type,
+                  uint32_t heap_base, uint32_t heap_size, uint32_t page_size,
                   VirtualHeap* parent_heap);
 
   bool Alloc(uint32_t size, uint32_t alignment, uint32_t allocation_type,


### PR DESCRIPTION
TL;DR

NtAllocateVirtualMemory, NtFreeVirtualMemory and NtProtectVirtualMemory shouldn't be able to allocate memory over physical or xex range.

I'm making it as draft for future updates (switch from hardcoded value into some const etc)

<This PR is for testing purposes right now.>

Affected titles (positive):
- Stormrise
- London 2012
- Dead or Alive 4

Affected titles (negative):
-TBD