### PR TITLE
[Kernel/XMP] Fixed notification regression

### DIFF
--- a/src/xenia/kernel/xam/apps/xmp_app.cc
+++ b/src/xenia/kernel/xam/apps/xmp_app.cc
@@ -406,9 +406,6 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
              uint32_t(args->controller), uint32_t(args->locked));
 
       disabled_ = args->locked;
-      if (disabled_) {
-        XMPStop(0);
-      }
       kernel_state_->BroadcastNotification(kMsgDisableChanged, disabled_);
       return X_E_SUCCESS;
     }

--- a/src/xenia/kernel/xam/apps/xmp_app.h
+++ b/src/xenia/kernel/xam/apps/xmp_app.h
@@ -34,6 +34,10 @@ class XmpApp : public App {
     kPlaying = 1,
     kPaused = 2,
   };
+  enum class PlaybackClient : uint32_t {
+    kSystem = 0,
+    kTitle = 1,
+  };
   enum class PlaybackMode : uint32_t {
     // kInOrder = ?,
     kUnknown = 0,
@@ -90,12 +94,12 @@ class XmpApp : public App {
  private:
   static const uint32_t kMsgStateChanged = 0x0A000001;
   static const uint32_t kMsgPlaybackBehaviorChanged = 0x0A000002;
-  static const uint32_t kMsgDisableChanged = 0x0A000003;
+  static const uint32_t kMsgPlaybackControllerChanged = 0x0A000003;
 
   void OnStateChanged();
 
   State state_;
-  uint32_t disabled_;
+  PlaybackClient playback_client_;
   PlaybackMode playback_mode_;
   RepeatMode repeat_mode_;
   uint32_t unknown_flags_;


### PR DESCRIPTION
By fixing notification masks in commit: https://github.com/xenia-project/xenia/commit/fdec0ab332736b5d61f493649b83b1cbd239efd6 we accidentally broke few games.

Based on [4B4E0806](https://github.com/xenia-project/game-compatibility/issues/1621) I removed ``XMPStop`` from ``XMPSetPlaybackController`` responsibilities as it seems to be incorrect and causes game to get confused when it switches between playback clients. 

However [45410813](https://github.com/xenia-project/game-compatibility/issues/147) still had broken player. After spending some time debugging game and behaviour on console I figured out that ``locked`` in playback isn't locked, but it defines what have playback rights. Is it embedded media player or title itself. By changing that and provided notification state I managed to fix that player. 
Additionally it confirms uselessness of ``XMPStop`` in ``XMPSetPlaybackController``. By stopping system media player while being in menu it started playing title song, but not from start, but as it would run in the background whole time.