### PR TITLE
[Kernel] Implemented ExLoadedImageName

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -316,6 +316,17 @@ void KernelState::SetExecutableModule(object_ref<UserModule> module) {
     *variable_ptr = executable_module_->hmodule_ptr();
   }
 
+  // Setup the kernel's ExLoadedImageName field
+  export_entry = processor()->export_resolver()->GetExportByOrdinal(
+      "xboxkrnl.exe", ordinals::ExLoadedImageName);
+
+  if (export_entry) {
+    char* variable_ptr =
+        memory()->TranslateVirtual<char*>(export_entry->variable_ptr);
+    xe::string_util::copy_truncating(
+        variable_ptr, executable_module_->path(),
+        xboxkrnl::XboxkrnlModule::kExLoadedImageNameSize);
+  }
   // Spin up deferred dispatch worker.
   // TODO(benvanik): move someplace more appropriate (out of ctor, but around
   // here).

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_module.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_module.cc
@@ -189,6 +189,16 @@ XboxkrnlModule::XboxkrnlModule(Emulator* emulator, KernelState* kernel_state)
                                        ordinals::XexExecutableModuleHandle,
                                        ppXexExecutableModuleHandle);
 
+  // ExLoadedImageName (char*)
+  // The full path to loaded image/xex including its name.
+  // Used usually in custom dashboards (Aurora)
+  // Todo(Gliniak): Confirm that official kernel always allocate space for this
+  // variable.
+  uint32_t ppExLoadedImageName =
+      memory_->SystemHeapAlloc(kExLoadedImageNameSize);
+  export_resolver_->SetVariableMapping(
+      "xboxkrnl.exe", ordinals::ExLoadedImageName, ppExLoadedImageName);
+
   // ExLoadedCommandLine (char*)
   // The name of the xex. Not sure this is ever really used on real devices.
   // Perhaps it's how swap disc/etc data is sent?

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_module.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_module.h
@@ -27,6 +27,8 @@ namespace xboxkrnl {
 
 class XboxkrnlModule : public KernelModule {
  public:
+  static constexpr size_t kExLoadedImageNameSize = 255 + 1;
+
   XboxkrnlModule(Emulator* emulator, KernelState* kernel_state);
   virtual ~XboxkrnlModule();
 


### PR DESCRIPTION
This is based on clues inside freestyledash code (Thanks 💃)

This resolve one of reasons why custom dashes usually cannot run.

PS. I'm not sure about one thing. Does maximal path length on xbox matches defined _MAX_PATH? (and the alignment 🤷‍♂️)

![image](https://user-images.githubusercontent.com/153369/95683002-df345880-0be8-11eb-9233-f3815b4fe2a5.png)
