### PR TITLE
[XAM] Return correct error code from GetServiceInfo

### DIFF
--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -47,7 +47,7 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
       // XONLINE_SERVICE_INFO structure.
       XELOGD("CXLiveLogon::GetServiceInfo({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return 1229;  // ERROR_CONNECTION_INVALID
+      return 0x80151802;  // ERROR_CONNECTION_INVALID
     }
     case 0x00058020: {
       // 0x00058004 is called right before this.


### PR DESCRIPTION
Based on PGR4 code

![image](https://user-images.githubusercontent.com/153369/125035998-ca5ef580-e092-11eb-9506-1fe5631f7e68.png)

Seems like ``XMsginProcessCall`` returns some internal code
I tried to use this: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781 to figure out what is correct message structure and define it correctly, but I had bad luck with it.

This fixes crash in PGR4 and Rainbow Six Vegas 2
