### PR TITLE
[Base] Fix fpfs with GCC/Clang

### DIFF
--- a/src/xenia/base/string_util.h
+++ b/src/xenia/base/string_util.h
@@ -221,7 +221,7 @@ inline T fpfs(const std::string_view value, bool force_hex) {
   } else {
 #if XE_COMPILER_CLANG || XE_COMPILER_GNUC
     auto temp = std::string(range);
-    result = std::strtof(temp.c_str(), nullptr);
+    result = std::strtod(temp.c_str(), nullptr);
 #else
     auto [p, error] = std::from_chars(range.data(), range.data() + range.size(),
                                       result, std::chars_format::general);


### PR DESCRIPTION
The fpfs function is using strtof to convert a string to floating point
value, but the type may be a double. Using strtof in that case won't
provide enough precision, so switch to using strtod. When the type is a
float, the double will be down-converted to the correct value.