### PR TITLE
[Kernel] Make KeEnter/LeaveCriticalRegion only affect the caller thread

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -960,14 +960,14 @@ void KeReleaseSpinLockFromRaisedIrql(lpdword_t lock_ptr) {
 DECLARE_XBOXKRNL_EXPORT2(KeReleaseSpinLockFromRaisedIrql, kThreading,
                          kImplemented, kHighFrequency);
 
-void KeEnterCriticalRegion() { XThread::EnterCriticalRegion(); }
+void KeEnterCriticalRegion() {
+  XThread::GetCurrentThread()->EnterCriticalRegion();
+}
 DECLARE_XBOXKRNL_EXPORT2(KeEnterCriticalRegion, kThreading, kImplemented,
                          kHighFrequency);
 
 void KeLeaveCriticalRegion() {
-  XThread::LeaveCriticalRegion();
-
-  XThread::GetCurrentThread()->CheckApcs();
+  XThread::GetCurrentThread()->LeaveCriticalRegion();
 }
 DECLARE_XBOXKRNL_EXPORT2(KeLeaveCriticalRegion, kThreading, kImplemented,
                          kHighFrequency);

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -578,11 +578,15 @@ void XThread::Reenter(uint32_t address) {
 }
 
 void XThread::EnterCriticalRegion() {
-  xe::global_critical_region::mutex().lock();
+  guest_object<X_KTHREAD>()->apc_disable_count--;
 }
 
 void XThread::LeaveCriticalRegion() {
-  xe::global_critical_region::mutex().unlock();
+  auto kthread = guest_object<X_KTHREAD>();
+  auto apc_disable_count = ++kthread->apc_disable_count;
+  if (apc_disable_count == 0) {
+    CheckApcs();
+  }
 }
 
 uint32_t XThread::RaiseIrql(uint32_t new_irql) {
@@ -593,11 +597,11 @@ void XThread::LowerIrql(uint32_t new_irql) { irql_ = new_irql; }
 
 void XThread::CheckApcs() { DeliverAPCs(); }
 
-void XThread::LockApc() { EnterCriticalRegion(); }
+void XThread::LockApc() { global_critical_region_.mutex().lock(); }
 
 void XThread::UnlockApc(bool queue_delivery) {
   bool needs_apc = apc_list_.HasPending();
-  LeaveCriticalRegion();
+  global_critical_region_.mutex().unlock();
   if (needs_apc && queue_delivery) {
     thread_->QueueUserCallback([this]() { DeliverAPCs(); });
   }
@@ -632,7 +636,8 @@ void XThread::DeliverAPCs() {
   // https://www.drdobbs.com/inside-nts-asynchronous-procedure-call/184416590?pgno=7
   auto processor = kernel_state()->processor();
   LockApc();
-  while (apc_list_.HasPending()) {
+  auto kthread = guest_object<X_KTHREAD>();
+  while (apc_list_.HasPending() && kthread->apc_disable_count == 0) {
     // Get APC entry (offset for LIST_ENTRY offset) and cache what we need.
     // Calling the routine may delete the memory/overwrite it.
     uint32_t apc_ptr = apc_list_.Shift() - 8;

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -111,7 +111,9 @@ struct X_KTHREAD {
   uint8_t unk_8B;                     // 0x8B
   uint8_t unk_8C[0x10];               // 0x8C
   xe::be<uint32_t> unk_9C;            // 0x9C
-  uint8_t unk_A0[0x1C];               // 0xA0
+  uint8_t unk_A0[0x10];               // 0xA0
+  int32_t apc_disable_count;          // 0xB0
+  uint8_t unk_B4[0x8];                // 0xB4
   uint8_t suspend_count;              // 0xBC
   uint8_t unk_BD;                     // 0xBD
   uint8_t unk_BE;                     // 0xBE
@@ -190,8 +192,8 @@ class XThread : public XObject, public cpu::Thread {
 
   virtual void Reenter(uint32_t address);
 
-  static void EnterCriticalRegion();
-  static void LeaveCriticalRegion();
+  void EnterCriticalRegion();
+  void LeaveCriticalRegion();
   uint32_t RaiseIrql(uint32_t new_irql);
   void LowerIrql(uint32_t new_irql);
 


### PR DESCRIPTION
Right now **KeEnterCriticalRegion** & **KeLeaveCriticalRegion** act on a global `xe::global_critical_region` shared between all threads, but AFAIK this seems to be wrong behaviour, most things I can find about NT's KeEnter/LeaveCriticalRegion say that those funcs should only be affecting APCs being ran on the caller thread and not all APCs globally, #1748 goes into this in more detail.

(that issue also talks about a problem this caused when trying to add threading to XamTaskSchedule, in a nutshell game code would run KeEnterCriticalRegion -> XamTaskSchedule -> WaitForSingleObject -> KeLeaveCriticalRegion, but as the critical region funcs affect all threads it'd stop XamTaskSchedule from being able to create/signal any other threads, only allowing code to run on the caller thread)

I've tried fixing this here by mostly doing the same as X360 kernel does, the critical region funcs now increment/decrement `X_KTHREAD[0xB0]`, and DeliverAPCs checks that value to see if APCs can be ran or not (also changed LockApc/UnlockApc code that needed to lock xe::global_critical_region and were using EnterCriticalRegion for it, just made them act on xe::global_critical_region directly instead)

With these changes XamTaskSchedule can now create/manage other threads when in the middle of a critical region fine, other than that I haven't really noticed any improvements in games, similarly I haven't seen any regressions from it neither (I haven't really tested with that many games myself though, but it's been merged into canary-experimental for a few weeks now, haven't seen issues reported from it).

If anyone knows a title that makes heavy use of those funcs it'd be great if you can try these changes with it.

---

Any thoughts about these changes would be appreciated, I've never really touched the threading stuff before so for all I know something here is a bad idea, or maybe there was a reason these funcs were setup as they were.

I don't think the new X_KTHREAD accesses need any kind of mutex/locks around them at least, since only the caller thread would be accessing them AFAIK.