### PR TITLE
[VFS/Kernel] Improved cache partition support via XMountUtilityDrive workarounds

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -329,6 +329,22 @@ int xenia_main(const std::vector<std::string>& args) {
         emulator->file_system()->RegisterSymbolicLink("cache1:", "\\CACHE1");
       }
     }
+
+    // Some (older?) games try accessing cache:\ too
+    // NOTE: this must be registered _after_ the cache0/cache1 devices, due to
+    // substring/start_with logic inside VirtualFileSystem::ResolvePath, else
+    // accesses to those devices will go here instead
+    auto cache_device =
+        std::make_unique<xe::vfs::HostPathDevice>("\\CACHE", "cache", false);
+    if (!cache_device->Initialize()) {
+      XELOGE("Unable to scan cache path");
+    } else {
+      if (!emulator->file_system()->RegisterDevice(std::move(cache_device))) {
+        XELOGE("Unable to register cache path");
+      } else {
+        emulator->file_system()->RegisterSymbolicLink("cache:", "\\CACHE");
+      }
+    }
   }
 
   // Set a debug handler.

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -674,6 +674,66 @@ dword_result_t FscSetCacheElementCount(dword_t unk_0, dword_t unk_1) {
 }
 DECLARE_XBOXKRNL_EXPORT1(FscSetCacheElementCount, kFileSystem, kStub);
 
