### PR TITLE
[APU] Skip audio header when there is no valid input

### DIFF
--- a/src/xenia/apu/xma_context.cc
+++ b/src/xenia/apu/xma_context.cc
@@ -301,7 +301,9 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
 
   // No available data.
   if (!data->input_buffer_0_valid && !data->input_buffer_1_valid) {
-    data->output_buffer_valid = 0;
+    // 4156081D checks specifically for offset 0x20 when both input buffers
+    // are invalid.
+    data->input_buffer_read_offset = kBitsPerHeader;
     return;
   }
 

--- a/src/xenia/apu/xma_context.h
+++ b/src/xenia/apu/xma_context.h
@@ -134,7 +134,7 @@ class XmaContext {
  public:
   static const uint32_t kBytesPerPacket = 2048;
   static const uint32_t kBitsPerPacket = kBytesPerPacket * 8;
-  static const uint32_t kBitsPerHeader = 33;
+  static const uint32_t kBitsPerHeader = 32;
 
   static const uint32_t kBytesPerSample = 2;
   static const uint32_t kSamplesPerFrame = 512;


### PR DESCRIPTION
Thanks Cancerous1/Randprint for initial research in this topic!

### Point of research:
![image](https://user-images.githubusercontent.com/153369/137682620-dbe4cbff-cffc-4b33-ba26-e400a15d9498.png)

r24 - Amount of invalid input buffers
r26 - Input offset
Interesting is ``lbz r10, 0x40(r11)`` I might be wrong, but that would mean that it checks a byte value from 10th dword from ``XMA_CONTEXT_DATA`` structure? Which is reserved/unknown?

### Research & changes
Initially I though that in such case output buffer should be invalidated, but after longer analysis and breaking game on console I figured out that it doesn't work like that. Instead it sets input offset to 0x20 (aka skips header) and go on.
Additionally I changed size of header constant because it doesn't match with xma_helpers and that offset.

### Concerns
What about context with no packets? Should it also set it to 0x20 or be invalidated completely?

### What it resolved:
This fixes buzzing sound in certain titles.

### What it breaks:
- https://github.com/xenia-project/game-compatibility/issues/293 - Causes to stuck before going ingame, but goes wrong even earlier
