### PR TITLE
[Kernel] Workarounds to allow XMountUtilityDrive to be successful

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -75,7 +75,6 @@ DEFINE_path(
     "Storage");
 
 DEFINE_bool(mount_scratch, false, "Enable scratch mount", "Storage");
-DEFINE_bool(mount_cache, false, "Enable cache mount", "Storage");
 
 DEFINE_transient_path(target, "",
                       "Specifies the target .xex or .iso to execute.",

--- a/src/xenia/kernel/xam/xam_task.cc
+++ b/src/xenia/kernel/xam/xam_task.cc
@@ -23,6 +23,8 @@
 
 #include "third_party/fmt/include/fmt/format.h"
 
+DECLARE_bool(mount_cache);
+
 namespace xe {
 namespace kernel {
 namespace xam {
@@ -60,7 +62,7 @@ dword_result_t XamTaskSchedule(lpvoid_t callback,
   // Check if unknown param matches what XMountUtilityDrive uses
   // (these are likely flags instead of an ID though, maybe has a chance of
   // being used by something other than XMountUtilityDrive...)
-  if (unknown && *unknown == 0x2080002) {
+  if (cvars::mount_cache && unknown && *unknown == 0x2080002) {
     // If this is cache-partition-task game will set message[0x10 or 0x14] to
     // 0x4A6F7368 ('Josh'), offset probably changes depending on revision of
     // cache-mounting code?

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -667,6 +667,24 @@ dword_result_t FscSetCacheElementCount(dword_t unk_0, dword_t unk_1) {
 }
 DECLARE_XBOXKRNL_EXPORT1(FscSetCacheElementCount, kFileSystem, kStub);
 
+dword_result_t NtDeviceIoControlFile(
+    dword_t handle, dword_t event_handle, dword_t apc_routine,
+    dword_t apc_context, dword_t io_status_block, dword_t io_control_code,
+    lpvoid_t input_buffer, dword_t input_buffer_len, lpvoid_t output_buffer,
+    dword_t output_buffer_len) {
+  // Called by STFS/cache code, seems to check the sanity of returned values -
+  // the values below appear to pass this check
+  if (io_control_code == 0x74004) {
+    xe::store_and_swap<uint64_t>(output_buffer, 0);
+    xe::store_and_swap<uint64_t>(output_buffer + 8, 0xFF000);
+  } else if (io_control_code == 0x70000) {
+    xe::store_and_swap<uint32_t>(output_buffer, 0xFF000 / 512);
+    xe::store_and_swap<uint32_t>(output_buffer + 4, 512);
+  }
+  return X_STATUS_SUCCESS;
+}
+DECLARE_XBOXKRNL_EXPORT1(NtDeviceIoControlFile, kFileSystem, kStub);
+
 void RegisterIoExports(xe::cpu::ExportResolver* export_resolver,
                        KernelState* kernel_state) {}
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io_info.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io_info.cc
@@ -126,6 +126,12 @@ dword_result_t NtQueryInformationFile(
       out_length = sizeof(*info);
       break;
     }
+    case XFileAlignmentInformation: {
+      auto info = info_ptr.as<uint32_t*>();
+      *info = 0;
+      out_length = sizeof(*info);
+      break;
+    }
     default: {
       // Unsupported, for now.
       assert_always();

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
@@ -17,11 +17,25 @@
 
 namespace xe {
 namespace kernel {
+namespace xam {
+extern bool cache_task_scheduled_;  // xam_task.cc
+};
 namespace xboxkrnl {
 
 dword_result_t XexCheckExecutablePrivilege(dword_t privilege) {
   // BOOL
   // DWORD Privilege
+
+  // XFlushUtilityDrive checks for privilege 0xB, if not set then it sets an
+  // event and waits for it to complete (which atm it never will, as we don't
+  // run any of the STFC handling code)
+
+  // However if the privilege is set then it'll skip over the event waiting code
+  // (some games may act differently if this privilege is always set though, so
+  // only start setting it once we know cache has been mounted by the game)
+  if (privilege == 0xB && xe::kernel::xam::cache_task_scheduled_) {
+    return 1;
+  }
 
   // Privilege is bit position in xe_xex2_system_flags enum - so:
   // Privilege=6 -> 0x00000040 -> XEX_SYSTEM_INSECURE_SOCKETS

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.cc
@@ -17,25 +17,11 @@
 
 namespace xe {
 namespace kernel {
-namespace xam {
-extern bool cache_task_scheduled_;  // xam_task.cc
-};
 namespace xboxkrnl {
 
 dword_result_t XexCheckExecutablePrivilege(dword_t privilege) {
   // BOOL
   // DWORD Privilege
-
-  // XFlushUtilityDrive checks for privilege 0xB, if not set then it sets an
-  // event and waits for it to complete (which atm it never will, as we don't
-  // run any of the STFC handling code)
-
-  // However if the privilege is set then it'll skip over the event waiting code
-  // (some games may act differently if this privilege is always set though, so
-  // only start setting it once we know cache has been mounted by the game)
-  if (privilege == 0xB && xe::kernel::xam::cache_task_scheduled_) {
-    return 1;
-  }
 
   // Privilege is bit position in xe_xex2_system_flags enum - so:
   // Privilege=6 -> 0x00000040 -> XEX_SYSTEM_INSECURE_SOCKETS

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -960,14 +960,17 @@ void KeReleaseSpinLockFromRaisedIrql(lpdword_t lock_ptr) {
 DECLARE_XBOXKRNL_EXPORT2(KeReleaseSpinLockFromRaisedIrql, kThreading,
                          kImplemented, kHighFrequency);
 
-void KeEnterCriticalRegion() { XThread::EnterCriticalRegion(); }
+void KeEnterCriticalRegion() {
+  XThread::GetCurrentThread()->EnterCriticalRegion();
+}
 DECLARE_XBOXKRNL_EXPORT2(KeEnterCriticalRegion, kThreading, kImplemented,
                          kHighFrequency);
 
 void KeLeaveCriticalRegion() {
-  XThread::LeaveCriticalRegion();
+  auto thread = XThread::GetCurrentThread();
+  thread->LeaveCriticalRegion();
 
-  XThread::GetCurrentThread()->CheckApcs();
+  thread->CheckApcs();
 }
 DECLARE_XBOXKRNL_EXPORT2(KeLeaveCriticalRegion, kThreading, kImplemented,
                          kHighFrequency);

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -190,8 +190,8 @@ class XThread : public XObject, public cpu::Thread {
 
   virtual void Reenter(uint32_t address);
 
-  static void EnterCriticalRegion();
-  static void LeaveCriticalRegion();
+  void EnterCriticalRegion();
+  void LeaveCriticalRegion();
   uint32_t RaiseIrql(uint32_t new_irql);
   void LowerIrql(uint32_t new_irql);
 
@@ -269,6 +269,7 @@ class XThread : public XObject, public cpu::Thread {
   int32_t priority_ = 0;
 
   xe::global_critical_region global_critical_region_;
+  std::recursive_mutex local_critical_region_;
   std::atomic<uint32_t> irql_ = {0};
   util::NativeList apc_list_;
 };

--- a/src/xenia/vfs/devices/null_device.cc
+++ b/src/xenia/vfs/devices/null_device.cc
@@ -1,0 +1,62 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/vfs/devices/null_device.h"
+
+#include "xenia/base/filesystem.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/math.h"
+#include "xenia/kernel/xfile.h"
+#include "xenia/vfs/devices/null_entry.h"
+
+namespace xe {
+namespace vfs {
+
+NullDevice::NullDevice(const std::string& mount_path,
+                       const std::initializer_list<std::string>& null_paths)
+    : Device(mount_path), null_paths_(null_paths) {}
+
+NullDevice::~NullDevice() = default;
+
+bool NullDevice::Initialize() {
+  auto root_entry = new NullEntry(this, nullptr, mount_path_);
+  root_entry->attributes_ = kFileAttributeDirectory;
+  root_entry_ = std::unique_ptr<Entry>(root_entry);
+
+  for (auto path : null_paths_) {
+    auto child = NullEntry::Create(this, root_entry, path);
+    root_entry->children_.push_back(std::unique_ptr<Entry>(child));
+  }
+  return true;
+}
+
+void NullDevice::Dump(StringBuffer* string_buffer) {
+  auto global_lock = global_critical_region_.Acquire();
+  root_entry_->Dump(string_buffer, 0);
+}
+
+Entry* NullDevice::ResolvePath(const std::string_view path) {
+  XELOGFS("NullDevice::ResolvePath({})", path);
+
+  auto root = root_entry_.get();
+  if (path.empty()) {
+    return root_entry_.get();
+  }
+
+  for (auto& child : root->children()) {
+    if (!strcasecmp(child->path().c_str(), path.data())) {
+      return child.get();
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace vfs
+}  // namespace xe

--- a/src/xenia/vfs/devices/null_device.h
+++ b/src/xenia/vfs/devices/null_device.h
@@ -35,12 +35,14 @@ class NullDevice : public Device {
   uint32_t attributes() const override { return 0; }
   uint32_t component_name_max_length() const override { return 40; }
 
-  uint32_t total_allocation_units() const override { return 128 * 1024; }
-  uint32_t available_allocation_units() const override { return 128 * 1024; }
+  uint32_t total_allocation_units() const override { return 8 * 1024; }
+  uint32_t available_allocation_units() const override { return 8 * 1024; }
 
-  // STFC/cache code seems to require the product of these two to equal 0x10000!
-  uint32_t sectors_per_allocation_unit() const override { return 1; }
-  uint32_t bytes_per_sector() const override { return 0x10000; }
+  // STFC/cache code seems to require the product of these two to equal 0x10000
+  uint32_t sectors_per_allocation_unit() const override { return 0x10; }
+
+  // STFC requires <= 0x1000
+  uint32_t bytes_per_sector() const override { return 0x1000; }
 
  private:
   std::unique_ptr<Entry> root_entry_;

--- a/src/xenia/vfs/devices/null_device.h
+++ b/src/xenia/vfs/devices/null_device.h
@@ -1,0 +1,53 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_VFS_DEVICES_NULL_DEVICE_H_
+#define XENIA_VFS_DEVICES_NULL_DEVICE_H_
+
+#include <string>
+
+#include "xenia/vfs/device.h"
+
+namespace xe {
+namespace vfs {
+
+class NullEntry;
+
+class NullDevice : public Device {
+ public:
+  NullDevice(const std::string& mount_path,
+             const std::initializer_list<std::string>& null_paths);
+  ~NullDevice() override;
+
+  bool Initialize() override;
+  void Dump(StringBuffer* string_buffer) override;
+  Entry* ResolvePath(const std::string_view path) override;
+
+  bool is_read_only() const override { return false; }
+
+  const std::string& name() const override { return root_entry_.get()->name(); }
+  uint32_t attributes() const override { return 0; }
+  uint32_t component_name_max_length() const override { return 40; }
+
+  uint32_t total_allocation_units() const override { return 128 * 1024; }
+  uint32_t available_allocation_units() const override { return 128 * 1024; }
+
+  // STFC/cache code seems to require the product of these two to equal 0x10000!
+  uint32_t sectors_per_allocation_unit() const override { return 1; }
+  uint32_t bytes_per_sector() const override { return 0x10000; }
+
+ private:
+  std::unique_ptr<Entry> root_entry_;
+  std::vector<std::string> null_paths_;
+};
+
+}  // namespace vfs
+}  // namespace xe
+
+#endif  // XENIA_VFS_DEVICES_NULL_DEVICE_H_

--- a/src/xenia/vfs/devices/null_entry.cc
+++ b/src/xenia/vfs/devices/null_entry.cc
@@ -1,0 +1,55 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/vfs/devices/null_entry.h"
+
+#include "xenia/base/filesystem.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/mapped_memory.h"
+#include "xenia/base/math.h"
+#include "xenia/base/string.h"
+#include "xenia/vfs/device.h"
+#include "xenia/vfs/devices/null_file.h"
+
+namespace xe {
+namespace vfs {
+
+NullEntry::NullEntry(Device* device, Entry* parent, std::string path)
+    : Entry(device, parent, path) {}
+
+NullEntry::~NullEntry() = default;
+
+NullEntry* NullEntry::Create(Device* device, Entry* parent,
+                             const std::string& path) {
+  auto entry = new NullEntry(device, parent, path);
+
+  entry->create_timestamp_ = 0;
+  entry->access_timestamp_ = 0;
+  entry->write_timestamp_ = 0;
+
+  entry->attributes_ = kFileAttributeNormal;
+
+  entry->size_ = 0;
+  entry->allocation_size_ = 0;
+  return entry;
+}
+
+X_STATUS NullEntry::Open(uint32_t desired_access, File** out_file) {
+  if (is_read_only() && (desired_access & (FileAccess::kFileWriteData |
+                                           FileAccess::kFileAppendData))) {
+    XELOGE("Attempting to open file for write access on read-only device");
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  *out_file = new NullFile(desired_access, this);
+  return X_STATUS_SUCCESS;
+}
+
+}  // namespace vfs
+}  // namespace xe

--- a/src/xenia/vfs/devices/null_entry.h
+++ b/src/xenia/vfs/devices/null_entry.h
@@ -1,0 +1,42 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_VFS_DEVICES_NULL_ENTRY_H_
+#define XENIA_VFS_DEVICES_NULL_ENTRY_H_
+
+#include <string>
+
+#include "xenia/base/filesystem.h"
+#include "xenia/vfs/entry.h"
+
+namespace xe {
+namespace vfs {
+
+class NullDevice;
+
+class NullEntry : public Entry {
+ public:
+  NullEntry(Device* device, Entry* parent, std::string path);
+  ~NullEntry() override;
+
+  static NullEntry* Create(Device* device, Entry* parent,
+                           const std::string& path);
+
+  X_STATUS Open(uint32_t desired_access, File** out_file) override;
+
+  bool can_map() const override { return false; }
+
+ private:
+  friend class NullDevice;
+};
+
+}  // namespace vfs
+}  // namespace xe
+
+#endif  // XENIA_VFS_DEVICES_NULL_ENTRY_H_

--- a/src/xenia/vfs/devices/null_file.cc
+++ b/src/xenia/vfs/devices/null_file.cc
@@ -1,0 +1,52 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/vfs/devices/null_file.h"
+
+#include "xenia/vfs/devices/null_entry.h"
+
+namespace xe {
+namespace vfs {
+
+NullFile::NullFile(uint32_t file_access, NullEntry* entry)
+    : File(file_access, entry) {}
+
+NullFile::~NullFile() = default;
+
+void NullFile::Destroy() { delete this; }
+
+X_STATUS NullFile::ReadSync(void* buffer, size_t buffer_length,
+                            size_t byte_offset, size_t* out_bytes_read) {
+  if (!(file_access_ & FileAccess::kFileReadData)) {
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+
+X_STATUS NullFile::WriteSync(const void* buffer, size_t buffer_length,
+                             size_t byte_offset, size_t* out_bytes_written) {
+  if (!(file_access_ &
+        (FileAccess::kFileWriteData | FileAccess::kFileAppendData))) {
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+
+X_STATUS NullFile::SetLength(size_t length) {
+  if (!(file_access_ & FileAccess::kFileWriteData)) {
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+
+}  // namespace vfs
+}  // namespace xe

--- a/src/xenia/vfs/devices/null_file.h
+++ b/src/xenia/vfs/devices/null_file.h
@@ -1,0 +1,40 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_VFS_DEVICES_NULL_FILE_H_
+#define XENIA_VFS_DEVICES_NULL_FILE_H_
+
+#include <string>
+
+#include "xenia/base/filesystem.h"
+#include "xenia/vfs/file.h"
+
+namespace xe {
+namespace vfs {
+
+class NullEntry;
+
+class NullFile : public File {
+ public:
+  NullFile(uint32_t file_access, NullEntry* entry);
+  ~NullFile() override;
+
+  void Destroy() override;
+
+  X_STATUS ReadSync(void* buffer, size_t buffer_length, size_t byte_offset,
+                    size_t* out_bytes_read) override;
+  X_STATUS WriteSync(const void* buffer, size_t buffer_length,
+                     size_t byte_offset, size_t* out_bytes_written) override;
+  X_STATUS SetLength(size_t length) override;
+};
+
+}  // namespace vfs
+}  // namespace xe
+
+#endif  // XENIA_VFS_DEVICES_NULL_FILE_H_

--- a/src/xenia/vfs/virtual_file_system.cc
+++ b/src/xenia/vfs/virtual_file_system.cc
@@ -13,6 +13,8 @@
 #include "xenia/base/string.h"
 #include "xenia/kernel/xfile.h"
 
+DEFINE_bool(mount_cache, false, "Enable cache mount", "Storage");
+
 namespace xe {
 namespace vfs {
 

--- a/src/xenia/vfs/virtual_file_system.h
+++ b/src/xenia/vfs/virtual_file_system.h
@@ -15,10 +15,13 @@
 #include <unordered_map>
 #include <vector>
 
+#include "xenia/base/cvar.h"
 #include "xenia/base/mutex.h"
 #include "xenia/vfs/device.h"
 #include "xenia/vfs/entry.h"
 #include "xenia/vfs/file.h"
+
+DECLARE_bool(mount_cache);
 
 namespace xe {
 namespace vfs {


### PR DESCRIPTION
Right now it seems even with `mount_cache` enabled, when games call XMountUtilityDrive (compiled into the XEX, from some SDK lib I guess) it'll fail due to checking some things we don't handle atm.

In best case the game will ignore the result and still access cache anyway, but in worst case the game may use the result to determine if HDD is even available at all (eg. pretty much all Halo games will only recognize HDD if this succeeds)

Fortunately the function isn't too complex to work around, mostly just needs some NtOpenFile/NtWriteFile calls to the `Partition1/Cache0/Cache1` devices to succeed, I've handled this in here by creating a new NullDevice class that just returns success to every call made to it. If mount_cache is set then `\Device\Harddisk0` will be created as a NullDevice, which then handles the `Partition1/Cache0/Cache1` paths for us.

The harder bit is what happens after those checks, seems the game sets something up with XamTaskSchedule which handles the actual cache filesystem stuff for it.
(In the past I had to try getting around this part since we didn't have any impl for XamTaskSchedule, but thankfully the one added recently mostly satisfies it)

~~The code ran by XamTaskSchedule seems to fail for some reason though (maybe because of missing StfsCreateDevice kernel export or something related to that, couldn't really track down the cause), but it's not a huge issue since we can just change the result from XamTaskSchedule if we see that it's a cache-partition-related task (the code passes along an STFC header to the task, so we can check for the 0x4A6F7368 magic to know if it's a cache task, offset of the header can change depending on the game though.. probably different revisions of the cache code)~~

~~With that the XMountUtilityDrive func should return success, however there's still an issue with AFAIK XFlushUtilityDrive (from strings in Halo 3 Epsilon), which seems to set some event and then get stuck waiting on another event. It looks like the XamTask is supposed to handle these via a KeWaitForSingleObject loop (which I guess means XamTaskSchedule should be running the task in it's own thread), but since the task proc failed before it started that loop, there's nothing to set the event that Flush is waiting on...~~

~~Luckily this function will skip over all the event code if `XexCheckExecutablePrivilege(0xB)` is set, so I've just added a check to that func to return true if it's checking 0xB & the game has previously set up cache with XamTaskSchedule.
(XMountUtilityDrive also has a check for the same privilege and skips the XamTask stuff if set, but unfortunately some games can go down bad code paths if this privilege is always set, eg Sega Rally Revo... but making sure the game has actually tried mounting the cache partition beforehand seems to let it work fine)~~

EDIT: above can all be solved by making the XamTaskSchedule callback run in its own thread, making that happen is easier said than done though, my other replies go into why.

---

Of course all this is a workaround (that I've tried to make as un-hacky as I could), not a proper fix... I guess the alternative would be to implement all the cache/STFC stuff properly (which would then probably turn cache into 4GiB of inaccessible blob files...) though if anyone has any other ideas how it could be handled I'd be happy to hear them.

I don't really know if we want such multi-part workarounds to be part of main Xenia tree though so I'll leave this as a draft for now, hopefully it'll come in useful for others that want to look into cache partition stuff, or at least can be pointed to if anyone ever needs support for cache. (would appreciate any review of the code though!)

(btw if anyone wants to look into the XMountUtilityDrive func at all, searching for usages of XamTaskSchedule import should find it, usually the only func that uses that)

Affected titles:
- Halo 3: HDD is now detected, allowing access to Theatre mode, and map cache files will get written into the cache folders
- Halo 3 Epsilon: similar to Halo 3, except some reason this needs NtWriteFile to support APC routines else it'll hang after writing to cache (#1410)
- Halo 3 Beta: will now load without error & is playable, as long as code is updated to also mount cache:\\, and support for import libraries is added (https://github.com/xenia-canary/xenia-canary/commit/e9eca0a4c95c8d3e8cbc7f94dbdf3af5ce9db2df)