### PR TITLE
[XAM] XamShowSigninUI: Fix issue with loading profile(s)

### DIFF
--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -546,7 +546,12 @@ DECLARE_XAM_EXPORT1(XamUserAreUsersFriends, kUserProfiles, kStub);
 
 dword_result_t XamShowSigninUI(dword_t unk, dword_t unk_mask) {
   // Mask values vary. Probably matching user types? Local/remote?
-  // Games seem to sit and loop until we trigger this notification.
+
+  // To fix game modes that display a 4 profile signin UI (even if playing alone):
+  // XN_SYS_SIGNINCHANGED
+  kernel_state()->BroadcastNotification(0x0000000A, 1);
+  // Games seem to sit and loop until we trigger this notification:
+  // XN_SYS_UI (off)
   kernel_state()->BroadcastNotification(0x00000009, 0);
   return X_ERROR_SUCCESS;
 }


### PR DESCRIPTION
This fixes an issue with loading profiles when selecting certain game modes (even if playing alone).

Specifically in Perfect Dark XBLA when you would try to load up the Combat Simulator, Co-operative, or Counter-operative game modes the title would display a loading message, and then just boot the user back to the main menu. 
https://github.com/xenia-project/game-compatibility/issues/316#issuecomment-379186790

The system expects the 4 player sign in UI to show up and then be submitted, but Xenia did not send an XNotify confirming that had happened, so the title behaves as if the UI had been closed. 

Example of expected behavior on a real console (see 3:35):
https://www.youtube.com/watch?v=nHkzTpqnNRM

I am not sure if any other titles are impacted.