### PR TITLE
[Kernel/XAM] Allow sharing xam_info.cc functions between many xam files

### DIFF
--- a/src/xenia/kernel/xam/xam_info.h
+++ b/src/xenia/kernel/xam/xam_info.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "xenia/kernel/kernel_state.h"
+#include "xenia/kernel/util/shim_utils.h"
+#include "xenia/kernel/xam/xam_private.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+dword_result_t XamCreateEnumeratorHandle(unknown_t unk1, unknown_t unk2,
+                                         unknown_t unk3, unknown_t unk4,
+                                         unknown_t unk5, unknown_t unk6,
+                                         unknown_t unk7, unknown_t unk8);
+
+dword_result_t XamGetPrivateEnumStructureFromHandle(unknown_t unk1,
+                                                    unknown_t unk2);
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe


### PR DESCRIPTION
This file can be used to provide support for xam functions that are used frequently between different xam functions.

I already pasted:
``XamCreateEnumeratorHandle``
``XamGetPrivateEnumStructureFromHandle``

as I know they're used between few XAM functions (related to enumerators) and almost implemented them locally.

Feel free to suggest any improvements/changes 💃 