### PR TITLE
[CPU/XEX] Fix ApplyPatch not updating security_info_, causing issues with some patches

### DIFF
--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -170,6 +170,8 @@ class XexModule : public xe::cpu::Module {
   std::unique_ptr<Function> CreateFunction(uint32_t address) override;
 
  private:
+  void ReadSecurityInfo();
+
   int ReadImage(const void* xex_addr, size_t xex_length, bool use_dev_key);
   int ReadImageUncompressed(const void* xex_addr, size_t xex_length);
   int ReadImageBasicCompressed(const void* xex_addr, size_t xex_length);


### PR DESCRIPTION
- Move security info conversion code into ReadSecurityInfo
- Update ApplyPatch to call ReadSecurityInfo after patching headers

Right now ApplyPatch doesn't update security_info_ after applying a patch, making image_size() & other code that relies on security_info_ return outdated/incorrect data.

This can be seen when applying the Saints Row title update, before applying patch image_size() returns a normal 0x02160000, but after patching it returns 0x6d060000, which ends up breaking the memory alloc code inside ApplyPatch.
Changing ApplyPatch to update security info after patching it returns a more normal 0x02040000 image size instead (and can be seen that security_info_.page_descriptor_count is lower after the patch, so I'm guessing the incorrect image size was likely due to the image_size() function using the older count, making it read past the page descriptor bounds)

Affected titles:
- Saints Row 1 - TU1 can now be applied without issue