### PR TITLE
[Base] Add user-literals for several memory sizes

### DIFF
--- a/src/xenia/base/arena.cc
+++ b/src/xenia/base/arena.cc
@@ -60,7 +60,7 @@ void* Arena::Alloc(size_t size, size_t align) {
 
   if (active_chunk_) {
     if (active_chunk_->capacity - active_chunk_->offset <
-        size + get_padding() + 4096) {
+        size + get_padding() + 4_KiB) {
       Chunk* next = active_chunk_->next;
       if (!next) {
         assert_true(size + get_padding() < chunk_size_,

--- a/src/xenia/base/arena.h
+++ b/src/xenia/base/arena.h
@@ -14,11 +14,15 @@
 #include <cstdint>
 #include <vector>
 
+#include "xenia/base/literals.h"
+
 namespace xe {
+
+using namespace xe::literals;
 
 class Arena {
  public:
-  explicit Arena(size_t chunk_size = 4 * 1024 * 1024);
+  explicit Arena(size_t chunk_size = 4_MiB);
   ~Arena();
 
   void Reset();

--- a/src/xenia/base/literals.h
+++ b/src/xenia/base/literals.h
@@ -1,0 +1,39 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_BASE_LITERALS_H_
+#define XENIA_BASE_LITERALS_H_
+
+#include <cstdint>
+
+namespace xe::literals {
+
+constexpr size_t operator""_KiB(unsigned long long int x) {
+  return 1024ULL * x;
+}
+
+constexpr size_t operator""_MiB(unsigned long long int x) {
+  return 1024_KiB * x;
+}
+
+constexpr size_t operator""_GiB(unsigned long long int x) {
+  return 1024_MiB * x;
+}
+
+constexpr size_t operator""_TiB(unsigned long long int x) {
+  return 1024_GiB * x;
+}
+
+constexpr size_t operator""_PiB(unsigned long long int x) {
+  return 1024_TiB * x;
+}
+
+}  // namespace xe::literals
+
+#endif  // XENIA_BASE_LITERALS_H_

--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -25,6 +25,7 @@
 #include "xenia/base/cvar.h"
 #include "xenia/base/debugging.h"
 #include "xenia/base/filesystem.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/math.h"
 #include "xenia/base/memory.h"
 #include "xenia/base/platform.h"
@@ -59,6 +60,7 @@ DEFINE_int32(
     "Logging");
 
 namespace dp = disruptorplus;
+using namespace xe::literals;
 
 namespace xe {
 
@@ -74,7 +76,7 @@ struct LogLine {
   char prefix_char;
 };
 
-thread_local char thread_log_buffer_[64 * 1024];
+thread_local char thread_log_buffer_[64_KiB];
 
 FileLogSink::~FileLogSink() {
   if (file_) {
@@ -234,7 +236,7 @@ class Logger {
   }
 
  private:
-  static const size_t kBufferSize = 8 * 1024 * 1024;
+  static const size_t kBufferSize = 8_MiB;
   uint8_t buffer_[kBufferSize];
 
   static const size_t kBlockSize = 256;

--- a/src/xenia/base/string_buffer.cc
+++ b/src/xenia/base/string_buffer.cc
@@ -13,12 +13,15 @@
 #include <cstdarg>
 
 #include "xenia/base/assert.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/math.h"
 
 namespace xe {
 
+using namespace xe::literals;
+
 StringBuffer::StringBuffer(size_t initial_capacity) {
-  buffer_capacity_ = std::max(initial_capacity, static_cast<size_t>(16 * 1024));
+  buffer_capacity_ = std::max(initial_capacity, static_cast<size_t>(16_KiB));
   buffer_ = reinterpret_cast<char*>(std::malloc(buffer_capacity_));
   assert_not_null(buffer_);
   buffer_[0] = 0;
@@ -40,7 +43,7 @@ void StringBuffer::Grow(size_t additional_length) {
   }
   size_t old_capacity = buffer_capacity_;
   size_t new_capacity =
-      std::max(xe::round_up(buffer_offset_ + additional_length, 16 * 1024),
+      std::max(xe::round_up(buffer_offset_ + additional_length, 16_KiB),
                old_capacity * 2);
   auto new_buffer = std::realloc(buffer_, new_capacity);
   assert_not_null(new_buffer);

--- a/src/xenia/base/testing/threading_test.cc
+++ b/src/xenia/base/testing/threading_test.cc
@@ -824,7 +824,7 @@ TEST_CASE("Create and Run Thread", "[thread]") {
   }
 
   SECTION("16kb stack size") {
-    params.stack_size = 16 * 1024 * 1024;
+    params.stack_size = 16_MiB;
     thread = Thread::Create(params, [] {
       Thread::Exit(-1);
       FAIL("Function must not return");

--- a/src/xenia/base/threading.h
+++ b/src/xenia/base/threading.h
@@ -25,10 +25,13 @@
 #include <vector>
 
 #include "xenia/base/assert.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/platform.h"
 
 namespace xe {
 namespace threading {
+
+using namespace xe::literals;
 
 #if XE_PLATFORM_ANDROID
 void AndroidInitialize();
@@ -368,7 +371,7 @@ struct ThreadPriority {
 class Thread : public WaitHandle {
  public:
   struct CreationParameters {
-    size_t stack_size = 4 * 1024 * 1024;
+    size_t stack_size = 4_MiB;
     bool create_suspended = false;
     int32_t initial_priority = 0;
   };

--- a/src/xenia/cpu/backend/x64/x64_code_cache.cc
+++ b/src/xenia/cpu/backend/x64/x64_code_cache.cc
@@ -20,6 +20,7 @@
 #include "third_party/fmt/include/fmt/format.h"
 #include "xenia/base/assert.h"
 #include "xenia/base/clock.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/memory.h"
@@ -30,6 +31,8 @@ namespace xe {
 namespace cpu {
 namespace backend {
 namespace x64 {
+
+using namespace xe::literals;
 
 X64CodeCache::X64CodeCache() = default;
 
@@ -227,7 +230,7 @@ void X64CodeCache::PlaceGuestCode(uint32_t guest_address, void* machine_code,
       old_commit_mark = generated_code_commit_mark_;
       if (high_mark <= old_commit_mark) break;
 
-      new_commit_mark = old_commit_mark + 16 * 1024 * 1024;
+      new_commit_mark = old_commit_mark + 16_MiB;
       if (generated_code_execute_base_ == generated_code_write_base_) {
         xe::memory::AllocFixed(generated_code_execute_base_, new_commit_mark,
                                xe::memory::AllocationType::kCommit,
@@ -310,7 +313,7 @@ uint32_t X64CodeCache::PlaceData(const void* data, size_t length) {
     old_commit_mark = generated_code_commit_mark_;
     if (high_mark <= old_commit_mark) break;
 
-    new_commit_mark = old_commit_mark + 16 * 1024 * 1024;
+    new_commit_mark = old_commit_mark + 16_MiB;
     if (generated_code_execute_base_ == generated_code_write_base_) {
       xe::memory::AllocFixed(generated_code_execute_base_, new_commit_mark,
                              xe::memory::AllocationType::kCommit,

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -18,6 +18,7 @@
 #include "xenia/base/assert.h"
 #include "xenia/base/atomic.h"
 #include "xenia/base/debugging.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/memory.h"
@@ -50,8 +51,9 @@ namespace x64 {
 
 using xe::cpu::hir::HIRBuilder;
 using xe::cpu::hir::Instr;
+using namespace xe::literals;
 
-static const size_t kMaxCodeSize = 1 * 1024 * 1024;
+static const size_t kMaxCodeSize = 1_MiB;
 
 static const size_t kStashOffset = 32;
 // static const size_t kStashOffsetHigh = 32 + 32;

--- a/src/xenia/cpu/ppc/testing/ppc_testing_main.cc
+++ b/src/xenia/cpu/ppc/testing/ppc_testing_main.cc
@@ -10,6 +10,7 @@
 #include "xenia/base/console_app_main.h"
 #include "xenia/base/cvar.h"
 #include "xenia/base/filesystem.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/platform.h"
@@ -36,6 +37,7 @@ namespace cpu {
 namespace test {
 
 using xe::cpu::ppc::PPCContext;
+using namespace xe::literals;
 
 typedef std::vector<std::pair<std::string, std::string>> AnnotationList;
 
@@ -177,7 +179,7 @@ class TestSuite {
 
 class TestRunner {
  public:
-  TestRunner() : memory_size_(64 * 1024 * 1024) {
+  TestRunner() : memory_size_(64_MiB) {
     memory_.reset(new Memory());
     memory_->Initialize();
   }

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -16,6 +16,7 @@
 #include "xenia/base/cvar.h"
 #include "xenia/base/debugging.h"
 #include "xenia/base/exception_handler.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/memory.h"
 #include "xenia/base/profiling.h"
@@ -56,6 +57,8 @@ namespace cpu {
 
 using xe::cpu::ppc::PPCOpcode;
 using xe::kernel::XThread;
+
+using namespace xe::literals;
 
 class BuiltinModule : public Module {
  public:
@@ -142,8 +145,8 @@ bool Processor::Setup(std::unique_ptr<backend::Backend> backend) {
   // Open the trace data path, if requested.
   functions_trace_path_ = cvars::trace_function_data_path;
   if (!functions_trace_path_.empty()) {
-    functions_trace_file_ = ChunkedMappedMemoryWriter::Open(
-        functions_trace_path_, 32 * 1024 * 1024, true);
+    functions_trace_file_ =
+        ChunkedMappedMemoryWriter::Open(functions_trace_path_, 32_MiB, true);
   }
 
   return true;

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -20,6 +20,7 @@
 #include "xenia/base/cvar.h"
 #include "xenia/base/debugging.h"
 #include "xenia/base/exception_handler.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/mapped_memory.h"
 #include "xenia/base/profiling.h"
@@ -59,6 +60,8 @@ DEFINE_string(
     "General");
 
 namespace xe {
+
+using namespace xe::literals;
 
 Emulator::Emulator(const std::filesystem::path& command_line,
                    const std::filesystem::path& storage_root,
@@ -415,8 +418,7 @@ bool Emulator::SaveToFile(const std::filesystem::path& path) {
   Pause();
 
   filesystem::CreateFile(path);
-  auto map = MappedMemory::Open(path, MappedMemory::Mode::kReadWrite, 0,
-                                1024ull * 1024ull * 1024ull * 2ull);
+  auto map = MappedMemory::Open(path, MappedMemory::Mode::kReadWrite, 0, 2_GiB);
   if (!map) {
     return false;
   }

--- a/src/xenia/gpu/d3d12/deferred_command_list.h
+++ b/src/xenia/gpu/d3d12/deferred_command_list.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "xenia/base/assert.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/math.h"
 #include "xenia/ui/d3d12/d3d12_api.h"
 
@@ -23,12 +24,14 @@ namespace xe {
 namespace gpu {
 namespace d3d12 {
 
+using namespace xe::literals;
+
 class D3D12CommandProcessor;
 
 class DeferredCommandList {
  public:
   DeferredCommandList(const D3D12CommandProcessor& command_processor,
-                      size_t initial_size_bytes = 1024 * 1024);
+                      size_t initial_size_bytes = 1_MiB);
 
   void Reset();
   void Execute(ID3D12GraphicsCommandList* command_list,

--- a/src/xenia/gpu/vulkan/texture_cache.cc
+++ b/src/xenia/gpu/vulkan/texture_cache.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 
 #include "third_party/fmt/include/fmt/format.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/memory.h"
@@ -36,8 +37,10 @@ namespace vulkan {
 
 using xe::ui::vulkan::CheckResult;
 
+using namespace xe::literals;
+
 constexpr uint32_t kMaxTextureSamplers = 32;
-constexpr VkDeviceSize kStagingBufferSize = 64 * 1024 * 1024;
+constexpr VkDeviceSize kStagingBufferSize = 64_MiB;
 
 const char* get_dimension_name(xenos::DataDimension dimension) {
   static const char* names[] = {

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -27,10 +27,12 @@ namespace xe {
 namespace gpu {
 namespace vulkan {
 
+using namespace xe::literals;
 using namespace xe::gpu::xenos;
+
 using xe::ui::vulkan::CheckResult;
 
-constexpr size_t kDefaultBufferCacheCapacity = 256 * 1024 * 1024;
+constexpr size_t kDefaultBufferCacheCapacity = 256_MiB;
 
 VulkanCommandProcessor::VulkanCommandProcessor(
     VulkanGraphicsSystem* graphics_system, kernel::KernelState* kernel_state)

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -14,6 +14,7 @@
 #include "third_party/fmt/include/fmt/format.h"
 #include "xenia/base/byte_stream.h"
 #include "xenia/base/clock.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/profiling.h"
@@ -40,6 +41,8 @@ const uint32_t XAPC::kDummyKernelRoutine;
 const uint32_t XAPC::kDummyRundownRoutine;
 
 using xe::cpu::ppc::PPCOpcode;
+
+using namespace xe::literals;
 
 uint32_t next_xthread_id_ = 0;
 
@@ -370,7 +373,7 @@ X_STATUS XThread::Create() {
   RetainHandle();
 
   xe::threading::Thread::CreationParameters params;
-  params.stack_size = 16 * 1024 * 1024;  // Allocate a big host stack.
+  params.stack_size = 16_MiB;  // Allocate a big host stack.
   params.create_suspended = true;
   thread_ = xe::threading::Thread::Create(params, [this]() {
     // Set thread ID override. This is used by logging.
@@ -1018,7 +1021,7 @@ object_ref<XThread> XThread::Restore(KernelState* kernel_state,
 
     xe::threading::Thread::CreationParameters params;
     params.create_suspended = true;  // Not done restoring yet.
-    params.stack_size = 16 * 1024 * 1024;
+    params.stack_size = 16_MiB;
     thread->thread_ = xe::threading::Thread::Create(params, [thread, state]() {
       // Set thread ID override. This is used by logging.
       xe::threading::set_current_thread_id(thread->handle());

--- a/src/xenia/ui/graphics_upload_buffer_pool.h
+++ b/src/xenia/ui/graphics_upload_buffer_pool.h
@@ -13,8 +13,12 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "xenia/base/literals.h"
+
 namespace xe {
 namespace ui {
+
+using namespace xe::literals;
 
 // Submission index is the fence value or a value derived from it (if reclaiming
 // less often than once per fence value, for instance).
@@ -23,7 +27,7 @@ class GraphicsUploadBufferPool {
  public:
   // Taken from the Direct3D 12 MiniEngine sample (LinearAllocator
   // kCpuAllocatorPageSize). Large enough for most cases.
-  static constexpr size_t kDefaultPageSize = 2 * 1024 * 1024;
+  static constexpr size_t kDefaultPageSize = 2_MiB;
 
   virtual ~GraphicsUploadBufferPool();
 

--- a/src/xenia/vfs/devices/disc_image_device.cc
+++ b/src/xenia/vfs/devices/disc_image_device.cc
@@ -9,6 +9,7 @@
 
 #include "xenia/vfs/devices/disc_image_device.h"
 
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/vfs/devices/disc_image_entry.h"
@@ -16,7 +17,9 @@
 namespace xe {
 namespace vfs {
 
-const size_t kXESectorSize = 2048;
+using namespace xe::literals;
+
+const size_t kXESectorSize = 2_KiB;
 
 DiscImageDevice::DiscImageDevice(const std::string_view mount_path,
                                  const std::filesystem::path& host_path)
@@ -89,7 +92,7 @@ DiscImageDevice::Error DiscImageDevice::Verify(ParseState* state) {
   state->root_size = xe::load<uint32_t>(fs_ptr + 24);
   state->root_offset =
       state->game_offset + (state->root_sector * kXESectorSize);
-  if (state->root_size < 13 || state->root_size > 32 * 1024 * 1024) {
+  if (state->root_size < 13 || state->root_size > 32_MiB) {
     return Error::kErrorDamagedFile;
   }
 

--- a/src/xenia/vfs/vfs_dump.cc
+++ b/src/xenia/vfs/vfs_dump.cc
@@ -13,6 +13,7 @@
 
 #include "xenia/base/console_app_main.h"
 #include "xenia/base/cvar.h"
+#include "xenia/base/literals.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 
@@ -21,6 +22,8 @@
 
 namespace xe {
 namespace vfs {
+
+using namespace xe::literals;
 
 DEFINE_transient_path(source, "", "Specifies the file to dump from.",
                       "General");
@@ -91,7 +94,7 @@ int vfs_dump_main(const std::vector<std::string>& args) {
         }
 
         // Allocate a buffer rounded up to the nearest 512MB.
-        buffer_size = xe::round_up(entry->size(), 512 * 1024 * 1024);
+        buffer_size = xe::round_up(entry->size(), 512_MiB);
         buffer = new uint8_t[buffer_size];
       }
 


### PR DESCRIPTION
Rather than using `n * 1024 * 1024`, this adds a convenient `_MiB`/`_KiB` user-literal to the new `literals.h` header to concisely describe units of memory in a much more readable way. Any other useful literals can be added to this header. These literals exist in the `xe::literals` namespace so they are opt-in, similar to `std::chrono` literals, and require a `using namespace xe::literals` statement to utilize it within the current scope.

I've done a pass through the codebase to replace trivial instances of `1024 * 1024 * ...` expressions being used but avoided anything that added additional casting complexity from `size_t` to `uint32_t` and such to keep this commit concise.