### PR TITLE
Fix xenia.log file not always being created in the executable folder.

### DIFF
--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -79,8 +79,7 @@ class Logger {
     if (cvars::log_file.empty()) {
       // Default to app name.
       auto file_name = fmt::format("{}.log", app_name);
-      auto file_path = std::filesystem::path(file_name);
-      xe::filesystem::CreateParentFolder(file_path);
+      auto file_path = xe::filesystem::GetExecutableFolder() / file_name;
       file_ = xe::filesystem::OpenFile(file_path, "wt");
     } else {
       if (cvars::log_file == "stdout") {


### PR DESCRIPTION
When launching xenia from the command line, and your current working directory was not the xenia directory, the log file would be created in your current working directory instead of the executable folder.

For example: 

![image](https://user-images.githubusercontent.com/1125884/90966572-0b2e3a00-e4d4-11ea-8ea0-c74726279065.png)


This pullrequest fixes that, and creates the log file in the executable folder (unless the user manually specified a log file location of course)