### PR TITLE
[x64] Add `GFNI`-based optimization for `VECTOR_SH{R,L}_V128(Int8)` and tests

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -742,9 +742,9 @@ struct VECTOR_SHL_V128
         }
         if (all_same) {
           // Every count is the same, so we can use gf2p8affineqb.
-          const uint8_t shift_amount = shamt.u8[0];
+          const uint8_t shift_amount = shamt.u8[0] & 0b111;
           const uint64_t shift_matrix =
-              0x0102040810204080 >> (shift_amount * 8);
+              UINT64_C(0x0102040810204080) >> (shift_amount * 8);
           e.vgf2p8affineqb(i.dest, i.src1,
                            e.StashConstantXmm(0, vec128q(shift_matrix)), 0);
           return;
@@ -950,8 +950,8 @@ struct VECTOR_SHR_V128
         }
         if (all_same) {
           // Every count is the same, so we can use gf2p8affineqb.
-          const uint8_t shift_amount = shamt.u8[0];
-          const uint64_t shift_matrix = 0x0102040810204080
+          const uint8_t shift_amount = shamt.u8[0] & 0b111;
+          const uint64_t shift_matrix = UINT64_C(0x0102040810204080)
                                         << (shift_amount * 8);
           e.vgf2p8affineqb(i.dest, i.src1,
                            e.StashConstantXmm(0, vec128q(shift_matrix)), 0);
@@ -1133,12 +1133,11 @@ struct VECTOR_SHA_V128
         }
         if (all_same) {
           // Every count is the same, so we can use gf2p8affineqb.
-          const uint8_t shift_amount = shamt.u8[0];
+          const uint8_t shift_amount = shamt.u8[0] & 0b111;
           const uint64_t shift_matrix =
-              shift_amount < 8
-                  ? (0x0102040810204080ULL << (shift_amount * 8)) |
-                        (0x8080808080808080ULL >> (64 - shift_amount * 8))
-                  : 0x8080808080808080ULL;
+              (UINT64_C(0x0102040810204080) << (shift_amount * 8)) |
+              (UINT64_C(0x8080808080808080) >> (64 - shift_amount * 8));
+          ;
           e.vgf2p8affineqb(i.dest, i.src1,
                            e.StashConstantXmm(0, vec128q(shift_matrix)), 0);
           return;

--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -731,6 +731,25 @@ struct VECTOR_SHL_V128
   static void EmitInt8(X64Emitter& e, const EmitArgType& i) {
     // TODO(benvanik): native version (with shift magic).
     if (i.src2.is_constant) {
+      if (e.IsFeatureEnabled(kX64EmitGFNI)) {
+        const auto& shamt = i.src2.constant();
+        bool all_same = true;
+        for (size_t n = 0; n < 16 - n; ++n) {
+          if (shamt.u8[n] != shamt.u8[n + 1]) {
+            all_same = false;
+            break;
+          }
+        }
+        if (all_same) {
+          // Every count is the same, so we can use gf2p8affineqb.
+          const uint8_t shift_amount = shamt.u8[0];
+          const uint64_t shift_matrix =
+              0x0102040810204080 >> (shift_amount * 8);
+          e.vgf2p8affineqb(i.dest, i.src1,
+                           e.StashConstantXmm(0, vec128q(shift_matrix)), 0);
+          return;
+        }
+      }
       e.lea(e.GetNativeParam(1), e.StashConstantXmm(1, i.src2.constant()));
     } else {
       e.lea(e.GetNativeParam(1), e.StashXmm(1, i.src2));
@@ -920,6 +939,25 @@ struct VECTOR_SHR_V128
   static void EmitInt8(X64Emitter& e, const EmitArgType& i) {
     // TODO(benvanik): native version (with shift magic).
     if (i.src2.is_constant) {
+      if (e.IsFeatureEnabled(kX64EmitGFNI)) {
+        const auto& shamt = i.src2.constant();
+        bool all_same = true;
+        for (size_t n = 0; n < 16 - n; ++n) {
+          if (shamt.u8[n] != shamt.u8[n + 1]) {
+            all_same = false;
+            break;
+          }
+        }
+        if (all_same) {
+          // Every count is the same, so we can use gf2p8affineqb.
+          const uint8_t shift_amount = shamt.u8[0];
+          const uint64_t shift_matrix = 0x0102040810204080
+                                        << (shift_amount * 8);
+          e.vgf2p8affineqb(i.dest, i.src1,
+                           e.StashConstantXmm(0, vec128q(shift_matrix)), 0);
+          return;
+        }
+      }
       e.lea(e.GetNativeParam(1), e.StashConstantXmm(1, i.src2.constant()));
     } else {
       e.lea(e.GetNativeParam(1), e.StashXmm(1, i.src2));
@@ -1087,8 +1125,8 @@ struct VECTOR_SHA_V128
       if (e.IsFeatureEnabled(kX64EmitGFNI)) {
         const auto& shamt = i.src2.constant();
         bool all_same = true;
-        for (size_t n = 0; n < 8 - n; ++n) {
-          if (shamt.u16[n] != shamt.u16[n + 1]) {
+        for (size_t n = 0; n < 16 - n; ++n) {
+          if (shamt.u8[n] != shamt.u8[n + 1]) {
             all_same = false;
             break;
           }

--- a/src/xenia/cpu/testing/vector_shl_test.cc
+++ b/src/xenia/cpu/testing/vector_shl_test.cc
@@ -58,6 +58,28 @@ TEST_CASE("VECTOR_SHL_I8_CONSTANT", "[instr]") {
       });
 }
 
+// This targets the "all_same" optimization of the Int8 specialization of
+// VECTOR_SHL_V128
+TEST_CASE("VECTOR_SHL_I8_SAME_CONSTANT", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreVR(
+        b, 3,
+        b.VectorShl(LoadVR(b, 4), b.LoadConstantVec128(vec128b(5)), INT8_TYPE));
+    b.Return();
+  });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->v[4] = vec128b(0x7E, 0x7E, 0x7E, 0x7F, 0x80, 0xFF, 0x01, 0x12,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+      },
+      [](PPCContext* ctx) {
+        auto result = ctx->v[3];
+        REQUIRE(result == vec128b(0xC0, 0xC0, 0xC0, 0xE0, 0x00, 0xE0, 0x20,
+                                  0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                  0x00, 0x00));
+      });
+}
+
 TEST_CASE("VECTOR_SHL_I16", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
     StoreVR(b, 3, b.VectorShl(LoadVR(b, 4), LoadVR(b, 5), INT16_TYPE));

--- a/src/xenia/cpu/testing/vector_shr_test.cc
+++ b/src/xenia/cpu/testing/vector_shr_test.cc
@@ -58,6 +58,28 @@ TEST_CASE("VECTOR_SHR_I8_CONSTANT", "[instr]") {
       });
 }
 
+// This targets the "all_same" optimization of the Int8 specialization of
+// VECTOR_SHR_V128
+TEST_CASE("VECTOR_SHR_I8_SAME_CONSTANT", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreVR(
+        b, 3,
+        b.VectorShr(LoadVR(b, 4), b.LoadConstantVec128(vec128b(3)), INT8_TYPE));
+    b.Return();
+  });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->v[4] = vec128b(0x7E, 0x7E, 0x7E, 0x7F, 0x80, 0xFF, 0x01, 0x12,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+      },
+      [](PPCContext* ctx) {
+        auto result = ctx->v[3];
+        REQUIRE(result == vec128b(0x0F, 0x0F, 0x0F, 0x0F, 0x10, 0x1F, 0x00,
+                                  0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                  0x00, 0x00));
+      });
+}
+
 TEST_CASE("VECTOR_SHR_I16", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
     StoreVR(b, 3, b.VectorShr(LoadVR(b, 4), LoadVR(b, 5), INT16_TYPE));


### PR DESCRIPTION
In the `Int8` case of `VECTOR_SH{R,L}_V128`, when all the values are the
same, then a single-instruction `gf2p8affineqb` can be emitted that does
an int8-based arithmetic-shift, utilizing GF(8) arithmetic.

More info here:
https://wunkolo.github.io/post/2020/11/gf2p8affineqb-int8-shifting/

Also fixes the iteration-type for when detecting if all of the simd
lanes are the same value(was iterating `u16` and not `u8`).

Also adds some tests for these cases