### PR TITLE
[Kernel] Add PVR opcode (includes cvars support)

### DIFF
--- a/src/xenia/cpu/cpu_flags.cc
+++ b/src/xenia/cpu/cpu_flags.cc
@@ -38,6 +38,13 @@ DEFINE_bool(
 DEFINE_bool(validate_hir, false,
             "Perform validation checks on the HIR during compilation.", "CPU");
 
+DEFINE_uint64(
+    pvr, 0x710700,
+    "Processor version and revision number.\nBits 0 to 15 are the version "
+    "number.\nBits 16 to 31 are the revision number.\nNote: Some XEXs (such as "
+    "mfgbootlauncher.xex) may check for a value that's less than 0x710700.",
+    "CPU");
+
 // Breakpoints:
 DEFINE_uint64(break_on_instruction, 0,
               "int3 before the given guest address is executed.", "CPU");

--- a/src/xenia/cpu/cpu_flags.h
+++ b/src/xenia/cpu/cpu_flags.h
@@ -26,6 +26,9 @@ DECLARE_bool(disable_global_lock);
 
 DECLARE_bool(validate_hir);
 
+DECLARE_uint64(pvr);
+
+// Breakpoints:
 DECLARE_uint64(break_on_instruction);
 DECLARE_int32(break_condition_gpr);
 DECLARE_uint64(break_condition_value);

--- a/src/xenia/cpu/ppc/ppc_emit_control.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_control.cc
@@ -620,6 +620,16 @@ int InstrEmit_mfspr(PPCHIRBuilder& f, const InstrData& i) {
       // TBU
       v = f.Shr(f.LoadClock(), 32);
       break;
+    case 287:
+      // [ Processor Version Register (PVR) ]
+      // PVR is a 32 bit, read-only register within the supervisor level.
+      // Bits 0 to 15 are the version number.
+      // Bits 16 to 31 are the revision number.
+      // Known Values: 0x710600?, 0x710700, 0x710800 (Corona?);
+      // Note: Some XEXs (such as mfgbootlauncher.xex) may check for a value
+      // that's less than 0x710700.
+      v = f.LoadConstantUint64(cvars::pvr);
+      break;
     default:
       XEINSTRNOTIMPLEMENTED();
       return 1;


### PR DESCRIPTION
Adds the PVR opcode to the list of recognized opcodes. Includes useful comments.

***Revival of #1464 (deleted fork)***