### PR TITLE
[Wildcard] Match exact string if it doesn't contain any pattern

### DIFF
--- a/src/xenia/base/filesystem_wildcard.cc
+++ b/src/xenia/base/filesystem_wildcard.cc
@@ -19,6 +19,7 @@ namespace xe::filesystem {
 WildcardFlags WildcardFlags::FIRST(true, false, false);
 WildcardFlags WildcardFlags::LAST(false, true, false);
 WildcardFlags WildcardFlags::ANY(false, false, true);
+WildcardFlags WildcardFlags::FIRST_AND_LAST(true, true, false);
 
 WildcardFlags::WildcardFlags()
     : FromStart(false), ToEnd(false), ExactLength(false) {}
@@ -89,7 +90,8 @@ void WildcardEngine::PreparePattern(const std::string_view pattern) {
   }
   if (last != pattern.size()) {
     std::string str_str(pattern.substr(last));
-    rules_.push_back(WildcardRule(str_str, WildcardFlags::LAST));
+    rules_.push_back(WildcardRule(
+        str_str, last ? WildcardFlags::LAST : WildcardFlags::FIRST_AND_LAST));
   }
 }
 

--- a/src/xenia/base/filesystem_wildcard.h
+++ b/src/xenia/base/filesystem_wildcard.h
@@ -30,6 +30,7 @@ class WildcardFlags {
   static WildcardFlags FIRST;
   static WildcardFlags LAST;
   static WildcardFlags ANY;
+  static WildcardFlags FIRST_AND_LAST;
 };
 
 class WildcardRule {


### PR DESCRIPTION
TLDR:
This resolves such situation:

Provided pattern: ``abc.file``
Files in directory: ``aaabc.file, abc.file``

Actual behavior:
Returned file is: ``aabc.file``

Expected Behavior: 
Returned file is: ``abc.file``

This resolves:
https://github.com/xenia-project/game-compatibility/issues/480 - Requirement for protect_zero (was loading incorrect shader files)
https://github.com/xenia-project/game-compatibility/issues/1650 - Wasn't booting at all