### PR TITLE
[Base] Remove multiple trailing separators in path

### DIFF
--- a/src/xenia/base/testing/utf8_test.cc
+++ b/src/xenia/base/testing/utf8_test.cc
@@ -388,19 +388,38 @@ TEST_CASE("UTF-8 Fix Path Separators", "[utf8]") {
 
 TEST_CASE("UTF-8 Find Name From Path", "[utf8]") {
   TEST_PATH(utf8::find_name_from_path, "/", "");
+  TEST_PATH(utf8::find_name_from_path, "//", "");
+  TEST_PATH(utf8::find_name_from_path, "///", "");
   TEST_PATH(utf8::find_name_from_path, "foo/bar/baz/qux/", "qux");
+  TEST_PATH(utf8::find_name_from_path, "foo/bar/baz/qux//", "qux");
+  TEST_PATH(utf8::find_name_from_path, "foo/bar/baz/qux///", "qux");
   TEST_PATH(utf8::find_name_from_path, "foo/bar/baz/qux.txt", "qux.txt");
   TEST_PATH(utf8::find_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ/",
             "ほげほげ");
+  TEST_PATH(utf8::find_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "ほげほげ");
+  TEST_PATH(utf8::find_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ///",
+            "ほげほげ");
   TEST_PATH(utf8::find_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ.txt",
             "ほげほげ.txt");
+  TEST_PATH(utf8::find_name_from_path, "/foo", "foo");
+  TEST_PATH(utf8::find_name_from_path, "//foo", "foo");
+  TEST_PATH(utf8::find_name_from_path, "///foo", "foo");
   TEST_PATH(utf8::find_name_from_path, "/foo/bar/baz/qux.txt", "qux.txt");
   TEST_PATH(utf8::find_name_from_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ/",
+            "ほげほげ");
+  TEST_PATH(utf8::find_name_from_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "ほげほげ");
+  TEST_PATH(utf8::find_name_from_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ///",
             "ほげほげ");
   TEST_PATH(utf8::find_name_from_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ.txt",
             "ほげほげ.txt");
   TEST_PATH(utf8::find_name_from_path, "X:/foo/bar/baz/qux.txt", "qux.txt");
   TEST_PATH(utf8::find_name_from_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ/",
+            "ほげほげ");
+  TEST_PATH(utf8::find_name_from_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "ほげほげ");
+  TEST_PATH(utf8::find_name_from_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ///",
             "ほげほげ");
   TEST_PATH(utf8::find_name_from_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ.txt",
             "ほげほげ.txt");
@@ -413,26 +432,44 @@ TEST_CASE("UTF-8 Find Name From Path", "[utf8]") {
 TEST_CASE("UTF-8 Find Base Name From Path", "[utf8]") {
   TEST_PATH(utf8::find_base_name_from_path, "foo/bar/baz/qux.txt", "qux");
   TEST_PATH(utf8::find_base_name_from_path, "foo/bar/baz/qux/", "qux");
+  TEST_PATH(utf8::find_base_name_from_path, "foo/bar/baz/qux//", "qux");
+  TEST_PATH(utf8::find_base_name_from_path, "foo/bar/baz/qux///", "qux");
   TEST_PATH(utf8::find_base_name_from_path,
             "ほげ/ぴよ/ふが/ほげら/ほげほげ.txt", "ほげほげ");
   TEST_PATH(utf8::find_base_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ/",
+            "ほげほげ");
+  TEST_PATH(utf8::find_base_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "ほげほげ");
+  TEST_PATH(utf8::find_base_name_from_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ///",
             "ほげほげ");
   TEST_PATH(utf8::find_base_name_from_path, "ほげ/ぴよ/ふが/ほげら.ほげほげ",
             "ほげら");
   TEST_PATH(utf8::find_base_name_from_path, "/foo/bar/baz/qux.txt", "qux");
   TEST_PATH(utf8::find_base_name_from_path, "/foo/bar/baz/qux/", "qux");
+  TEST_PATH(utf8::find_base_name_from_path, "/foo/bar/baz/qux//", "qux");
+  TEST_PATH(utf8::find_base_name_from_path, "/foo/bar/baz/qux///", "qux");
   TEST_PATH(utf8::find_base_name_from_path,
             "/ほげ/ぴよ/ふが/ほげら/ほげほげ.txt", "ほげほげ");
   TEST_PATH(utf8::find_base_name_from_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ/",
             "ほげほげ");
+  TEST_PATH(utf8::find_base_name_from_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "ほげほげ");
+  TEST_PATH(utf8::find_base_name_from_path,
+            "/ほげ/ぴよ/ふが/ほげら/ほげほげ///", "ほげほげ");
   TEST_PATH(utf8::find_base_name_from_path, "/ほげ/ぴよ/ふが/ほげら.ほげほげ",
             "ほげら");
   TEST_PATH(utf8::find_base_name_from_path, "X:/foo/bar/baz/qux.txt", "qux");
   TEST_PATH(utf8::find_base_name_from_path, "X:/foo/bar/baz/qux/", "qux");
+  TEST_PATH(utf8::find_base_name_from_path, "X:/foo/bar/baz/qux//", "qux");
+  TEST_PATH(utf8::find_base_name_from_path, "X:/foo/bar/baz/qux///", "qux");
   TEST_PATH(utf8::find_base_name_from_path,
             "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ.txt", "ほげほげ");
   TEST_PATH(utf8::find_base_name_from_path,
             "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ/", "ほげほげ");
+  TEST_PATH(utf8::find_base_name_from_path,
+            "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ//", "ほげほげ");
+  TEST_PATH(utf8::find_base_name_from_path,
+            "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ///", "ほげほげ");
   TEST_PATH(utf8::find_base_name_from_path, "X:/ほげ/ぴよ/ふが/ほげら.ほげほげ",
             "ほげら");
 }
@@ -443,37 +480,78 @@ TEST_CASE("UTF-8 Find Base Path", "[utf8]") {
   TEST_PATH(utf8::find_base_path, "", "");
   TEST_PATH(utf8::find_base_path, "/", "");
   TEST_PATH(utf8::find_base_path, "//", "");
+  TEST_PATH(utf8::find_base_path, "///", "");
   TEST_PATH(utf8::find_base_path, "/foo", "");
+  TEST_PATH(utf8::find_base_path, "//foo", "");
+  TEST_PATH(utf8::find_base_path, "///foo", "");
   TEST_PATH(utf8::find_base_path, "/foo/", "");
+  TEST_PATH(utf8::find_base_path, "/foo//", "");
+  TEST_PATH(utf8::find_base_path, "/foo///", "");
+  TEST_PATH(utf8::find_base_path, "//foo/", "");
+  TEST_PATH(utf8::find_base_path, "//foo//", "");
+  TEST_PATH(utf8::find_base_path, "//foo///", "");
+  TEST_PATH(utf8::find_base_path, "///foo/", "");
+  TEST_PATH(utf8::find_base_path, "///foo//", "");
+  TEST_PATH(utf8::find_base_path, "///foo///", "");
   TEST_PATH(utf8::find_base_path, "/foo/bar", "/foo");
   TEST_PATH(utf8::find_base_path, "/foo/bar/", "/foo");
+  TEST_PATH(utf8::find_base_path, "/foo/bar//", "/foo");
+  TEST_PATH(utf8::find_base_path, "/foo/bar///", "/foo");
   TEST_PATH(utf8::find_base_path, "/foo/bar/baz/qux", "/foo/bar/baz");
   TEST_PATH(utf8::find_base_path, "/foo/bar/baz/qux/", "/foo/bar/baz");
+  TEST_PATH(utf8::find_base_path, "/foo/bar/baz/qux//", "/foo/bar/baz");
+  TEST_PATH(utf8::find_base_path, "/foo/bar/baz/qux///", "/foo/bar/baz");
   TEST_PATH(utf8::find_base_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ",
             "/ほげ/ぴよ/ふが/ほげら");
   TEST_PATH(utf8::find_base_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ/",
             "/ほげ/ぴよ/ふが/ほげら");
+  TEST_PATH(utf8::find_base_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "/ほげ/ぴよ/ふが/ほげら");
+  TEST_PATH(utf8::find_base_path, "/ほげ/ぴよ/ふが/ほげら/ほげほげ///",
+            "/ほげ/ぴよ/ふが/ほげら");
   TEST_PATH(utf8::find_base_path, "foo", "");
   TEST_PATH(utf8::find_base_path, "foo/", "");
+  TEST_PATH(utf8::find_base_path, "foo//", "");
+  TEST_PATH(utf8::find_base_path, "foo///", "");
   TEST_PATH(utf8::find_base_path, "foo/bar", "foo");
   TEST_PATH(utf8::find_base_path, "foo/bar/", "foo");
+  TEST_PATH(utf8::find_base_path, "foo/bar//", "foo");
+  TEST_PATH(utf8::find_base_path, "foo/bar///", "foo");
   TEST_PATH(utf8::find_base_path, "foo/bar/baz/qux", "foo/bar/baz");
   TEST_PATH(utf8::find_base_path, "foo/bar/baz/qux/", "foo/bar/baz");
+  TEST_PATH(utf8::find_base_path, "foo/bar/baz/qux//", "foo/bar/baz");
+  TEST_PATH(utf8::find_base_path, "foo/bar/baz/qux///", "foo/bar/baz");
   TEST_PATH(utf8::find_base_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ",
             "ほげ/ぴよ/ふが/ほげら");
   TEST_PATH(utf8::find_base_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ/",
             "ほげ/ぴよ/ふが/ほげら");
+  TEST_PATH(utf8::find_base_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "ほげ/ぴよ/ふが/ほげら");
+  TEST_PATH(utf8::find_base_path, "ほげ/ぴよ/ふが/ほげら/ほげほげ///",
+            "ほげ/ぴよ/ふが/ほげら");
   TEST_PATH(utf8::find_base_path, "X:", "");
   TEST_PATH(utf8::find_base_path, "X:/", "");
+  TEST_PATH(utf8::find_base_path, "X://", "");
+  TEST_PATH(utf8::find_base_path, "X:///", "");
   TEST_PATH(utf8::find_base_path, "X:/foo", "X:");
   TEST_PATH(utf8::find_base_path, "X:/foo/", "X:");
+  TEST_PATH(utf8::find_base_path, "X:/foo//", "X:");
+  TEST_PATH(utf8::find_base_path, "X:/foo///", "X:");
   TEST_PATH(utf8::find_base_path, "X:/foo/bar", "X:/foo");
   TEST_PATH(utf8::find_base_path, "X:/foo/bar/", "X:/foo");
+  TEST_PATH(utf8::find_base_path, "X:/foo/bar//", "X:/foo");
+  TEST_PATH(utf8::find_base_path, "X:/foo/bar///", "X:/foo");
   TEST_PATH(utf8::find_base_path, "X:/foo/bar/baz/qux", "X:/foo/bar/baz");
   TEST_PATH(utf8::find_base_path, "X:/foo/bar/baz/qux/", "X:/foo/bar/baz");
+  TEST_PATH(utf8::find_base_path, "X:/foo/bar/baz/qux//", "X:/foo/bar/baz");
+  TEST_PATH(utf8::find_base_path, "X:/foo/bar/baz/qux///", "X:/foo/bar/baz");
   TEST_PATH(utf8::find_base_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ",
             "X:/ほげ/ぴよ/ふが/ほげら");
   TEST_PATH(utf8::find_base_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ/",
+            "X:/ほげ/ぴよ/ふが/ほげら");
+  TEST_PATH(utf8::find_base_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ//",
+            "X:/ほげ/ぴよ/ふが/ほげら");
+  TEST_PATH(utf8::find_base_path, "X:/ほげ/ぴよ/ふが/ほげら/ほげほげ///",
             "X:/ほげ/ぴよ/ふが/ほげら");
 }
 
@@ -482,6 +560,8 @@ TEST_CASE("UTF-8 Find Base Path", "[utf8]") {
 TEST_CASE("UTF-8 Canonicalize Path", "[utf8]") {
   TEST_PATH(utf8::canonicalize_path, "foo/bar/baz/qux", "foo/bar/baz/qux");
   TEST_PATH(utf8::canonicalize_path, "foo/bar/baz/qux/", "foo/bar/baz/qux");
+  TEST_PATH(utf8::canonicalize_path, "foo/bar/baz/qux//", "foo/bar/baz/qux");
+  TEST_PATH(utf8::canonicalize_path, "foo/bar/baz/qux///", "foo/bar/baz/qux");
   TEST_PATH(utf8::canonicalize_path, "foo/./baz/qux", "foo/baz/qux");
   TEST_PATH(utf8::canonicalize_path, "foo/./baz/qux/", "foo/baz/qux");
   TEST_PATH(utf8::canonicalize_path, "foo/../baz/qux", "baz/qux");


### PR DESCRIPTION
Right now path like: ``game:\media\data360\\`` returns incorrectly file_name as empty string and base path as ``game:\media\data360``. In this case we should receive: ``data360`` as filename and ``game:\media\`` as base path.

Another way of dealing with it is by usage of ``fix_guest_path_separators``, but we would need to apply it to every path we're receiving, so this way is more universal 🤔 