### PR TITLE
[x64] IsFeatureEnabled: Allow parallel feature checks

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -221,7 +221,7 @@ class X64Emitter : public Xbyak::CodeGenerator {
   Xbyak::Address StashConstantXmm(int index, const vec128_t& v);
 
   bool IsFeatureEnabled(uint32_t feature_flag) const {
-    return (feature_flags_ & feature_flag) != 0;
+    return (feature_flags_ & feature_flag) == feature_flag;
   }
 
   FunctionDebugInfo* debug_info() const { return debug_info_; }


### PR DESCRIPTION
Just checking if the resulting mask is non-zero means we cannot allow this function to check for multiple features in parallel. A hypothetical computer that supports FMA but not AVX2 will return `true` if you try to call `IsFeatureEnabled(kX64EmitFMA | kX64EmitAVX2)`. We should make sure all the masked flags return `true` rather than check for non-zero.

This is ramping up to allow for particular subsets of AVX512 to be checked for in parallel with a single function call.