### PR TITLE
[Kernel/XAM] XamEnumerate: Ignore clearing provided buffer

### DIFF
--- a/src/xenia/kernel/xam/xam_enum.cc
+++ b/src/xenia/kernel/xam/xam_enum.cc
@@ -57,7 +57,6 @@ uint32_t xeXamEnumerate(uint32_t handle, uint32_t flags, lpvoid_t buffer_ptr,
 
     result = X_ERROR_INSUFFICIENT_BUFFER;
     if (actual_buffer_size >= needed_buffer_size) {
-      buffer_ptr.Zero(actual_buffer_size);
       result =
           e->WriteItems(buffer_ptr.guest_address(), buffer_ptr.as<uint8_t*>(),
                         actual_buffer_size, &item_count);


### PR DESCRIPTION
It looks like XamEnumerate shouldn't care about provided buffer_size.

Disassembling xam.xex provide info that it only clears 0x1C bytes
![image](https://user-images.githubusercontent.com/153369/105747062-9195ee80-5f40-11eb-9aca-3ab59d0ed1a3.png)

Out of curiosity I patched one of the games that I have to provide custom value.
I checked 3 values:
- 0x10000
- 0x100000
- 0x20000000

For each of these values game went further just fine, which might suggest that XamEnumerate doesn't care about provided size