### PR TITLE
[Kernel/Memory] MmQueryAddressProtect - Check for protect_bits equals 0

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
@@ -401,6 +401,11 @@ DECLARE_XBOXKRNL_EXPORT2(MmQueryAddressProtect, kMemory, kImplemented,
 
 void MmSetAddressProtect(lpvoid_t base_address, dword_t region_size,
                          dword_t protect_bits) {
+  if (!protect_bits) {
+    XELOGE("MmSetAddressProtect: Failed due to incorrect protect_bits");
+    return;
+  }
+
   uint32_t protect = FromXdkProtectFlags(protect_bits);
   auto heap = kernel_memory()->LookupHeap(base_address);
   heap->Protect(base_address.guest_address(), region_size, protect);


### PR DESCRIPTION
I found out that Black Ops 3 explicitly calls ``MmSetAddressProtect`` with protect bits 0. Which seems to be unhandled case by us.

### Actual behaviour:
Right now providing 0 causes it to mark it as PAGE_NOACCESS, which seems to be incorrect as PAGE_NOACCESS is 0x01

### New behaviour:
Providing 0 do not cause any change to provided range and old protection stays intact.

### Proof
```
d> F8000028 MmSetAddressProtect(BF8A0000, 00400000, 00000000)
d> F8000028 ! EMULATOR PAUSED !
!> F8000028 ==== CRASH DUMP ====
```

You can see r5 is set to 0
![image](https://user-images.githubusercontent.com/153369/99291412-0f05fa00-2840-11eb-8a52-252dd3e56ea5.png)
Now there is only one operation on it which might be translated to: r23 = r5 & 0x7fffffff
![image](https://user-images.githubusercontent.com/153369/99291450-1fb67000-2840-11eb-8860-b133b099031b.png)
We're skipping some code that doesn't impact r23 and go to place where ``MmSetAddressProtect`` is called
![image](https://user-images.githubusercontent.com/153369/99291748-92275000-2840-11eb-8823-ac6a80d28cff.png)
![image](https://user-images.githubusercontent.com/153369/99291770-9a7f8b00-2840-11eb-806a-c8fecabbcac0.png)
