### PR TITLE
[Kernel/IO] Implemented XFileRenameInformation

### DIFF
--- a/src/xenia/base/filesystem.cc
+++ b/src/xenia/base/filesystem.cc
@@ -24,5 +24,13 @@ bool CreateParentFolder(const std::filesystem::path& path) {
   return true;
 }
 
+bool FileHandle::Rename(const std::string_view file_name) {
+  std::error_code error_code;
+  auto new_path = path().parent_path() / file_name;
+
+  std::filesystem::rename(path(), new_path, error_code);
+  return error_code.value();
+}
+
 }  // namespace filesystem
 }  // namespace xe

--- a/src/xenia/base/filesystem.h
+++ b/src/xenia/base/filesystem.h
@@ -82,6 +82,8 @@ class FileHandle {
 
   const std::filesystem::path& path() const { return path_; }
 
+  bool Rename(const std::string_view file_name);
+
   // Reads the requested number of bytes from the file starting at the given
   // offset. The total number of bytes read is returned only if the complete
   // read succeeds.

--- a/src/xenia/kernel/info/file.h
+++ b/src/xenia/kernel/info/file.h
@@ -107,6 +107,13 @@ struct X_FILE_NETWORK_OPEN_INFORMATION {
 };
 static_assert_size(X_FILE_NETWORK_OPEN_INFORMATION, 56);
 
+struct X_FILE_RENAME_INFORMATION {
+  be<uint32_t> rename;
+  be<uint32_t> root_dir_handle;
+  X_ANSI_STRING ansi_string;
+};
+static_assert_size(X_FILE_RENAME_INFORMATION, 16);
+
 #pragma pack(pop)
 
 }  // namespace kernel

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -266,6 +266,10 @@ X_STATUS XFile::Write(uint32_t buffer_guest_address, uint32_t buffer_length,
 }
 
 X_STATUS XFile::SetLength(size_t length) { return file_->SetLength(length); }
+X_STATUS XFile::SetName(const std::string_view file_name) {
+  entry()->set_name(file_name);
+  return file_->SetName(file_name);
+}
 
 void XFile::RegisterIOCompletionPort(uint32_t key,
                                      object_ref<XIOCompletion> port) {

--- a/src/xenia/kernel/xfile.h
+++ b/src/xenia/kernel/xfile.h
@@ -110,6 +110,7 @@ class XFile : public XObject {
                  uint32_t apc_context);
 
   X_STATUS SetLength(size_t length);
+  X_STATUS SetName(const std::string_view file_name);
 
   void RegisterIOCompletionPort(uint32_t key, object_ref<XIOCompletion> port);
   void RemoveIOCompletionPort(uint32_t key);

--- a/src/xenia/vfs/devices/disc_image_entry.h
+++ b/src/xenia/vfs/devices/disc_image_entry.h
@@ -35,6 +35,7 @@ class DiscImageEntry : public Entry {
   size_t data_offset() const { return data_offset_; }
   size_t data_size() const { return data_size_; }
 
+  void SetHostFileName(const std::string_view filename) override { return; }
   X_STATUS Open(uint32_t desired_access, File** out_file) override;
 
   bool can_map() const override { return true; }

--- a/src/xenia/vfs/devices/host_path_entry.cc
+++ b/src/xenia/vfs/devices/host_path_entry.cc
@@ -109,6 +109,10 @@ bool HostPathEntry::DeleteEntryInternal(Entry* entry) {
   }
 }
 
+void HostPathEntry::SetHostFileName(const std::string_view filename) {
+  host_path_ = host_path_.parent_path() / filename;
+}
+
 void HostPathEntry::update() {
   xe::filesystem::FileInfo file_info;
   if (!xe::filesystem::GetInfo(host_path_, &file_info)) {

--- a/src/xenia/vfs/devices/host_path_entry.h
+++ b/src/xenia/vfs/devices/host_path_entry.h
@@ -31,6 +31,7 @@ class HostPathEntry : public Entry {
                                xe::filesystem::FileInfo file_info);
 
   const std::filesystem::path& host_path() { return host_path_; }
+  void SetHostFileName(const std::string_view filename) override;
 
   X_STATUS Open(uint32_t desired_access, File** out_file) override;
 

--- a/src/xenia/vfs/devices/host_path_file.cc
+++ b/src/xenia/vfs/devices/host_path_file.cc
@@ -64,5 +64,13 @@ X_STATUS HostPathFile::SetLength(size_t length) {
   }
 }
 
+X_STATUS HostPathFile::SetName(const std::string_view file_name) {
+  if (file_handle_->Rename(file_name)) {
+    return X_STATUS_SUCCESS;
+  } else {
+    return X_STATUS_NO_SUCH_FILE;
+  }
+}
+
 }  // namespace vfs
 }  // namespace xe

