### PR TITLE
[APU] Add vectorized audio frame conversion

### DIFF
--- a/src/xenia/apu/xma_context.h
+++ b/src/xenia/apu/xma_context.h
@@ -187,7 +187,7 @@ class XmaContext {
 
   // Convert sample format and swap bytes
   static bool ConvertFrame(const uint8_t** samples, int num_channels,
-                           int num_samples, uint8_t* output_buffer);
+                           uint8_t* output_buffer);
 
   bool ValidFrameOffset(uint8_t* block, size_t size_bytes,
                         size_t frame_offset_bits);


### PR DESCRIPTION
Previously about 0.5 to 1 ms was spend converting frames from ffmpeg format (le float) to dsp format (be int16).
With this patch, conversion time is negligible.