### PR TITLE
[Kernel/XAM] XamContentCreateEx - Extended Error Support

### DIFF
--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -202,8 +202,12 @@ dword_result_t XamContentCreateEx(dword_t user_index, lpstring_t root_name,
   }
 
   if (overlapped_ptr) {
-    kernel_state()->CompleteOverlappedImmediateEx(overlapped_ptr, result, 0,
-                                                  disposition);
+    X_RESULT extended_error = X_HRESULT_FROM_WIN32(result);
+    if (int32_t(extended_error) < 0) {
+      result = X_ERROR_FUNCTION_FAILED;
+    }
+    kernel_state()->CompleteOverlappedImmediateEx(overlapped_ptr, result,
+                                                  extended_error, disposition);
     return X_ERROR_IO_PENDING;
   } else {
     return result;


### PR DESCRIPTION
Based on disassembly of Silent Hill: Homecoming

I figured out that it checks for very specific extended error codes. 
On screenshot you can see two of them: 
0x80070003 - X_ERROR_PATH_NOT_FOUND
0x80070570

and there is also one more check for:
0x80070026

We're not returning the first one (correct path) or any other error code and games goes a little insane and runs second instance of main menu in the background which causes issues.

![image](https://user-images.githubusercontent.com/153369/103484658-d79fdc80-4df0-11eb-940e-701928b858ed.png)

# What does it fix
- Silent Hill: Homecoming - It fixes issue when pressing Start Game/Load Game causes window to pop and then returns to main menu & saving
- Ridge Racer 6 - Fixes saving
- Ridge Racer Unbounded - Fixes initial save (second save still crashes due to used handle to savefile)
- Wartech: Senko no Ronde - Resolves no device found error (before main menu) & saving issues