### PR TITLE
[Base] Add operator<< string conversion for vec128_t

### DIFF
--- a/src/xenia/base/string_util.h
+++ b/src/xenia/base/string_util.h
@@ -134,7 +134,7 @@ inline std::string to_hex_string(double value) {
 }
 
 inline std::string to_hex_string(const vec128_t& value) {
-  return fmt::format("[{:08X} {:08X} {:08X} {:08X} {:08X}]", value.u32[0],
+  return fmt::format("[{:08X} {:08X} {:08X} {:08X}]", value.u32[0],
                      value.u32[1], value.u32[2], value.u32[3]);
 }
 

--- a/src/xenia/base/vec128.cc
+++ b/src/xenia/base/vec128.cc
@@ -8,17 +8,24 @@
  */
 
 #include <cstddef>
+#include <ostream>
 #include <string>
 
 #include "third_party/fmt/include/fmt/format.h"
 #include "xenia/base/math.h"
 #include "xenia/base/platform.h"
+#include "xenia/base/string_util.h"
 #include "xenia/base/vec128.h"
 
 namespace xe {
 
 std::string to_string(const vec128_t& value) {
   return fmt::format("({}, {}, {}, {})", value.x, value.y, value.z, value.w);
+}
+
+std::ostream& operator<<(std::ostream& os, const vec128_t& value) {
+  os << string_util::to_hex_string(value);
+  return os;
 }
 
 }  // namespace xe

--- a/src/xenia/base/vec128.h
+++ b/src/xenia/base/vec128.h
@@ -257,6 +257,8 @@ static inline vec128_t vec128b(uint8_t x0, uint8_t x1, uint8_t x2, uint8_t x3,
 
 std::string to_string(const vec128_t& value);
 
+std::ostream& operator<<(std::ostream& os, const vec128_t& value);
+
 }  // namespace xe
 
 #endif  // XENIA_BASE_VEC128_H_


### PR DESCRIPTION
This allows `catch` to print out the contents of a particular vector when diagnosing how a `REQUIRE` expression has failed.

Before:
![ApplicationFrameHost_CnxMy71sEO](https://user-images.githubusercontent.com/644247/147889088-ad1c3d3f-f431-4fa0-b96c-c4aab637f693.png)

After:
![ApplicationFrameHost_VV7p8njAWa](https://user-images.githubusercontent.com/644247/147889089-c78b5c56-98d3-4650-b290-7b0778af14f1.png)

Also fixes an indexing issue in `string_util::to_hex_string`