### PR TITLE
Threading test fixes

### DIFF
--- a/src/xenia/base/testing/threading_test.cc
+++ b/src/xenia/base/testing/threading_test.cc
@@ -813,7 +813,7 @@ TEST_CASE("Create and Run Thread", "Thread") {
   result = Wait(Thread::GetCurrentThread(), false, 50ms);
   REQUIRE(result == WaitResult::kTimeout);
 
-  params.stack_size = 16 * 1024;
+  params.stack_size = 16 * 1024 * 1024;
   thread = Thread::Create(params, [] {
     while (true) {
       Thread::Exit(-1);

--- a/src/xenia/base/threading_posix.cc
+++ b/src/xenia/base/threading_posix.cc
@@ -1007,7 +1007,10 @@ Thread* Thread::GetCurrentThread() {
   pthread_t handle = pthread_self();
 
   current_thread_ = new PosixThread(handle);
-  atexit([] { delete current_thread_; });
+  // TODO(bwrsandman): Disabling deleting thread_local current thread to prevent
+  //                   assert in destructor. Since this is thread local, the
+  //                   "memory leaking" is controlled.
+  // atexit([] { delete current_thread_; });
 
   return current_thread_;
 }

--- a/src/xenia/base/threading_posix.cc
+++ b/src/xenia/base/threading_posix.cc
@@ -505,6 +505,7 @@ class PosixCondition<Thread> : public PosixConditionBase {
       }
     }
     if (pthread_create(&thread_, &attr, ThreadStartRoutine, start_data) != 0) {
+      pthread_attr_destroy(&attr);
       return false;
     }
     pthread_attr_destroy(&attr);


### PR DESCRIPTION
Fix a failed test because of too small stack in pthreads attr. This in not the theoretical minimum on the platform, but the actual needed `PosixThread` size.

Fix an on exit assert fail.