### PR TITLE
[VFS] Reset reading index while no entry was found

### DIFF
--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -62,6 +62,7 @@ X_STATUS XFile::QueryDirectory(X_FILE_DIRECTORY_INFORMATION* out_info,
 
     entry = file_->entry()->IterateChildren(find_engine_, &find_index_);
     if (!entry) {
+      find_index_ = 0;
       return X_STATUS_NO_MORE_FILES;
     }
   }


### PR DESCRIPTION
Copy of my comment from dev channel:

> It uses NtQueryDirectoryFile few times. On the first time it provides not existing file name what sets find_index_ to amount of files. 
> Then second execution is without filename and without restart flag what causes it to autofail due to not reseting find_index_ to 0 in previous fail.



