### PR TITLE
[Kernel/Thread] Added missing paramteter to KeSetAffinityThread

### DIFF
--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -88,7 +88,8 @@ struct X_KTHREAD {
   char unk_10[0xAC];             // 0x10
   uint8_t suspend_count;         // 0xBC
   uint8_t unk_BD;                // 0xBD
-  uint16_t unk_BE;               // 0xBE
+  uint8_t unk_BE;                // 0xBE
+  uint8_t current_cpu;           // 0xBF
   char unk_C0[0x70];             // 0xC0
   xe::be<uint64_t> create_time;  // 0x130
   xe::be<uint64_t> exit_time;    // 0x138
@@ -165,7 +166,6 @@ class XThread : public XObject, public cpu::Thread {
   int32_t priority() const { return priority_; }
   int32_t QueryPriority();
   void SetPriority(int32_t increment);
-  uint32_t affinity() const { return affinity_; }
   void SetAffinity(uint32_t affinity);
   uint32_t active_cpu() const;
   void SetActiveCpu(uint32_t cpu_index);
@@ -220,7 +220,6 @@ class XThread : public XObject, public cpu::Thread {
   bool running_ = false;
 
   int32_t priority_ = 0;
-  uint32_t affinity_ = 0;
 
   xe::global_critical_region global_critical_region_;
   std::atomic<uint32_t> irql_ = {0};


### PR DESCRIPTION
I found out that ``KeSetAffinityThread`` have optional parameter. I called it ``affinity_ptr``, but feel free to provide better name 

![image](https://user-images.githubusercontent.com/153369/94369798-2a7c4080-00ec-11eb-9668-a4cc86d4b8a3.png)

Here we can see few things.
1. Param2 must be lower than 6 (cpu_core?)
2. KeSetAffinityThread have 3 parameters (3rd is a pointer)
3. Output of that function depends on value under 3rd parameter.



These 2 fragments are usages of that function above. We can see that second argument is check on input and output and that parameter is used as affinity (to be precise: 1 << param2)
![image](https://user-images.githubusercontent.com/153369/94369806-3405a880-00ec-11eb-96e3-998bb29a6f6f.png)
![image](https://user-images.githubusercontent.com/153369/94369812-3bc54d00-00ec-11eb-8525-22c97ca3e320.png)
