### PR TITLE
[Base/Kernel] Add and use truncating null-terminating string copying

### DIFF
--- a/src/xenia/base/string_util.h
+++ b/src/xenia/base/string_util.h
@@ -10,11 +10,15 @@
 #ifndef XENIA_BASE_STRING_UTIL_H_
 #define XENIA_BASE_STRING_UTIL_H_
 
+#include <algorithm>
 #include <charconv>
+#include <cstddef>
+#include <cstring>
 #include <string>
 
 #include "third_party/fmt/include/fmt/format.h"
 #include "xenia/base/assert.h"
+#include "xenia/base/memory.h"
 #include "xenia/base/platform.h"
 #include "xenia/base/string.h"
 #include "xenia/base/vec128.h"
@@ -29,6 +33,40 @@
 
 namespace xe {
 namespace string_util {
+
+inline size_t copy_truncating(char* dest, const std::string_view source,
+                              size_t dest_buffer_count) {
+  if (!dest_buffer_count) {
+    return 0;
+  }
+  size_t chars_copied = std::min(source.size(), dest_buffer_count - size_t(1));
+  std::memcpy(dest, source.data(), chars_copied);
+  dest[chars_copied] = '\0';
+  return chars_copied;
+}
+
+inline size_t copy_truncating(char16_t* dest, const std::u16string_view source,
+                              size_t dest_buffer_count) {
+  if (!dest_buffer_count) {
+    return 0;
+  }
+  size_t chars_copied = std::min(source.size(), dest_buffer_count - size_t(1));
+  std::memcpy(dest, source.data(), chars_copied * sizeof(char16_t));
+  dest[chars_copied] = u'\0';
+  return chars_copied;
+}
+
+inline size_t copy_and_swap_truncating(char16_t* dest,
+                                       const std::u16string_view source,
+                                       size_t dest_buffer_count) {
+  if (!dest_buffer_count) {
+    return 0;
+  }
+  size_t chars_copied = std::min(source.size(), dest_buffer_count - size_t(1));
+  xe::copy_and_swap(dest, source.data(), chars_copied);
+  dest[chars_copied] = u'\0';
+  return chars_copied;
+}
 
 inline std::string to_hex_string(uint32_t value) {
   return fmt::format("{:08X}", value);

--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/base/logging.h"
+#include "xenia/base/math.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/xam_private.h"
@@ -223,7 +224,8 @@ dword_result_t XamContentCreateDeviceEnumerator(dword_t content_type,
     xe::store_and_swap(&dev->device_type, dummy_device_info_.device_type);
     xe::store_and_swap(&dev->total_bytes, dummy_device_info_.total_bytes);
     xe::store_and_swap(&dev->free_bytes, dummy_device_info_.free_bytes);
-    xe::copy_and_swap(dev->name, dummy_device_info_.name, 28);
+    xe::copy_and_swap(dev->name, dummy_device_info_.name,
+                      xe::countof(dev->name));
   }
 
   *handle_out = e->handle();

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -9,6 +9,7 @@
 
 #include "third_party/imgui/imgui.h"
 #include "xenia/base/logging.h"
+#include "xenia/base/string_util.h"
 #include "xenia/emulator.h"
 #include "xenia/kernel/kernel_flags.h"
 #include "xenia/kernel/kernel_state.h"
@@ -188,8 +189,8 @@ class KeyboardInputDialog : public xe::ui::ImGuiDialog {
       *out_text_ = default_text;
     }
     text_buffer_.resize(max_length);
-    std::strncpy(text_buffer_.data(), default_text_.c_str(),
-                 std::min(text_buffer_.size() - 1, default_text_.size()));
+    xe::string_util::copy_truncating(text_buffer_.data(), default_text_,
+                                     text_buffer_.size());
   }
 
   void OnDraw(ImGuiIO& io) override {

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -10,6 +10,8 @@
 #include <cstring>
 
 #include "xenia/base/logging.h"
+#include "xenia/base/math.h"
+#include "xenia/base/string_util.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/xam_private.h"
@@ -91,7 +93,8 @@ X_HRESULT_result_t XamUserGetSigninInfo(dword_t user_index, dword_t flags,
   const auto& user_profile = kernel_state()->user_profile();
   info->xuid = user_profile->xuid();
   info->signin_state = user_profile->signin_state();
-  std::strncpy(info->name, user_profile->name().data(), 15);
+  xe::string_util::copy_truncating(info->name, user_profile->name(),
+                                   xe::countof(info->name));
   return X_E_SUCCESS;
 }
 DECLARE_XAM_EXPORT1(XamUserGetSigninInfo, kUserProfiles, kImplemented);
@@ -110,10 +113,8 @@ dword_result_t XamUserGetName(dword_t user_index, lpstring_t buffer,
   const auto& user_name = user_profile->name();
 
   // Real XAM will only copy a maximum of 15 characters out.
-  size_t copy_length = std::min(
-      {size_t(15), user_name.size(), static_cast<size_t>(buffer_len) - 1});
-  std::memcpy(buffer, user_name.data(), copy_length);
-  buffer[copy_length] = '\0';
+  xe::string_util::copy_truncating(buffer, user_name,
+                                   std::min(buffer_len.value(), uint32_t(15)));
   return X_ERROR_SUCCESS;
 }
 DECLARE_XAM_EXPORT1(XamUserGetName, kUserProfiles, kImplemented);


### PR DESCRIPTION
This supersedes and more correctly includes #1632. Ensures null termination of strings written by certain kernel functions even in case of buffer overflow. I'm not sure about the designed overflow behavior of the kernel functions when I'm using the new copying, but overall this seems safe, also fixes the issue found by @Gliniak in #1632.