### PR TITLE
[Kernel/Memory] Return error when region_size is 0

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
@@ -80,7 +80,7 @@ dword_result_t NtAllocateVirtualMemory(lpdword_t base_addr_ptr,
   // it's simple today we could extend it to do better things in the future.
 
   // Must request a size.
-  if (!base_addr_ptr || !region_size_ptr) {
+  if (!base_addr_ptr || !region_size_ptr || !*region_size_ptr) {
     return X_STATUS_INVALID_PARAMETER;
   }
   // Check allocation type.
@@ -198,7 +198,7 @@ dword_result_t NtProtectVirtualMemory(lpdword_t base_addr_ptr,
   assert_true(debug_memory == 0);
 
   // Must request a size.
-  if (!base_addr_ptr || !region_size_ptr) {
+  if (!base_addr_ptr || !region_size_ptr || !*region_size_ptr) {
     return X_STATUS_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
Based on research on console and document provided by @Triang3l (Thanks 🦊 )

Link to document: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntallocatevirtualmemory

Last sentence from RegionSize description says: 

> RegionSize cannot be zero on input.


Right now we don't care when game provides 0 as region_size_ptr what causes it to be sucessful and allocate 2 pages (iirc)
Meanwhile this action should fail with code: ``X_STATUS_INVALID_PARAMETER``

# Impact
 - NBA Live games