### PR TITLE
[Kernel/Notify] Resolved missing version and mask_index

### DIFF
--- a/src/xenia/kernel/xnotifylistener.cc
+++ b/src/xenia/kernel/xnotifylistener.cc
@@ -32,7 +32,7 @@ void XNotifyListener::Initialize(uint64_t mask, uint32_t max_version) {
 }
 
 void XNotifyListener::EnqueueNotification(XNotificationID id, uint32_t data) {
-  auto key = XNotificationKey{id};
+  auto key = XNotificationKey(id);
   // Ignore if the notification doesn't match our mask.
   if ((mask_ & uint64_t(1ULL << key.mask_index)) == 0) {
     return;

--- a/src/xenia/kernel/xnotifylistener.h
+++ b/src/xenia/kernel/xnotifylistener.h
@@ -30,13 +30,8 @@ union XNotificationKey {
   };
   XNotificationID id;
 
-  static constexpr XNotificationID get_id(uint8_t mask_index,
-                                          uint16_t local_id) {
-    XNotificationKey key = {};
-    key.mask_index = mask_index;
-    key.local_id = local_id;
-    return key.id;
-  }
+  constexpr XNotificationKey(XNotificationID notification_id)
+      : id(notification_id){};
 };
 
 class XNotifyListener : public XObject {


### PR DESCRIPTION
As we talked on Discord.

RIght now created ``XNotificationKey`` lacks ``version`` and ``mask_index`` due to fields order in union (Thanks @Triang3l for sharing that wisdom).

That change resolves this issue and allows notifications from different groups to be corectly interpreted.