### PR TITLE
More achievement fixes

### DIFF
--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -737,6 +737,10 @@ dword_result_t XamReadTileToTexture(dword_t unknown, dword_t title_id,
                                     lpvoid_t buffer_ptr, dword_t stride,
                                     dword_t height, dword_t overlapped_ptr) {
   // TODO(gibbed): unknown=0,2,3,9
+
+  size_t size = size_t(stride) * size_t(height);
+  std::memset(buffer_ptr, 0xFF, size);
+
   if (overlapped_ptr) {
     kernel_state()->CompleteOverlappedImmediate(overlapped_ptr,
                                                 X_ERROR_SUCCESS);

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -703,7 +703,7 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
   }
 
   uint32_t dummy_count = std::min(100u, uint32_t(count));
-  for (uint32_t i = 0; i < dummy_count; ++i) {
+  for (uint32_t i = 1; i <= dummy_count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
         i, fmt::format(u"Dummy {}", i), u"Dummy description",
         u"Dummy unachieved"};

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -702,7 +702,7 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
     return result;
   }
 
-  uint32_t dummy_count = std::max(20u, uint32_t(count));
+  uint32_t dummy_count = std::min(20u, uint32_t(count));
   for (uint32_t i = 0; i < dummy_count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
         i, u"Dummy Text", u"Dummy Text", u"Dummy Text"};

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -702,7 +702,7 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
     return result;
   }
 
-  uint32_t dummy_count = std::min(20u, uint32_t(count));
+  uint32_t dummy_count = std::min(100u, uint32_t(count));
   for (uint32_t i = 0; i < dummy_count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
         i, u"Dummy Text", u"Dummy Text", u"Dummy Text"};

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -705,8 +705,15 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
   uint32_t dummy_count = std::min(100u, uint32_t(count));
   for (uint32_t i = 1; i <= dummy_count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
-        i, fmt::format(u"Dummy {}", i), u"Dummy description",
-        u"Dummy unachieved"};
+        i,  // dummy achievement id
+        fmt::format(u"Dummy {}", i),
+        u"Dummy description",
+        u"Dummy unachieved",
+        i,  // dummy image id
+        0,
+        {0, 0},
+        8};  // flags=8 makes dummy achievements show up in Crackdown's
+             // achievements list.
     e->AppendItem(item);
   }
 

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -705,7 +705,8 @@ dword_result_t XamUserCreateAchievementEnumerator(dword_t title_id,
   uint32_t dummy_count = std::min(100u, uint32_t(count));
   for (uint32_t i = 0; i < dummy_count; ++i) {
     auto item = XStaticAchievementEnumerator::AchievementDetails{
-        i, u"Dummy Text", u"Dummy Text", u"Dummy Text"};
+        i, fmt::format(u"Dummy {}", i), u"Dummy description",
+        u"Dummy unachieved"};
     e->AppendItem(item);
   }
 

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -732,15 +732,11 @@ dword_result_t XamParseGamerTileKey(lpdword_t key_ptr, lpdword_t out1_ptr,
 }
 DECLARE_XAM_EXPORT1(XamParseGamerTileKey, kUserProfiles, kStub);
 
-dword_result_t XamReadTileToTexture(dword_t unk1, dword_t unk2, dword_t unk3,
-                                    dword_t unk4, lpvoid_t buffer_ptr,
-                                    dword_t stride, dword_t height,
-                                    dword_t overlapped_ptr) {
-  // unk1: const?
-  // unk2: out0 from XamParseGamerTileKey
-  // unk3: some variant of out1/out2
-  // unk4: const?
-
+dword_result_t XamReadTileToTexture(dword_t unknown, dword_t title_id,
+                                    qword_t tile_id, dword_t user_index,
+                                    lpvoid_t buffer_ptr, dword_t stride,
+                                    dword_t height, dword_t overlapped_ptr) {
+  // TODO(gibbed): unknown=0,2,3,9
   if (overlapped_ptr) {
     kernel_state()->CompleteOverlappedImmediate(overlapped_ptr,
                                                 X_ERROR_SUCCESS);


### PR DESCRIPTION
[XAM] Fix dummy achievement details count.
[XAM] Cap dummy achievement details to 100.
[XAM] Better text for dummy achievement details.
[XAM] Base dummy achievement details at ID 1.
[XAM] Provide image ID and flags for dummy achievement details.
[XAM] Define unknown args for `XamReadTileToTexture`.
[XAM] Write stub texture buffer (white) in `XamReadTileToTexture`.