### PR TITLE
UTF-8 edge cases.

### DIFF
--- a/src/xenia/base/utf8.cc
+++ b/src/xenia/base/utf8.cc
@@ -490,7 +490,20 @@ std::string join_paths(const std::string_view left_path,
   return result + std::string(right_path);
 }
 
-std::string join_paths(std::vector<std::string_view> paths,
+std::string join_paths(const std::vector<std::string>& paths,
+                       char32_t separator) {
+  std::string result;
+  auto it = paths.cbegin();
+  if (it != paths.cend()) {
+    result = *it++;
+    for (; it != paths.cend(); ++it) {
+      result = join_paths(result, *it, separator);
+    }
+  }
+  return result;
+}
+
+std::string join_paths(const std::vector<std::string_view>& paths,
                        char32_t separator) {
   std::string result;
   auto it = paths.cbegin();

--- a/src/xenia/base/utf8.cc
+++ b/src/xenia/base/utf8.cc
@@ -560,6 +560,9 @@ std::string find_name_from_path(const std::string_view path,
   // path is padded with separator
   size_t padding = 0;
   if (*it == uint32_t(separator)) {
+    if (it == begin) {
+      return std::string();
+    }
     --it;
     --end;
     padding = 1;
@@ -626,7 +629,11 @@ std::string find_base_path(const std::string_view path, char32_t separator) {
   auto it = end;
   --it;
 
+  // skip trailing separator
   if (*it == uint32_t(separator)) {
+    if (it == begin) {
+      return std::string();
+    }
     --it;
   }
 

--- a/src/xenia/base/utf8.cc
+++ b/src/xenia/base/utf8.cc
@@ -517,8 +517,20 @@ std::string fix_path_separators(const std::string_view path,
   std::string result;
   auto it = path_begin;
   auto last = it;
+
+  auto is_separator = [old_separator, new_separator](char32_t c) {
+    return c == uint32_t(old_separator) || c == uint32_t(new_separator);
+  };
+
+  // Begins with a separator
+  if (is_separator(*it)) {
+    utfcpp::append(new_separator, result);
+    ++it;
+    last = it;
+  }
+
   for (;;) {
-    it = std::find(it, path_end, uint32_t(old_separator));
+    it = std::find_if(it, path_end, is_separator);
     if (it == path_end) {
       break;
     }

--- a/src/xenia/base/utf8.h
+++ b/src/xenia/base/utf8.h
@@ -68,7 +68,10 @@ std::string join_paths(const std::string_view left_path,
                        const std::string_view right_path,
                        char32_t separator = kPathSeparator);
 
-std::string join_paths(std::vector<std::string_view> paths,
+std::string join_paths(const std::vector<std::string>& paths,
+                       char32_t separator = kPathSeparator);
+
+std::string join_paths(const std::vector<std::string_view>& paths,
                        char32_t separator = kPathSeparator);
 
 inline std::string join_paths(
@@ -86,7 +89,12 @@ inline std::string join_guest_paths(const std::string_view left_path,
   return join_paths(left_path, right_path, kGuestPathSeparator);
 }
 
-inline std::string join_guest_paths(std::vector<std::string_view> paths) {
+inline std::string join_guest_paths(const std::vector<std::string>& paths) {
+  return join_paths(paths, kGuestPathSeparator);
+}
+
+inline std::string join_guest_paths(
+    const std::vector<std::string_view>& paths) {
   return join_paths(paths, kGuestPathSeparator);
 }
 


### PR DESCRIPTION
[Base] Fix edge case in UTF-8 `find_name_from_path`/`find_base_path` with strings that consist of only a separator.
[Base] Dedupe new/old separators in UTF-8 `fix_path_separators`.
[Base] Plain string variant of UTF-8 `join_paths`.
Add macro for automatically testing both `/` and `\` of all path input/outputs.
Add more UTF-8 path edge cases.