### PR TITLE
[XAM/Content] Improvements to aggregated content

### DIFF
--- a/src/xenia/kernel/xam/apps/xam_app.cc
+++ b/src/xenia/kernel/xam/apps/xam_app.cc
@@ -60,8 +60,8 @@ X_HRESULT XamApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       auto result = e->WriteItems(data->buffer_ptr, buffer, data->buffer_size,
                                   &item_count);
       assert_true(XSUCCEEDED(result));
-      assert_true(item_count == 1);
-      if (XSUCCEEDED(result)) {
+      assert_true(item_count <= 1);
+      if (XSUCCEEDED(result) && item_count == 1) {
         auto content_data = reinterpret_cast<XCONTENT_AGGREGATE_DATA*>(buffer);
         // TODO(gibbed): WTF?
         *reinterpret_cast<be<uint32_t>*>(&buffer[0x140]) =

--- a/src/xenia/kernel/xam/xam_content_aggregate.cc
+++ b/src/xenia/kernel/xam/xam_content_aggregate.cc
@@ -110,7 +110,7 @@ dword_result_t XamContentAggregateCreateEnumerator(qword_t xuid,
       content_aggregate_data.content_type = content_data.content_type;
       content_aggregate_data.display_name = content_data.display_name;
       content_aggregate_data.file_name = content_data.file_name;
-      content_aggregate_data.title_id = 1u;
+      content_aggregate_data.title_id = kernel_state()->title_id();
       content_aggregate_data.Write(item);
     }
   }


### PR DESCRIPTION
1. WriteItems returns not masked error codes which in case for example of 0x12 (NO_MORE_FILES) will be treated as success.
2. Instead of returning hardcoded 1 as title_id for content_aggregate_data let's use already loaded title_id. 

# Affected Titles
- Dead Rising 2 (correctly loads savefiles)
- EA sports series
- Something more?