### PR TITLE
Improve vrefp & vrsqrtefp accuracy

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2020 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -653,6 +653,7 @@ void X64Emitter::MovMem64(const Xbyak::RegExp& addr, uint64_t v) {
 static const vec128_t xmm_consts[] = {
     /* XMMZero                */ vec128f(0.0f),
     /* XMMOne                 */ vec128f(1.0f),
+    /* XMMOnePD               */ vec128d(1.0),
     /* XMMNegativeOne         */ vec128f(-1.0f, -1.0f, -1.0f, -1.0f),
     /* XMMFFFF                */
     vec128i(0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu),

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2019 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -49,6 +49,7 @@ enum RegisterFlags {
 enum XmmConst {
   XMMZero = 0,
   XMMOne,
+  XMMOnePD,
   XMMNegativeOne,
   XMMFFFF,
   XMMMaskX16Y16,


### PR DESCRIPTION
Improving vrefp accuracy is especially important for 5454082B as it fixes:

- Grass flickering
- Cactus collision
- Random events (bandits, "pls help me", ...)
- Camp spawning
- Horse spawning

That particular title was affected at load time. The objects where probably loaded incorrectly into memory, vrefp was not involved in those issues once in-game.