### PR TITLE
[XAM] Implemented: XStaticContentEnumerator

### DIFF
--- a/src/xenia/kernel/xam/xam_enum.cc
+++ b/src/xenia/kernel/xam/xam_enum.cc
@@ -41,27 +41,8 @@ uint32_t xeXamEnumerate(uint32_t handle, uint32_t flags, lpvoid_t buffer_ptr,
   } else if (!buffer_ptr) {
     result = X_ERROR_INVALID_PARAMETER;
   } else {
-    size_t needed_buffer_size = e->item_size() * e->items_per_enumerate();
-
-    uint32_t actual_buffer_size = buffer_size;
-    if (buffer_size == e->items_per_enumerate()) {
-      actual_buffer_size = static_cast<uint32_t>(needed_buffer_size);
-      // Known culprits:
-      //   Final Fight: Double Impact (saves)
-      XELOGW(
-          "Broken usage of XamEnumerate! buffer size={:X} vs actual "
-          "size={:X} (item size={:X}, items per enumerate={})",
-          buffer_size, actual_buffer_size, e->item_size(),
-          e->items_per_enumerate());
-    }
-
-    result = X_ERROR_INSUFFICIENT_BUFFER;
-    if (actual_buffer_size >= needed_buffer_size) {
-      buffer_ptr.Zero(actual_buffer_size);
-      result =
-          e->WriteItems(buffer_ptr.guest_address(), buffer_ptr.as<uint8_t*>(),
-                        actual_buffer_size, &item_count);
-    }
+    result = e->WriteItems(buffer_ptr.guest_address(),
+                           buffer_ptr.as<uint8_t*>(), buffer_size, &item_count);
   }
 
   if (items_returned) {

--- a/src/xenia/kernel/xenumerator.cc
+++ b/src/xenia/kernel/xenumerator.cc
@@ -60,13 +60,16 @@ uint32_t XStaticEnumerator::WriteItems(uint32_t buffer_ptr,
                                        uint8_t* buffer_data,
                                        uint32_t buffer_size,
                                        uint32_t* written_count) {
+  memset(buffer_data, 0, buffer_size);
+
   size_t count = std::min(item_count_ - current_item_, items_per_enumerate());
   if (!count) {
     return X_ERROR_NO_MORE_FILES;
   }
 
   size_t size = count * item_size();
-  if (size > buffer_size) {
+  size_t needed_buffer_size = item_size() * items_per_enumerate();
+  if (size > buffer_size || buffer_size < needed_buffer_size) {
     return X_ERROR_INSUFFICIENT_BUFFER;
   }
 


### PR DESCRIPTION
Based on Rick's ``AchievementEnumerator``.

I had to split ``ContentEnumerator`` into separate entity because: 
1. It will allow to implement custom logic for that specific enumerator
2. Sometimes games instead of providing _buffer_size_ in bytes they provide some arbitrary value (probably max amount of files).

I probably forgot about something or something can be simplified, so please point that out. Thanks

Affected games:
- Splatterhouse
- ¯\_(ツ)_/¯ (We will see soon)