### PR TITLE
[Kernel] Filter thread names from guest.

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_debug.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_debug.cc
@@ -47,8 +47,12 @@ void HandleSetThreadName(pointer_t<X_EXCEPTION_RECORD> record) {
     return;
   }
 
+  // TODO(gibbed): cvar for thread name encoding for conversion, some games use
+  // SJIS and there's no way to automatically know this.
   auto name =
-      kernel_memory()->TranslateVirtual<const char*>(thread_info->name_ptr);
+      std::string(kernel_memory()->TranslateVirtual<const char*>(thread_info->name_ptr));
+  std::replace_if(
+      name.begin(), name.end(), [](auto c) { return c < 32 || c > 127; }, '?');
 
   object_ref<XThread> thread;
   if (thread_info->thread_id == -1) {


### PR DESCRIPTION
Thread names from the guest code can be any random encoding (usually developer specific) such as SJIS, which is not valid UTF-8. This will throw exceptions if it's attempted to be converted to UTF-16 in our internal thread name setting code.