+dword_result_t NtDeviceIoControlFile(
+    dword_t handle, dword_t event_handle, dword_t apc_routine,
+    dword_t apc_context, dword_t io_status_block, dword_t io_control_code,
+    lpvoid_t input_buffer, dword_t input_buffer_len, lpvoid_t output_buffer,
+    dword_t output_buffer_len) {
+  // Called by XMountUtilityDrive cache-mounting code
+  // (checks if the returned values look valid, values below seem to pass the
+  // checks)
+  const uint32_t cache_size = 0xFF000;
+
+  const uint32_t X_IOCTL_DISK_GET_DRIVE_GEOMETRY = 0x70000;
+  const uint32_t X_IOCTL_DISK_GET_PARTITION_INFO = 0x74004;
+
+  if (io_control_code == X_IOCTL_DISK_GET_DRIVE_GEOMETRY) {
+    if (output_buffer_len < 0x8) {
+      assert_always();
+      return X_STATUS_BUFFER_TOO_SMALL;
+    }
+    xe::store_and_swap<uint32_t>(output_buffer, cache_size / 512);
+    xe::store_and_swap<uint32_t>(output_buffer + 4, 512);
+  } else if (io_control_code == X_IOCTL_DISK_GET_PARTITION_INFO) {
+    if (output_buffer_len < 0x10) {
+      assert_always();
+      return X_STATUS_BUFFER_TOO_SMALL;
+    }
+    xe::store_and_swap<uint64_t>(output_buffer, 0);
+    xe::store_and_swap<uint64_t>(output_buffer + 8, cache_size);
+  } else {
+    XELOGD("NtDeviceIoControlFile(0x{:X}) - unhandled IOCTL!",
+           uint32_t(io_control_code));
+    assert_always();
+    return X_STATUS_INVALID_PARAMETER;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+DECLARE_XBOXKRNL_EXPORT1(NtDeviceIoControlFile, kFileSystem, kStub);
+
+dword_result_t IoCreateDevice(dword_t device_struct, dword_t r4, dword_t r5,
+                              dword_t r6, dword_t r7, lpdword_t out_struct) {
+  // Called from XMountUtilityDrive XAM-task code
+  // That code tries writing things to a pointer at out_struct+0x18
+  // We'll alloc some scratch space for it so it doesn't cause any exceptions
+
+  // 0x24 is guessed size from accesses to out_struct - likely incorrect
+  auto out_guest = kernel_memory()->SystemHeapAlloc(0x24);
+
+  auto out = kernel_memory()->TranslateVirtual<uint8_t*>(out_guest);
+  memset(out, 0, 0x24);
+
+  // XMountUtilityDrive writes some kind of header here
+  // 0x1000 bytes should be enough to store it
+  auto out_guest2 = kernel_memory()->SystemHeapAlloc(0x1000);
+  xe::store_and_swap(out + 0x18, out_guest2);
+
+  *out_struct = out_guest;
+  return X_STATUS_SUCCESS;
+}
+DECLARE_XBOXKRNL_EXPORT1(IoCreateDevice, kFileSystem, kStub);
+
 void RegisterIoExports(xe::cpu::ExportResolver* export_resolver,
                        KernelState* kernel_state) {}
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io_info.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io_info.cc
@@ -126,6 +126,13 @@ dword_result_t NtQueryInformationFile(
       out_length = sizeof(*info);
       break;
     }
+    case XFileAlignmentInformation: {
+      // Requested by XMountUtilityDrive XAM-task
+      auto info = info_ptr.as<uint32_t*>();
+      *info = 0;  // FILE_BYTE_ALIGNMENT?
+      out_length = sizeof(*info);
+      break;
+    }
     default: {
       // Unsupported, for now.
       assert_always();

--- a/src/xenia/vfs/devices/null_device.cc
+++ b/src/xenia/vfs/devices/null_device.cc
@@ -1,0 +1,62 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/vfs/devices/null_device.h"
+
+#include "xenia/base/filesystem.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/math.h"
+#include "xenia/kernel/xfile.h"
+#include "xenia/vfs/devices/null_entry.h"
+
+namespace xe {
+namespace vfs {
+
+NullDevice::NullDevice(const std::string& mount_path,
+                       const std::initializer_list<std::string>& null_paths)
+    : Device(mount_path), null_paths_(null_paths), name_("NullDevice") {}
+
+NullDevice::~NullDevice() = default;
+
+bool NullDevice::Initialize() {
+  auto root_entry = new NullEntry(this, nullptr, mount_path_);
+  root_entry->attributes_ = kFileAttributeDirectory;
+  root_entry_ = std::unique_ptr<Entry>(root_entry);
+
+  for (auto path : null_paths_) {
+    auto child = NullEntry::Create(this, root_entry, path);
+    root_entry->children_.push_back(std::unique_ptr<Entry>(child));
+  }
+  return true;
+}
+
+void NullDevice::Dump(StringBuffer* string_buffer) {
+  auto global_lock = global_critical_region_.Acquire();
+  root_entry_->Dump(string_buffer, 0);
+}
+
+Entry* NullDevice::ResolvePath(const std::string_view path) {
+  XELOGFS("NullDevice::ResolvePath({})", path);
+
+  auto root = root_entry_.get();
+  if (path.empty()) {
+    return root_entry_.get();
+  }
+
+  for (auto& child : root->children()) {
+    if (!strcasecmp(child->path().c_str(), path.data())) {
+      return child.get();
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace vfs
+}  // namespace xe

--- a/src/xenia/vfs/devices/null_device.h
+++ b/src/xenia/vfs/devices/null_device.h
@@ -1,0 +1,57 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_VFS_DEVICES_NULL_DEVICE_H_
+#define XENIA_VFS_DEVICES_NULL_DEVICE_H_
+
+#include <string>
+
+#include "xenia/vfs/device.h"
+
+namespace xe {
+namespace vfs {
+
+class NullEntry;
+
+class NullDevice : public Device {
+ public:
+  NullDevice(const std::string& mount_path,
+             const std::initializer_list<std::string>& null_paths);
+  ~NullDevice() override;
+
+  bool Initialize() override;
+  void Dump(StringBuffer* string_buffer) override;
+  Entry* ResolvePath(const std::string_view path) override;
+
+  bool is_read_only() const override { return false; }
+
+  const std::string& name() const override { return name_; }
+  uint32_t attributes() const override { return 0; }
+  uint32_t component_name_max_length() const override { return 40; }
+
+  uint32_t total_allocation_units() const override { return 0x10; }
+  uint32_t available_allocation_units() const override { return 0x10; }
+
+  // STFC/cache code seems to require the product of the next two to equal
+  // 0x10000
+  uint32_t sectors_per_allocation_unit() const override { return 0x80; }
+
+  // STFC requires <= 0x1000
+  uint32_t bytes_per_sector() const override { return 0x200; }
+
+ private:
+  std::string name_;
+  std::unique_ptr<Entry> root_entry_;
+  std::vector<std::string> null_paths_;
+};
+
+}  // namespace vfs
+}  // namespace xe
+
+#endif  // XENIA_VFS_DEVICES_NULL_DEVICE_H_

--- a/src/xenia/vfs/devices/null_entry.cc
+++ b/src/xenia/vfs/devices/null_entry.cc
@@ -1,0 +1,55 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/vfs/devices/null_entry.h"
+
+#include "xenia/base/filesystem.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/mapped_memory.h"
+#include "xenia/base/math.h"
+#include "xenia/base/string.h"
+#include "xenia/vfs/device.h"
+#include "xenia/vfs/devices/null_file.h"
+
+namespace xe {
+namespace vfs {
+
+NullEntry::NullEntry(Device* device, Entry* parent, std::string path)
+    : Entry(device, parent, path) {}
+
+NullEntry::~NullEntry() = default;
+
+NullEntry* NullEntry::Create(Device* device, Entry* parent,
+                             const std::string& path) {
+  auto entry = new NullEntry(device, parent, path);
+
+  entry->create_timestamp_ = 0;
+  entry->access_timestamp_ = 0;
+  entry->write_timestamp_ = 0;
+
+  entry->attributes_ = kFileAttributeNormal;
+
+  entry->size_ = 0;
+  entry->allocation_size_ = 0;
+  return entry;
+}
+
+X_STATUS NullEntry::Open(uint32_t desired_access, File** out_file) {
+  if (is_read_only() && (desired_access & (FileAccess::kFileWriteData |
+                                           FileAccess::kFileAppendData))) {
+    XELOGE("Attempting to open file for write access on read-only device");
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  *out_file = new NullFile(desired_access, this);
+  return X_STATUS_SUCCESS;
+}
+
+}  // namespace vfs
+}  // namespace xe

--- a/src/xenia/vfs/devices/null_entry.h
+++ b/src/xenia/vfs/devices/null_entry.h
@@ -1,0 +1,42 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_VFS_DEVICES_NULL_ENTRY_H_
+#define XENIA_VFS_DEVICES_NULL_ENTRY_H_
+
+#include <string>
+
+#include "xenia/base/filesystem.h"
+#include "xenia/vfs/entry.h"
+
+namespace xe {
+namespace vfs {
+
+class NullDevice;
+
+class NullEntry : public Entry {
+ public:
+  NullEntry(Device* device, Entry* parent, std::string path);
+  ~NullEntry() override;
+
+  static NullEntry* Create(Device* device, Entry* parent,
+                           const std::string& path);
+
+  X_STATUS Open(uint32_t desired_access, File** out_file) override;
+
+  bool can_map() const override { return false; }
+
+ private:
+  friend class NullDevice;
+};
+
+}  // namespace vfs
+}  // namespace xe
+
+#endif  // XENIA_VFS_DEVICES_NULL_ENTRY_H_

--- a/src/xenia/vfs/devices/null_file.cc
+++ b/src/xenia/vfs/devices/null_file.cc
@@ -1,0 +1,52 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/vfs/devices/null_file.h"
+
+#include "xenia/vfs/devices/null_entry.h"
+
+namespace xe {
+namespace vfs {
+
+NullFile::NullFile(uint32_t file_access, NullEntry* entry)
+    : File(file_access, entry) {}
+
+NullFile::~NullFile() = default;
+
+void NullFile::Destroy() { delete this; }
+
+X_STATUS NullFile::ReadSync(void* buffer, size_t buffer_length,
+                            size_t byte_offset, size_t* out_bytes_read) {
+  if (!(file_access_ & FileAccess::kFileReadData)) {
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+
+X_STATUS NullFile::WriteSync(const void* buffer, size_t buffer_length,
+                             size_t byte_offset, size_t* out_bytes_written) {
+  if (!(file_access_ &
+        (FileAccess::kFileWriteData | FileAccess::kFileAppendData))) {
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+
+X_STATUS NullFile::SetLength(size_t length) {
+  if (!(file_access_ & FileAccess::kFileWriteData)) {
+    return X_STATUS_ACCESS_DENIED;
+  }
+
+  return X_STATUS_SUCCESS;
+}
+
+}  // namespace vfs
+}  // namespace xe

--- a/src/xenia/vfs/devices/null_file.h
+++ b/src/xenia/vfs/devices/null_file.h
@@ -1,0 +1,40 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_VFS_DEVICES_NULL_FILE_H_
+#define XENIA_VFS_DEVICES_NULL_FILE_H_
+
+#include <string>
+
+#include "xenia/base/filesystem.h"
+#include "xenia/vfs/file.h"
+
+namespace xe {
+namespace vfs {
+
+class NullEntry;
+
+class NullFile : public File {
+ public:
+  NullFile(uint32_t file_access, NullEntry* entry);
+  ~NullFile() override;
+
+  void Destroy() override;
+
+  X_STATUS ReadSync(void* buffer, size_t buffer_length, size_t byte_offset,
+                    size_t* out_bytes_read) override;
+  X_STATUS WriteSync(const void* buffer, size_t buffer_length,
+                     size_t byte_offset, size_t* out_bytes_written) override;
+  X_STATUS SetLength(size_t length) override;
+};
+
+}  // namespace vfs
+}  // namespace xe
+
+#endif  // XENIA_VFS_DEVICES_NULL_FILE_H_


### PR DESCRIPTION
(This is mostly the same as #1740, cleaned up a little & without the CriticalRegion stuff that was merged in with #1849, made this separate since that PR has some info I didn't want to delete)

With this PR the **XMountUtilityDrive** function statically-linked into games will hopefully always return success, which should help with games that use that function to test HDD availability (eg. all the Halo games)

This is mostly done with workarounds though, as the linked-in code seems to include nearly a whole filesystem implementation inside it AFAIK, using things like the Stfs* kernel functions that we don't currently handle.

Fortunately we can just return some status codes that the utility drive code expects instead, and let it think that the cache0:/cache1:/cache: symlinks were created by it (while those were actually already created by us earlier on, pointing to HostPathDevices), and with that hardly any of the cache-FS code inside the game actually needs to be ran.

(maybe in future it could be worth investigating how to make that FS stuff work properly, but with the end-result of that being a 500MB+ binary blob that no tools have any support for I didn't see much point in trying it myself... especially since all the cache partition accesses map over to Win32 folders fine, and there's not any STFS metadata or console-compatibility to worry about here)

---

A new **VFS::NullDevice** class is used to handle the `\Device\Harddisk0\Partition0`, `Cache0` & `Cache1` devices, as the XMountUtilityDrive code requires reads/writes to those paths to succeed. Right now a single NullDevice gets created for `\Device\Harddisk0` which then handles the Partition0/Cache0/Cache1 paths.

(maybe it'd be better if those paths were all separate NullDevice instances instead, but IIRC there's some limit with VFS that doesn't let device roots have handles opened for them, so this pretty much just treats Partition0/Cache0/Cache1 as files, which works fine for how the game accesses those devices)

**XamTaskSchedule** has been updated to spawn a new thread for each task - this is needed because XMountUtilityDrive seems to communicate some stuff with the task that it scheduled, updating some addrs & waiting for events to be signalled in response etc.

Haven't really looked into how Xam handles those tasks yet, mostly just got lucky that letting it spawn a new thread worked fine. (I'd guess it's probably not a single-thread task-queue at least since the code for these tasks can include busy/wait-loops, which would block any other tasks afaik)

There's also some functions for checking status of a task/forcing task to quit/etc, but haven't handled those yet, just stubbed ones that the XMountUtilityDrive/task code needed.

(If anyone knows what game the original XamTaskSchedule code was created for it'd be great if you can try it with this new threaded code!)

---

Some things I haven't handled here but might be nice to add in future:

- Cache currently persists between titles, as explained [in comments of #1664](https://github.com/xenia-project/xenia/pull/1664/files#r550715241) some games can have issues with cache from other titles though - X360 itself seems to clear the cache _partition_ between different titleids.

We could maybe just clear the cache folders whenever a game is launched, but this would destroy any data that games can use between runs (eg. Halo auto-recorded demos are stored in cache until user decides to save them properly IIRC)

(since `mount_cache` has to be opted-in atm this shouldn't really be much of a problem right now, if they're enabling mount_cache then hopefully they'd know to try clearing cache if they have issues)

- Could probably detect when game requests cache: access (inside NullDevice maybe, or when game tries running ObCreateSymbolicLink), and use that as the trigger for creating the cache folders & mounting cache HostPathDevices, instead of creating/mounting on Xenia launch & needing `mount_cache` to be set (could still include mount_cache as a way to disable cache stuff though)

---
### Tested titles

Tested with `mount_cache = true`
- Halo 3 MP Beta: previously would dirty-disc error if XMountUtilityDrive wasn't successful, now seems to boot up fine & writes some data into cache folder.

- Halo 3: now writes 300MB+ cacheXXX.map files into cache0/cache1, and allows access to Theater mode without any "No HDD connected" errors.
Theater demos from actual X360 can also be played here too (but quickly exits out with a desync error, could be worth looking at this some more...)

- Halo Reach: writes cacheXXX.map files into cache0/1 folders (game doesn't seem to render menus with latest xenia-master though so not sure about theater mode, maybe need to redump it...)

- Forza Motorsport 2: now writes some files into cache folder

- Sega Rally Revo: previous XMountUtilityDrive attempts (eg forcing TitleInsecureUtilityDrive privilege) would cause game to hang with a black-screen on boot, now continues onto loading screens

The XMountUtilityDrive code did change a lot over time (going from cache: to cache0: & cache1:, XEX privilege checks being added/removed...), so there's a chance some title might not work well with these workarounds, fortunately haven't ran into any yet though!