### PR TITLE
[Base] Implement message boxes on Linux

### DIFF
--- a/src/xenia/base/main_posix.cc
+++ b/src/xenia/base/main_posix.cc
@@ -7,6 +7,9 @@
  ******************************************************************************
  */
 
+#include <stdio.h>
+#include <unistd.h>
+
 #include "xenia/base/cvar.h"
 #include "xenia/base/main.h"
 
@@ -16,7 +19,7 @@
 
 namespace xe {
 
-bool has_console_attached() { return true; }
+bool has_console_attached() { return isatty(fileno(stdin)) == 1; }
 
 void AttachConsole() {}
 

--- a/src/xenia/base/system.h
+++ b/src/xenia/base/system.h
@@ -11,7 +11,7 @@
 #define XENIA_BASE_SYSTEM_H_
 
 #include <filesystem>
-#include <string>
+#include <string_view>
 
 #include "xenia/base/string.h"
 

--- a/src/xenia/base/system_linux.cc
+++ b/src/xenia/base/system_linux.cc
@@ -7,14 +7,19 @@
  ******************************************************************************
  */
 
+#include <alloca.h>
+#include <dlfcn.h>
 #include <stdlib.h>
 
-#include <string>
+#include <cstring>
 
 #include "xenia/base/assert.h"
-#include "xenia/base/platform_linux.h"
+#include "xenia/base/logging.h"
 #include "xenia/base/string.h"
 #include "xenia/base/system.h"
+
+// Use headers in third party to not depend on system sdl headers for building
+#include "third_party/SDL2/include/SDL.h"
 
 namespace xe {
 
@@ -27,7 +32,39 @@ void LaunchWebBrowser(const std::string_view url) {
 void LaunchFileExplorer(const std::filesystem::path& path) { assert_always(); }
 
 void ShowSimpleMessageBox(SimpleMessageBoxType type, std::string_view message) {
-  assert_always();
+  void* libsdl2 = dlopen("libSDL2.so", RTLD_LAZY | RTLD_LOCAL);
+  assert_not_null(libsdl2);
+  if (libsdl2) {
+    auto* pSDL_ShowSimpleMessageBox =
+        reinterpret_cast<decltype(SDL_ShowSimpleMessageBox)*>(
+            dlsym(libsdl2, "SDL_ShowSimpleMessageBox"));
+    assert_not_null(pSDL_ShowSimpleMessageBox);
+    if (pSDL_ShowSimpleMessageBox) {
+      Uint32 flags;
+      const char* title;
+      char* message_copy = reinterpret_cast<char*>(alloca(message.size() + 1));
+      std::memcpy(message_copy, message.data(), message.size());
+      message_copy[message.size()] = '\0';
+
+      switch (type) {
+        default:
+        case SimpleMessageBoxType::Help:
+          title = "Xenia Help";
+          flags = SDL_MESSAGEBOX_INFORMATION;
+          break;
+        case SimpleMessageBoxType::Warning:
+          title = "Xenia Warning";
+          flags = SDL_MESSAGEBOX_WARNING;
+          break;
+        case SimpleMessageBoxType::Error:
+          title = "Xenia Error";
+          flags = SDL_MESSAGEBOX_ERROR;
+          break;
+      }
+      pSDL_ShowSimpleMessageBox(flags, title, message_copy, NULL);
+    }
+    dlclose(libsdl2);
+  }
 }
 
 }  // namespace xe


### PR DESCRIPTION
Use SDL for message boxes.
Loads SDL dynamically so we don't depend on it in `xenia-base`