### PR TITLE
[APU/XMA] Invalidate output buffer when there is no valid input buffer

### DIFF
--- a/src/xenia/apu/xma_context.cc
+++ b/src/xenia/apu/xma_context.cc
@@ -302,6 +302,7 @@ void XmaContext::DecodePackets(XMA_CONTEXT_DATA* data) {
 
   // No available data.
   if (!data->input_buffer_0_valid && !data->input_buffer_1_valid) {
+    data->output_buffer_valid = 0;
     return;
   }
 


### PR DESCRIPTION
It seems like setting output buffer to invalid when there is no valid input buffers resolves annoying bug, when games freezes if sound gets corrupted.

Now instead of freezing, games can correctly playback sounds or skips for like 125ms or less.
