### PR TITLE
[CPU/XEX] Use correct size for XEXP-patched header buffer

### DIFF
--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -249,12 +249,11 @@ int XexModule::ApplyPatch(XexModule* module) {
 
   // Patch base XEX header
   uint32_t original_image_size = module->image_size();
-  uint32_t header_target_size = patch_header->delta_headers_target_offset +
-                                patch_header->delta_headers_source_size;
+  uint32_t header_target_size = patch_header->size_of_target_headers;
 
   if (!header_target_size) {
-    header_target_size =
-        patch_header->size_of_target_headers;  // unsure which is more correct..
+    header_target_size = patch_header->delta_headers_target_offset +
+                         patch_header->delta_headers_source_size;
   }
 
   size_t mem_size = module->xex_header_mem_.size();


### PR DESCRIPTION
With Minecraft TU6 the previous code would allocate a buffer for the header which is too small, then when header delta-patch is applied it'd eventually overrun the header buffer and overwrite some other data, usually causing a crash (but not always)

The `size_of_target_headers` field seems to contain the correct size, but just in case it's not set somehow I also let it fall-back to the previous behaviour.

With this fix XEXP-patching should hopefully be pretty stable, at least Minecraft TU6-TU74 apparently don't have any issues after patching.

## Titles affected
- Minecraft: TU6 XEXP now applies fine, previously would crash soon after patch was applied.