### PR TITLE
[XAM] Achievement fixes.

### DIFF
--- a/src/xenia/kernel/xam/xam_enum.cc
+++ b/src/xenia/kernel/xam/xam_enum.cc
@@ -38,6 +38,8 @@ uint32_t xeXamEnumerate(uint32_t handle, uint32_t flags, lpvoid_t buffer_ptr,
   auto e = kernel_state()->object_table()->LookupObject<XEnumerator>(handle);
   if (!e) {
     result = X_ERROR_INVALID_HANDLE;
+  } else if (!buffer_ptr) {
+    result = X_ERROR_INVALID_PARAMETER;
   } else {
     size_t needed_buffer_size = e->item_size() * e->items_per_enumerate();
 

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -702,7 +702,7 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
     return result;
   }
 
-  for (uint8_t i = 0; i < count; ++i) {
+  for (uint32_t i = 0; i < count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
         i, u"Dummy Text", u"Dummy Text", u"Dummy Text"};
     e->AppendItem(item);

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -702,7 +702,8 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
     return result;
   }
 
-  for (uint32_t i = 0; i < count; ++i) {
+  uint32_t dummy_count = std::max(20u, uint32_t(count));
+  for (uint32_t i = 0; i < dummy_count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
         i, u"Dummy Text", u"Dummy Text", u"Dummy Text"};
     e->AppendItem(item);


### PR DESCRIPTION
[XAM] Fix missing buffer check on `XamEnumerate`.
[XAM] Fix infinite loop in adding dummy achievement details when `count`>255.
[XAM] Cap the number of dummy achievement details.