### PR TITLE
X_ERWLOCK fixes

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -1199,6 +1199,24 @@ void ExAcquireReadWriteLockExclusive(pointer_t<X_ERWLOCK> lock_ptr) {
 DECLARE_XBOXKRNL_EXPORT2(ExAcquireReadWriteLockExclusive, kThreading,
                          kImplemented, kBlocking);
 
+dword_result_t ExTryToAcquireReadWriteLockExclusive(
+    pointer_t<X_ERWLOCK> lock_ptr) {
+  auto old_irql = xeKeKfAcquireSpinLock(&lock_ptr->spin_lock);
+
+  uint32_t result;
+  if (lock_ptr->lock_count < 0) {
+    lock_ptr->lock_count = 0;
+    result = 1;
+  } else {
+    result = 0;
+  }
+
+  xeKeKfReleaseSpinLock(&lock_ptr->spin_lock, old_irql);
+  return result;
+}
+DECLARE_XBOXKRNL_EXPORT1(ExTryToAcquireReadWriteLockExclusive, kThreading,
+                         kImplemented);
+
 void ExReleaseReadWriteLock(pointer_t<X_ERWLOCK> lock_ptr) {
   auto old_irql = xeKeKfAcquireSpinLock(&lock_ptr->spin_lock);
 


### PR DESCRIPTION
[xboxkrnl] `ExAcquireReadWriteLockExclusive` fixes:
- Don't unnecessarily double-load lock count.
- Don't release spin lock before we're done with the lock.

[xboxkrnl] `ExReleaseReadWriteLock` fixes:
- Don't unncessarily double-load lock members.
- Reset readers entry count when lock count becomes negative.
- Properly decrease writers waiting count when writer event fired.

[xboxkrnl] Implement `ExTryToAcquireReadWriteLockExclusive`.
[xboxkrnl] Implement `ExAcquireReadWriteLockShared`.
[xboxknrl] Implement `ExTryToAcquireReadWriteLockShared`.