### PR TITLE
Fix "404 not found" on "Build commit on Github..."

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -429,7 +429,7 @@ void EmulatorWindow::ShowCommitID() {
       "https://github.com/xenia-project/xenia/pull/" XE_BUILD_PR_NUMBER);
 #else
   LaunchWebBrowser(
-      "https://github.com/xenia-project/xenia/commit/" XE_BUILD_COMMIT "/");
+      "https://github.com/xenia-project/xenia/commit/" XE_BUILD_COMMIT);
 #endif
 }
 


### PR DESCRIPTION
Removes a trailing slash from the URL