### PR TITLE
[XAM/Content] Set disposition for overlapped cases

### DIFF
--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -183,12 +183,9 @@ dword_result_t XamContentCreateEx(dword_t user_index, lpstring_t root_name,
   // 2 = opened
   uint32_t disposition = create ? 1 : 2;
   if (disposition_ptr) {
-    if (overlapped_ptr) {
-      // If async always set to zero, but don't set to a real value.
-      *disposition_ptr = 0;
-    } else {
-      *disposition_ptr = disposition;
-    }
+    // In case when overlapped_ptr exist we should clear disposition_ptr first
+    // however we're executing it immediately, so it's not required
+    *disposition_ptr = disposition;
   }
 
   if (create) {


### PR DESCRIPTION
Based on ``Bodycount`` game I figured out that in ``XamContentCreateEx`` we're not returning ``disposition`` when we're using ``overlap``.

I simply removed code responsible for clearing it out. We're using ``CompleteOverlappedImmediateEx`` to handle overlap, so it is instant anyway.

Fragment of code just in case 🐑 
![image](https://user-images.githubusercontent.com/153369/108342779-7d5dae00-71db-11eb-9468-9e9e7d3a050f.png)

# Affected Titles:
- Bodycount
