### PR TITLE
[Kernel] Implemented NtSetIoCompletion

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -353,6 +353,26 @@ dword_result_t NtCreateIoCompletion(lpdword_t out_handle,
 }
 DECLARE_XBOXKRNL_EXPORT1(NtCreateIoCompletion, kFileSystem, kImplemented);
 
+dword_result_t NtSetIoCompletion(dword_t handle, dword_t key_context,
+                                 dword_t apc_context, dword_t completion_status,
+                                 dword_t num_bytes) {
+  auto port =
+      kernel_state()->object_table()->LookupObject<XIOCompletion>(handle);
+  if (!port) {
+    return X_STATUS_INVALID_HANDLE;
+  }
+
+  XIOCompletion::IONotification notification;
+  notification.key_context = key_context;
+  notification.apc_context = apc_context;
+  notification.num_bytes = num_bytes;
+  notification.status = completion_status;
+
+  port->QueueNotification(notification);
+  return X_STATUS_SUCCESS;
+}
+DECLARE_XBOXKRNL_EXPORT1(NtSetIoCompletion, kFileSystem, kImplemented);
+
 // Dequeues a packet from the completion port.
 dword_result_t NtRemoveIoCompletion(
     dword_t handle, lpdword_t key_context, lpdword_t apc_context,

--- a/src/xenia/kernel/xiocompletion.cc
+++ b/src/xenia/kernel/xiocompletion.cc
@@ -30,7 +30,7 @@ bool XIOCompletion::WaitForNotification(uint64_t wait_ticks,
                                         IONotification* notify) {
   auto ms = std::chrono::milliseconds(TimeoutTicksToMs(wait_ticks));
   auto res = threading::Wait(notification_semaphore_.get(), false, ms);
-  if (res == threading::WaitResult::kSuccess) {
+  if (res == threading::WaitResult::kSuccess || !wait_ticks) {
     std::unique_lock<std::mutex> lock(notification_lock_);
     assert_false(notifications_.empty());
 


### PR DESCRIPTION
Additionally: "Fixed" issue where executing WaitForNotification with wait_ticks 0 caused it to return timeout.

I'm still leaving that change to debate, as it seems to be hacky-like fixed (that is why I quoted it).
It seems like it is timing issue between ``NtSetIoCompletion`` and ``NtRemoveIoCompletion`` if they're executed too close to each other sometimes it might return timeout even if it shouldn't

# Affected titles:
- [Naughty Bear: Gold Edition](https://github.com/xenia-project/game-compatibility/issues/680)
- [Wet](https://github.com/xenia-project/game-compatibility/issues/671)