### PR TITLE
Xam content / Storage fixes

### DIFF
--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -46,14 +46,12 @@ struct DeviceInfo {
 // they incorrectly only look at the lower 32-bits of free_bytes,
 // when it is a 64-bit value. Which means any size above ~4GB
 // will not be recognized properly.
-//
-// NOTE(randprint): you can use 120 GB and 42 GB 'fullness'
-// with the proper deviceID feel free to change at your discression
 #define ONE_GB (1024ull * 1024ull * 1024ull)
 static const DeviceInfo dummy_device_info_ = {
-    0x00000001,    1,  // found from debugging / reversing UE3 engine titles
-    4ull * ONE_GB,     // 4GB
-    3ull * ONE_GB,     // 3GB, so it looks a little used.
+    0x00000001,      // id
+    1,               // 1=HDD
+    20ull * ONE_GB,  // 20GB
+    3ull * ONE_GB,   // 3GB, so it looks a little used.
     u"Dummy HDD",
 };
 #undef ONE_GB
@@ -118,7 +116,7 @@ DECLARE_XAM_EXPORT1(XamContentGetDeviceState, kContent, kStub);
 
 typedef struct {
   xe::be<uint32_t> device_id;
-  xe::be<uint32_t> unknown;
+  xe::be<uint32_t> device_type;
   xe::be<uint64_t> total_bytes;
   xe::be<uint64_t> free_bytes;
   xe::be<uint16_t> name[28];
@@ -135,7 +133,7 @@ dword_result_t XamContentGetDeviceData(
   device_data.Zero();
   const auto& device_info = dummy_device_info_;
   device_data->device_id = device_info.device_id;
-  device_data->unknown = device_id & 0xFFFF;  // Fake it.
+  device_data->device_type = device_info.device_type;
   device_data->total_bytes = device_info.total_bytes;
   device_data->free_bytes = device_info.free_bytes;
   xe::store_and_swap<std::u16string>(&device_data->name[0], device_info.name);

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_module.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_module.cc
@@ -156,11 +156,14 @@ XboxkrnlModule::XboxkrnlModule(Emulator* emulator, KernelState* kernel_state)
   //
   // aomega08 says the value is 0x02000817, bit 27: debug mode on.
   // When that is set, though, allocs crash in weird ways.
+  //
+  // From kernel dissasembly, after storage is initialized
+  // XboxHardwareInfo flags is set with flag 5 (0x20).
   uint32_t pXboxHardwareInfo = memory_->SystemHeapAlloc(16);
   auto lpXboxHardwareInfo = memory_->TranslateVirtual(pXboxHardwareInfo);
   export_resolver_->SetVariableMapping(
       "xboxkrnl.exe", ordinals::XboxHardwareInfo, pXboxHardwareInfo);
-  xe::store_and_swap<uint32_t>(lpXboxHardwareInfo + 0, 0);    // flags
+  xe::store_and_swap<uint32_t>(lpXboxHardwareInfo + 0, 0x20);  // flags
   xe::store_and_swap<uint8_t>(lpXboxHardwareInfo + 4, 0x06);  // cpu count
   // Remaining 11b are zeroes?
 


### PR DESCRIPTION
These couple of fixes fix up all the rest of the storage detection issues I can find with the caveat of XamUIDeviceSelector needing some solution to set its pointer after a delay

The kernel commit sets the same flag to XboxHardwareInfo that the kernel does at startup after storage is initialized, found disassembling the kernel trying to debug why these last few problems with storage being detected persisted.

The commit to xam_content changes the size of the storage being reported as a hdd device type to the smallest size hdd that shipped with the 360, this fixed saving in Rapala fishing.

The changes to byteswap the deviceinfo struct in XamContentGetDeviceState fix a large number of storage detection issues in many games, with the caveat that a solution is needed in Xam_UI to XamShowDeviceSelectorUI as discussed and detailed here in issue https://github.com/xenia-project/xenia/issues/1296