### PR TITLE
Use xenia-base entrypoint for test suites.

### DIFF
--- a/tools/build/scripts/test_suite.lua
+++ b/tools/build/scripts/test_suite.lua
@@ -26,8 +26,12 @@ local function combined_test_suite(test_suite_name, project_root, base_path, con
     }))
     links(merge_arrays(config["links"], {
     }))
+    defines({
+      "XE_TEST_SUITE_NAME=\""..test_suite_name.."\"",
+    })
     files({
       project_root.."/"..build_tools_src.."/test_suite_main.cc",
+      project_root.."/src/xenia/base/main_"..platform_suffix..".cc",
       base_path.."/**_test.cc",
     })
 end

--- a/tools/build/src/test_suite_main.cc
+++ b/tools/build/src/test_suite_main.cc
@@ -13,44 +13,34 @@
 #include <string>
 #include <vector>
 
+#include "xenia/base/cvar.h"
+#include "xenia/base/main.h"
+
 #define CATCH_CONFIG_RUNNER
 #include "third_party/catch/include/catch.hpp"
-#include "xenia/base/cvar.h"
 
 namespace xe {
+namespace test_suite {
 
-bool has_console_attached() { return true; }
-
-// Used in console mode apps; automatically picked based on subsystem.
-int Main(int argc, char* argv[]) {
-  cvar::ParseLaunchArguments(argc, argv, "", std::vector<std::string>());
+int test_suite_main(const std::vector<std::string>& args) {
+  // Catch doesn't expose a way to pass a vector of strings, despite building a
+  // vector internally.
+  int argc = 0;
+  std::vector<const char*> argv;
+  for (const auto& arg : args) {
+    argv.push_back(arg.c_str());
+    argc++;
+  }
 
   // Run Catch.
-  int result = Catch::Session().run(argc, argv);
-
-  return result;
+  return Catch::Session().run(argc, argv.data());
 }
 
+}  // namespace test_suite
 }  // namespace xe
 
-#if _WIN32
-#include "xenia/base/platform_win.h"
+#ifndef XE_TEST_SUITE_NAME
+#error XE_TEST_SUITE_NAME is undefined!
+#endif
 
-extern "C" int main(int argc, wchar_t* argv[]) {
-  // Setup COM on the main thread.
-  // NOTE: this may fail if COM has already been initialized - that's OK.
-  CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-
-  // Convert all args to narrow, as gflags doesn't support wchar.
-  int argca = argc;
-  char** argva = (char**)alloca(sizeof(char*) * argca);
-  for (int n = 0; n < argca; n++) {
-    size_t len = wcslen(argv[n]);
-    argva[n] = (char*)alloca(len + 1);
-    std::wcstombs(argva[n], argv[n], len + 1);
-  }
-  return xe::Main(argc, argva);
-}
-#else
-extern "C" int main(int argc, char* argv[]) { return xe::Main(argc, argv); }
-#endif  // _WIN32
+DEFINE_ENTRY_POINT(XE_TEST_SUITE_NAME, xe::test_suite::test_suite_main, "");


### PR DESCRIPTION
Use xenia-base entrypoint for test suites. Fixes a bug where we were expecting `wchar` data in `main`, which is incorrect, causing invalid args to be parsed.