### PR TITLE
[UI] Force use of Xwayland when running on Wayland

### DIFF
--- a/src/xenia/ui/windowed_app_main_posix.cc
+++ b/src/xenia/ui/windowed_app_main_posix.cc
@@ -18,6 +18,10 @@
 #include "xenia/ui/windowed_app_context_gtk.h"
 
 extern "C" int main(int argc_pre_gtk, char** argv_pre_gtk) {
+  // Before touching anything GTK+, make sure that when running on Wayland,
+  // we'll still get an X11 (Xwayland) window
+  setenv("GDK_BACKEND", "x11", 1);
+
   // Initialize GTK+, which will handle and remove its own arguments from argv.
   // Both GTK+ and Xenia use --option=value argument format (see man
   // gtk-options), however, it's meaningless to try to parse the same argument


### PR DESCRIPTION
This adds a workaround to make Xenia use Xwayland when creating a GTK window using Wayland, instead of creating a Wayland window and then triggering an `assert` in the code.

I contributed pretty much the same change to ares a while back: https://github.com/ares-emulator/ares/pull/9

Please note that I only made sure that Xenia starts properly with this change. I can't test any further due to this system not having a fully Vulkan-compatible driver.

Closes https://github.com/xenia-project/xenia/issues/1936