--- a/src/xenia/vfs/devices/host_path_file.h
+++ b/src/xenia/vfs/devices/host_path_file.h
@@ -33,6 +33,7 @@ class HostPathFile : public File {
   X_STATUS WriteSync(const void* buffer, size_t buffer_length,
                      size_t byte_offset, size_t* out_bytes_written) override;
   X_STATUS SetLength(size_t length) override;
+  X_STATUS SetName(const std::string_view file_name) override;
 
  private:
   std::unique_ptr<xe::filesystem::FileHandle> file_handle_;

--- a/src/xenia/vfs/devices/stfs_container_entry.h
+++ b/src/xenia/vfs/devices/stfs_container_entry.h
@@ -40,6 +40,7 @@ class StfsContainerEntry : public Entry {
   size_t data_size() const { return data_size_; }
   size_t block() const { return block_; }
 
+  void SetHostFileName(const std::string_view filename) override { return; }
   X_STATUS Open(uint32_t desired_access, File** out_file) override;
 
   struct BlockRecord {

--- a/src/xenia/vfs/entry.cc
+++ b/src/xenia/vfs/entry.cc
@@ -44,6 +44,14 @@ void Entry::Dump(xe::StringBuffer* string_buffer, int indent) {
   }
 }
 
+void Entry::set_name(const std::string_view path) {
+  absolute_path_ = xe::utf8::join_guest_paths(device_->mount_path(), path);
+  path_ = xe::utf8::find_name_from_guest_path(path);
+  name_ = xe::utf8::find_name_from_guest_path(path);
+
+  SetHostFileName(name_);
+}
+
 bool Entry::is_read_only() const { return device_->is_read_only(); }
 
 Entry* Entry::GetChild(const std::string_view name) {

--- a/src/xenia/vfs/entry.h
+++ b/src/xenia/vfs/entry.h
@@ -94,6 +94,8 @@ class Entry {
   uint64_t access_timestamp() const { return access_timestamp_; }
   uint64_t write_timestamp() const { return write_timestamp_; }
 
+  void set_name(const std::string_view name);
+
   bool is_read_only() const;
 
   Entry* GetChild(const std::string_view name);
@@ -131,6 +133,7 @@ class Entry {
     return nullptr;
   }
   virtual bool DeleteEntryInternal(Entry* entry) { return false; }
+  virtual void SetHostFileName(const std::string_view filename) {};
 
   xe::global_critical_region global_critical_region_;
   Device* device_;

--- a/src/xenia/vfs/file.h
+++ b/src/xenia/vfs/file.h
@@ -45,6 +45,9 @@ class File {
   }
 
   virtual X_STATUS SetLength(size_t length) { return X_STATUS_NOT_IMPLEMENTED; }
+  virtual X_STATUS SetName(const std::string_view file_name) {
+    return X_STATUS_NOT_IMPLEMENTED;
+  }
 
   // xe::filesystem::FileAccess
   uint32_t file_access() const { return file_access_; }


### PR DESCRIPTION
TLDR: Some games uses ``XFileRenameInformation`` to rename savefiles adhoc.

I'm pulling it as draft. I'm not sure if everything works as intended and have proper names.

There is for sure missing path validation, but I had no idea where to put that function to be available where it is requred.

# Affected Titles:
[Nascar: Inside Line](https://github.com/xenia-project/game-compatibility/issues/1498)