### PR TITLE
threading test: zero initialize counter

### DIFF
--- a/src/xenia/base/testing/threading_test.cc
+++ b/src/xenia/base/testing/threading_test.cc
@@ -174,8 +174,8 @@ TEST_CASE("HighResolutionTimer") {
   {
     const auto interval1 = 100ms;
     const auto interval2 = 200ms;
-    std::atomic<uint64_t> counter1;
-    std::atomic<uint64_t> counter2;
+    std::atomic<uint64_t> counter1(0);
+    std::atomic<uint64_t> counter2(0);
     auto start = std::chrono::steady_clock::now();
     auto cb1 = [&counter1] { ++counter1; };
     auto cb2 = [&counter2] { ++counter2; };

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_module.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_module.cc
@@ -164,7 +164,7 @@ XboxkrnlModule::XboxkrnlModule(Emulator* emulator, KernelState* kernel_state)
   export_resolver_->SetVariableMapping(
       "xboxkrnl.exe", ordinals::XboxHardwareInfo, pXboxHardwareInfo);
   xe::store_and_swap<uint32_t>(lpXboxHardwareInfo + 0, 0x20);  // flags
-  xe::store_and_swap<uint8_t>(lpXboxHardwareInfo + 4, 0x06);  // cpu count
+  xe::store_and_swap<uint8_t>(lpXboxHardwareInfo + 4, 0x06);   // cpu count
   // Remaining 11b are zeroes?
 
   // ExConsoleGameRegion, probably same values as keyvault region uses?


### PR DESCRIPTION
The high performance test atomic counters need to be set to zero to have reliable results.