### PR TITLE
[Kernel] Added missing month to RtlTimeFieldsToTime

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_rtl.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_rtl.cc
@@ -529,9 +529,10 @@ DECLARE_XBOXKRNL_EXPORT1(RtlTimeToTimeFields, kNone, kImplemented);
 dword_result_t RtlTimeFieldsToTime(pointer_t<X_TIME_FIELDS> time_fields_ptr,
                                    lpqword_t time_ptr) {
   if (time_fields_ptr->year < 1601 || time_fields_ptr->month < 1 ||
-      time_fields_ptr->month > 11 || time_fields_ptr->day < 1 ||
-      time_fields_ptr->hour > 23 || time_fields_ptr->minute > 59 ||
-      time_fields_ptr->second > 59 || time_fields_ptr->milliseconds > 999) {
+      time_fields_ptr->month > 12 || time_fields_ptr->day < 1 ||
+      time_fields_ptr->day > 31 || time_fields_ptr->hour > 23 ||
+      time_fields_ptr->minute > 59 || time_fields_ptr->second > 59 ||
+      time_fields_ptr->milliseconds > 999) {
     return 0;
   }
   auto year = date::year{time_fields_ptr->year};


### PR DESCRIPTION
Additionally added check for highest possible month day

Source: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtltimefieldstotime (like from above implementation in Xenia)

``Month
Specifies a value from 1 to 12.`` but we had it up to 11 only.

# Affected Titles
https://github.com/xenia-project/game-compatibility/issues/29 - Resolves: Xbox live connection lost error