### PR TITLE
[Kernel/Object] Added base to object handle

### DIFF
--- a/src/xenia/kernel/util/object_table.h
+++ b/src/xenia/kernel/util/object_table.h
@@ -92,6 +92,9 @@ class ObjectTable {
                         std::vector<object_ref<XObject>>* results);
 
   X_HANDLE TranslateHandle(X_HANDLE handle);
+  static constexpr uint32_t GetHandleSlot(X_HANDLE handle) {
+    return (handle - XObject::kHandleBase) >> 2;
+  }
   X_STATUS FindFreeSlot(uint32_t* out_slot);
   bool Resize(uint32_t new_capacity);
 

--- a/src/xenia/kernel/xobject.h
+++ b/src/xenia/kernel/xobject.h
@@ -109,6 +109,13 @@ struct X_OBJECT_TYPE {
 
 class XObject {
  public:
+  // Burnout Paradise needs proper handle value for certain calculations
+  // It gets handle value from TLS (without base handle value is 0x88)
+  // and substract 0xF8000088. Without base we're receiving wrong address
+  // Instead of receiving address that starts with 0x82... we're receiving
+  // one with 0x8A... which causes crash
+  static constexpr uint32_t kHandleBase = 0xF8000000;
+
   enum Type {
     kTypeUndefined,
     kTypeEnumerator,


### PR DESCRIPTION
In first versions of Burnout Paradise there is code that rely on correct handle value.


![image](https://user-images.githubusercontent.com/153369/91631852-18b85800-e9dd-11ea-9ba3-2c85d511eba8.png)

uVar1 is handle to the thread that is stored via Tls.

If you calculate with actual values it looks like we're off to incorrect memory space (around 0x8A, but we should be at 0x82...)

Affected Titles:
- Burnout Paradise v1.0 (including demo)