### PR TITLE
[x64] Add `kX64EmitAVX512*` feature-flags

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -79,6 +79,14 @@ X64Emitter::X64Emitter(X64Backend* backend, XbyakAllocator* allocator)
     feature_flags_ |= cpu_.has(Xbyak::util::Cpu::tBMI2) ? kX64EmitBMI2 : 0;
     feature_flags_ |= cpu_.has(Xbyak::util::Cpu::tF16C) ? kX64EmitF16C : 0;
     feature_flags_ |= cpu_.has(Xbyak::util::Cpu::tMOVBE) ? kX64EmitMovbe : 0;
+    feature_flags_ |=
+        cpu_.has(Xbyak::util::Cpu::tAVX512F) ? kX64EmitAVX512F : 0;
+    feature_flags_ |=
+        cpu_.has(Xbyak::util::Cpu::tAVX512VL) ? kX64EmitAVX512VL : 0;
+    feature_flags_ |=
+        cpu_.has(Xbyak::util::Cpu::tAVX512BW) ? kX64EmitAVX512BW : 0;
+    feature_flags_ |=
+        cpu_.has(Xbyak::util::Cpu::tAVX512DQ) ? kX64EmitAVX512DQ : 0;
   }
 
   if (!cpu_.has(Xbyak::util::Cpu::tAVX)) {

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -131,6 +131,14 @@ enum X64EmitterFeatureFlags {
   kX64EmitBMI2 = 1 << 4,
   kX64EmitF16C = 1 << 5,
   kX64EmitMovbe = 1 << 6,
+
+  kX64EmitAVX512F = 1 << 7,
+  kX64EmitAVX512VL = 1 << 8,
+  kX64EmitAVX512Ortho = kX64EmitAVX512F | kX64EmitAVX512VL,
+
+  kX64EmitAVX512BW = 1 << 9,
+  kX64EmitAVX512DQ = 1 << 10,
+  kX64EmitAVX512Ortho64 = kX64EmitAVX512Ortho | kX64EmitAVX512DQ
 };
 
 class X64Emitter : public Xbyak::CodeGenerator {


### PR DESCRIPTION
Implements the detection of some baseline `AVX512` subsets and some common aliases into `X64EmitterFeatureFlags`.

So far, `AVX512{F,VL,BW,DQ}` are the only subsets of `AVX512` that are detected with this PR since I anticipate these are the ones that will actually be used a lot in the x64 backend. Some aliases are also implemented such as `kX64EmitAVX512Ortho` which is `AVX512F` and `AVX512VL` combined which are the two subsets of AVX512 required to allow for `AVX512` operations upon `ymm` and `xmm` registers.

These aliases can possibly be collapsed since we could just always require `AVX512VL` to be supported to allow for _any_ kind of `AVX512` to be used since we will practically always want to use `AVX512` on `xmm` registers at the very least as there is no use-case where we want to use the 512-bit `zmm` registers exclusively.

This PR depends upon #1932 since it involves parallel feature-checks.