### PR TITLE
[Kernel] Improved export stubs, implement XNetQosRelease

### DIFF
--- a/src/xenia/kernel/xbdm/xbdm_misc.cc
+++ b/src/xenia/kernel/xbdm/xbdm_misc.cc
@@ -50,7 +50,14 @@ MAKE_DUMMY_STUB_STATUS(DmRegisterCommandProcessor);
 void DmSendNotificationString(lpdword_t unk0_ptr) {}
 DECLARE_XBDM_EXPORT1(DmSendNotificationString, kDebug, kStub);
 
-MAKE_DUMMY_STUB_STATUS(DmRegisterCommandProcessorEx);
+dword_result_t DmRegisterCommandProcessorEx(lpdword_t name_ptr,
+                                            lpdword_t handler_fn,
+                                            dword_t unk3) {
+  // Return success to prevent some games from stalling
+  return X_STATUS_SUCCESS;
+}
+DECLARE_XBDM_EXPORT1(DmRegisterCommandProcessorEx, kDebug, kStub);
+
 MAKE_DUMMY_STUB_STATUS(DmStartProfiling);
 MAKE_DUMMY_STUB_STATUS(DmStopProfiling);
 
@@ -63,7 +70,8 @@ MAKE_DUMMY_STUB_STATUS(DmGetThreadInfoEx);
 MAKE_DUMMY_STUB_STATUS(DmSetProfilingOptions);
 
 dword_result_t DmWalkLoadedModules(lpdword_t unk0_ptr, lpdword_t unk1_ptr) {
-  return X_STATUS_INVALID_PARAMETER;
+  // Some games will loop forever unless this code is returned
+  return 0x82DA0104;
 }
 DECLARE_XBDM_EXPORT1(DmWalkLoadedModules, kDebug, kStub);
 


### PR DESCRIPTION
- Change **DmRegisterCommandProcessorEx** & **DmWalkLoadedModules** result codes
- Make **NetDll_XNetQosServiceLookup** set the pqos output parameter to a valid pointer before returning
- Implement **NetDll_XNetQosRelease** to allow freeing the qos struct allocated by XNetQosServiceLookup

Previously Halo 3 debug would freeze if **DmRegisterCommandProcessorEx** didn't return success, and would get stuck in an endless loop if **DmWalkLoadedModules** didn't return 0x82DA0104, so I've updated both to return what the game seemed to expect.
(wasn't sure about PRing these since there might have been a reason they had the result codes they did, but I couldn't find any mentions on the compatibility tracker for either export after a quick search, so hopefully this shouldn't break anything)

**NetDll_XNetQosServiceLookup** needed to be updated for Saints Row 1 (TU1) to load up properly, seems the game ignores any error code we give and still tries accessing the output ptr (a little surprised this passed cert, but maybe things were lax around TUs back then).
The code is pretty much just a copy of the NetDll_XNetDnsLookup function, except using the XNQOS struct instead, the definition for that struct comes from the xboxstubs.h file linked earlier on in xam_net.cc.
Since **XNetQosServiceLookup** is allocing memory I also implemented the **XNetQosRelease** function, again just a copy of XNetDnsRelease.

Affected titles:
- Halo 3 'delta' March 2007 - debug build can now start up
- Saints Row 1 (TU1) - now shows main menu without crashing (there's currently a problem stopping the TU1 xexp from being applied properly though, will have a PR for it soon)