### PR TITLE
[Kernel/IO] IoCompletion: Removed !wait_ticks check

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -458,7 +458,8 @@ dword_result_t NtSetIoCompletion(dword_t handle, dword_t key_context,
   port->QueueNotification(notification);
   return X_STATUS_SUCCESS;
 }
-DECLARE_XBOXKRNL_EXPORT1(NtSetIoCompletion, kFileSystem, kImplemented);
+DECLARE_XBOXKRNL_EXPORT2(NtSetIoCompletion, kFileSystem, kImplemented,
+                         kHighFrequency);
 
 // Dequeues a packet from the completion port.
 dword_result_t NtRemoveIoCompletion(
@@ -473,7 +474,9 @@ dword_result_t NtRemoveIoCompletion(
     status = X_STATUS_INVALID_HANDLE;
   }
 
-  uint64_t timeout_ticks = timeout ? static_cast<uint32_t>(*timeout) : 0u;
+  uint64_t timeout_ticks =
+      timeout ? static_cast<uint32_t>(*timeout)
+              : static_cast<uint64_t>(std::numeric_limits<int64_t>::min());
   XIOCompletion::IONotification notification;
   if (port->WaitForNotification(timeout_ticks, &notification)) {
     if (key_context) {
@@ -493,7 +496,8 @@ dword_result_t NtRemoveIoCompletion(
 
   return status;
 }
-DECLARE_XBOXKRNL_EXPORT1(NtRemoveIoCompletion, kFileSystem, kImplemented);
+DECLARE_XBOXKRNL_EXPORT2(NtRemoveIoCompletion, kFileSystem, kImplemented,
+                         kHighFrequency);
 
 dword_result_t NtQueryFullAttributesFile(
     pointer_t<X_OBJECT_ATTRIBUTES> obj_attribs,

--- a/src/xenia/kernel/xiocompletion.cc
+++ b/src/xenia/kernel/xiocompletion.cc
@@ -30,7 +30,7 @@ bool XIOCompletion::WaitForNotification(uint64_t wait_ticks,
                                         IONotification* notify) {
   auto ms = std::chrono::milliseconds(TimeoutTicksToMs(wait_ticks));
   auto res = threading::Wait(notification_semaphore_.get(), false, ms);
-  if (res == threading::WaitResult::kSuccess || !wait_ticks) {
+  if (res == threading::WaitResult::kSuccess) {
     std::unique_lock<std::mutex> lock(notification_lock_);
     assert_false(notifications_.empty());
 


### PR DESCRIPTION
By merging https://github.com/xenia-project/xenia/pull/1726 we introduced regression in at least 2 titles.

The case is that ``NtRemoveIoCompletion`` and ``NtSetIoCompletion`` are executed so frequently between 2 threads (iirc) that they run apart at some point what causes subthread that execute ``NtRemoveIoCompletion`` to run before main thread does ``NtSetIoCompletion`` and that causes lock.

I haven't found proper solution, however returning X_STATUS_SUCCESS instead of X_STATUS_TIMEOUT did a really nice trick.
I added note describing wth is going on just in case.

I also added these functions to high frequency one as in Monster High it can create 10gb log in around a minute. Which seems quite sketchy, but might be understanable. In WET they're using it to provide player movement (LOL)

What it resolved: (Thanks to https://github.com/Etokapa for testing)
- Crash in: Monster High & Monster Jam (Now they work even better than before)
- Huge memleak in WET during cutscenes

## Affected titles
- WET
- Monster Jam
- Monster High
- Naughty Bear
- <some more?>