### PR TITLE
[Config] Use locale-neutral fmt instead of to_string

### DIFF
--- a/src/xenia/base/cvar.h
+++ b/src/xenia/base/cvar.h
@@ -15,8 +15,9 @@
 #include <string>
 #include <vector>
 
-#include "cpptoml/include/cpptoml.h"
-#include "cxxopts/include/cxxopts.hpp"
+#include "third_party/cpptoml/include/cpptoml.h"
+#include "third_party/cxxopts/include/cxxopts.hpp"
+#include "third_party/fmt/include/fmt/format.h"
 #include "xenia/base/assert.h"
 #include "xenia/base/filesystem.h"
 #include "xenia/base/string_util.h"
@@ -216,7 +217,10 @@ inline std::string CommandVar<std::filesystem::path>::ToString(
 
 template <class T>
 std::string CommandVar<T>::ToString(T val) {
-  return std::to_string(val);
+  // Use fmt::format instead of std::to_string for locale-neutral formatting of
+  // floats, always with a period rather than a comma, which is treated as an
+  // unidentified trailing character by cpptoml.
+  return fmt::format("{}", val);
 }
 
 template <class T>


### PR DESCRIPTION
Suggested by @gibbed.

`std::to_string` may print floating-point numbers with a comma instead of a period on some locales (Russian, French) at least on Linux, which makes cpptoml fail to parse the previously generated config, and Xenia fails to start for the second time. `fmt::format` seems not to have such an issue (at least for the default format, without modifiers).

cpptoml tries to convert commas to periods, but that's not taken into account in overall value parsing — while looking for the end of the value, cpptoml only, in particular, checks if the character is not a period, but a comma is treated as an unidentified trailing character.

This change interacts with cpptoml and effects only config file writing, but doesn't change anything in cpptoml's logic, so compatibility of old configs shouldn't be affected — I think it should be safe to merge this part.

However, just not to forget, there's another parser of options, which is used for launch arguments — cxxopts. We possibly need to verify how cxxopts parses arguments on different operating systems and locales as well.

It's possible that we also need to verify reading of floats with a period in cpptoml across locales and operating systems, to ensure they're read correctly everywhere even when the system locale uses the comma.

I wasn't able to find other instances of `std::to_string` usage for floats. However, there's `snprintf` of a float in `DebugWindow::DrawRegisterTextBox` (possibly among other `(v)(s)(n)(w)printf` usages for floats) — also need to check all places where that happens and possibly update them to `fmt`, maybe as part of this pull request later, maybe in another one.