### PR TITLE
[XAM] Rollup of user fixes.

### DIFF
--- a/src/xenia/kernel/xam/user_profile.h
+++ b/src/xenia/kernel/xam/user_profile.h
@@ -202,6 +202,7 @@ class UserProfile {
   uint64_t xuid() const { return xuid_; }
   std::string name() const { return name_; }
   uint32_t signin_state() const { return 1; }
+  uint32_t type() const { return 2; /* online profile? */ }
 
   void AddSetting(std::unique_ptr<Setting> setting);
   Setting* GetSetting(uint32_t setting_id);


### PR DESCRIPTION
- [XAM] Fix `XamUserGetXUID` type mask handling.
- [XAM] Fix `XamGetUserName` return values.
- [XAM] Fix `XamGetUserName` copy size.
- [XAM] Implement `XamGetUserGamerTag`.
- [XAM] Fix `XamUserCheckPrivilege` handling of all users.
- [XAM] Stub `XamUserGetMembershipTier`.