### PR TITLE
[Kernel/XAM] CloseContent: Close files related to closed content

### DIFF
--- a/src/xenia/kernel/xam/content_manager.h
+++ b/src/xenia/kernel/xam/content_manager.h
@@ -159,6 +159,7 @@ class ContentManager {
   X_RESULT DeleteContent(const ContentData& data);
   std::filesystem::path ResolveGameUserContentPath();
   bool IsContentOpen(const ContentData& data) const;
+  void CloseOpenedFilesFromContent(const std::string_view root_name);
 
  private:
   std::filesystem::path ResolvePackageRoot(uint32_t content_type);


### PR DESCRIPTION
I found that few games doesn't close explicitly handles to savefiles. They do not use ``NtClose`` to close these files (even on console)

However they use ``XamContentClose`` and seems like this function should be also responsible for closing opened files within content.

< space for more info >

If you know how to simplify this even more feel free to tell me 🐑 

# Impacted Games:
- Ridge Racer Unbounded
- MindJack
- Spyro
- Saint's Row