### PR TITLE
[Build] Support building with the standalone VS Build Tools

### DIFF
--- a/xenia-build
+++ b/xenia-build
@@ -74,7 +74,16 @@ def import_vs_environment():
     install_path = None
     env_tool_args = None
 
-    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -prerelease -format json -utf8 -products Microsoft.VisualStudio.Product.BuildTools', shell=False, universal_newlines=True, encoding="utf-8")
+    vswhere = subprocess.check_output(
+        'third_party/vswhere/vswhere.exe -version "[15,)" -latest -prerelease -format json -utf8 -products '
+        "Microsoft.VisualStudio.Product.Enterprise "
+        "Microsoft.VisualStudio.Product.Professional "
+        "Microsoft.VisualStudio.Product.Community "
+        "Microsoft.VisualStudio.Product.BuildTools",
+        shell=False,
+        universal_newlines=True,
+        encoding="utf-8",
+    )
     if vswhere:
         vswhere = json.loads(vswhere)
     if vswhere and len(vswhere) > 0:

--- a/xenia-build
+++ b/xenia-build
@@ -74,7 +74,7 @@ def import_vs_environment():
     install_path = None
     env_tool_args = None
 
-    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -prerelease -format json -utf8', shell=False, universal_newlines=True, encoding="utf-8")
+    vswhere = subprocess.check_output('third_party/vswhere/vswhere.exe -version "[15,)" -latest -prerelease -format json -utf8 -products Microsoft.VisualStudio.Product.BuildTools', shell=False, universal_newlines=True, encoding="utf-8")
     if vswhere:
         vswhere = json.loads(vswhere)
     if vswhere and len(vswhere) > 0:


### PR DESCRIPTION
It has been possible for some time now to install the VS Build tools for C++ without installing the VS IDE. However, the current xenia build script doesn't support this because vswhere only searches for an installation of the VS IDE by default. This is easily fixable by adding `-products Microsoft.VisualStudio.Product.BuildTools` to the vswhere command and would work whether the VS IDE is installed or not.