### PR TITLE
[Kernel] Added %L to formatter

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_strings.cc
@@ -290,6 +290,13 @@ int32_t format_core(PPCContext* ppc_context, FormatData& data, ArgList& args,
           }
           state = FS_Type;
           continue;
+        } else if (c == 'L') {
+          // 58410826 incorrectly uses 'L' instead of 'l'.
+          // TODO(gibbed): L appears to be treated as an invalid token by
+          // xboxkrnl, investigate how invalid tokens are processed in xboxkrnl
+          // formatting when state FF_Type is reached.
+          state = FS_Type;
+          continue;
         } else if (c == 'h') {
           flags |= FF_IsShort;
           state = FS_Type;


### PR DESCRIPTION
Based on [58410826](https://github.com/xenia-project/game-compatibility/issues/304):

It uses formatter for string: ``memory://%08LX,%LX``

Simple addition of 'L' to formatter resolves issues with this title.

Feel free to propose better PR/Commit name 🙇 Thanks