### PR TITLE
Fix posix threading stuff 😿

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -277,7 +277,7 @@ def pipeline_linux_desktop(name, image, arch, cc, build_release_all):
                 'image': image,
                 'volumes': [volume_build('premake')],
                 'commands': [
-                    'valgrind --error-exitcode=99 ./build/bin/Linux/Debug/xenia-base-tests',
+                    'valgrind --error-exitcode=99 ./build/bin/Linux/Debug/xenia-base-tests --durations yes',
                 ],
                 'depends_on': ['build-premake-debug-tests'],
             },
@@ -287,7 +287,7 @@ def pipeline_linux_desktop(name, image, arch, cc, build_release_all):
                 'image': image,
                 'volumes': [volume_build('premake')],
                 'commands': [
-                    './build/bin/Linux/Release/xenia-base-tests',
+                    './build/bin/Linux/Release/xenia-base-tests --success --durations yes',
                 ],
                 'depends_on': ['build-premake-release-tests'],
             },
@@ -297,7 +297,7 @@ def pipeline_linux_desktop(name, image, arch, cc, build_release_all):
                 'image': image,
                 'volumes': [volume_build('cmake')],
                 'commands': [
-                    './build/bin/Linux/Release/xenia-base-tests',
+                    './build/bin/Linux/Release/xenia-base-tests --success --durations yes',
                 ],
                 'depends_on': ['build-cmake-release-tests'],
             },

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -17,6 +17,7 @@
 
 #include "xenia/app/discord/discord_presence.h"
 #include "xenia/app/emulator_window.h"
+#include "xenia/base/assert.h"
 #include "xenia/base/cvar.h"
 #include "xenia/base/debugging.h"
 #include "xenia/base/logging.h"
@@ -371,6 +372,7 @@ bool EmulatorApp::OnInitialize() {
   // Setup the emulator and run its loop in a separate thread.
   emulator_thread_quit_requested_.store(false, std::memory_order_relaxed);
   emulator_thread_event_ = xe::threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(emulator_thread_event_);
   emulator_thread_ = std::thread(&EmulatorApp::EmulatorThread, this);
 
   return true;

--- a/src/xenia/apu/audio_system.cc
+++ b/src/xenia/apu/audio_system.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -12,6 +12,7 @@
 #include "xenia/apu/apu_flags.h"
 #include "xenia/apu/audio_driver.h"
 #include "xenia/apu/xma_decoder.h"
+#include "xenia/base/assert.h"
 #include "xenia/base/byte_stream.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
@@ -45,14 +46,17 @@ AudioSystem::AudioSystem(cpu::Processor* processor)
   for (size_t i = 0; i < kMaximumClientCount; ++i) {
     client_semaphores_[i] =
         xe::threading::Semaphore::Create(0, kMaximumQueuedFrames);
+    assert_not_null(client_semaphores_[i]);
     wait_handles_[i] = client_semaphores_[i].get();
   }
   shutdown_event_ = xe::threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(shutdown_event_);
   wait_handles_[kMaximumClientCount] = shutdown_event_.get();
 
   xma_decoder_ = std::make_unique<xe::apu::XmaDecoder>(processor_);
 
   resume_event_ = xe::threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(resume_event_);
 }
 
 AudioSystem::~AudioSystem() {

--- a/src/xenia/apu/xma_decoder.cc
+++ b/src/xenia/apu/xma_decoder.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -139,6 +139,7 @@ X_STATUS XmaDecoder::Setup(kernel::KernelState* kernel_state) {
 
   worker_running_ = true;
   work_event_ = xe::threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(work_event_);
   worker_thread_ = kernel::object_ref<kernel::XHostThread>(
       new kernel::XHostThread(kernel_state, 128 * 1024, 0, [this]() {
         WorkerThreadMain();

--- a/src/xenia/base/delay_scheduler.cc
+++ b/src/xenia/base/delay_scheduler.cc
@@ -1,0 +1,111 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/base/delay_scheduler.h"
+#include "xenia/base/assert.h"
+#include "xenia/base/logging.h"
+
+namespace xe::internal {
+
+DelaySchedulerBase::~DelaySchedulerBase() {
+  if (call_on_destruct_) {
+    for (auto& slot : deletion_queue_) {
+      // No thread safety in destructors anyway
+      if (slot.state == State::kWaiting) {
+        callback_(slot.info);
+      }
+    }
+  }
+}
+
+void DelaySchedulerBase::Collect() {
+  static_assert(atomic_state_t::is_always_lock_free,
+                "Locks are unsafe to use with thread suspension");
+
+  for (auto& slot : deletion_queue_) {
+    TryCollectOne_impl(slot);
+  }
+}
+
+bool DelaySchedulerBase::TryCollectOne_impl(deletion_record_t& slot) {
+  auto now = clock::now();
+
+  auto state = State::kWaiting;
+  // Try to lock the waiting slot for reading the other fields
+  if (slot.state.compare_exchange_strong(state, State::kDeleting,
+                                         std::memory_order_acq_rel)) {
+    if (now > slot.due) {
+      // Time has passed, call back now
+      callback_(slot.info);
+      slot.info = nullptr;
+      slot.state.store(State::kFree, std::memory_order_release);
+      return true;
+    } else {
+      // Oops it's not yet due
+      slot.state.store(State::kWaiting, std::memory_order_release);
+    }
+  }
+  return false;
+}
+
+void DelaySchedulerBase::ScheduleAt_impl(
+    void* info, const clock::time_point& timeout_time) {
+  bool first_pass = true;
+
+  if (info == nullptr) {
+    return;
+  }
+
+  for (;;) {
+    if (TryScheduleAt_impl(info, timeout_time)) {
+      return;
+    }
+
+    if (first_pass) {
+      first_pass = false;
+      XELOGE(
+          "`DelayScheduler::ScheduleAt(...)` stalled: list is full! Find out "
+          "why or increase `MAX_QUEUE`.");
+    }
+  }
+}
+
+bool DelaySchedulerBase::TryScheduleAt_impl(
+    void* info, const clock::time_point& timeout_time) {
+  if (info == nullptr) {
+    return false;
+  }
+
+  for (auto& slot : deletion_queue_) {
+    // Clean up due item
+    TryCollectOne_impl(slot);
+
+    if (TryScheduleAtOne_impl(slot, info, timeout_time)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool DelaySchedulerBase::TryScheduleAtOne_impl(deletion_record_t& slot,
+                                               void* info,
+                                               clock::time_point due) {
+  auto state = State::kFree;
+  if (slot.state.compare_exchange_strong(state, State::kInitializing,
+                                         std::memory_order_acq_rel)) {
+    slot.info = info;
+    slot.due = due;
+    slot.state.store(State::kWaiting, std::memory_order_release);
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace xe::internal

--- a/src/xenia/base/delay_scheduler.h
+++ b/src/xenia/base/delay_scheduler.h
@@ -1,0 +1,142 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_BASE_DELAY_SCHEDULER_H_
+#define XENIA_BASE_DELAY_SCHEDULER_H_
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+namespace xe {
+
+namespace internal {
+// Put the implementation in a non templated base class to reduce compile time
+// and code duplication
+class DelaySchedulerBase {
+ protected:  // Types
+  enum class State : uint_least8_t {
+    kFree = 0,      // Slot is unsued
+    kInitializing,  // Slot is reserved and currently written to by a thread
+    kWaiting,       // The slot contains a pointer scheduled for deletion
+    kDeleting       // A thread is currently deleting the pointer
+  };
+  using atomic_state_t = std::atomic<State>;
+  using clock = std::chrono::steady_clock;
+  struct deletion_record_t {
+    atomic_state_t state;
+    void* info;
+    clock::time_point due;
+  };
+  using deletion_queue_t = std::vector<deletion_record_t>;
+  using callback_t = std::function<void(void*)>;
+
+ public:
+  /// Check all scheduled items in the queue and free any that are due using
+  /// `callback(info);`. Call this to reliably collect all due wait items in the
+  /// queue.
+  void Collect();
+
+  size_t size() { return deletion_queue_.size(); }
+
+ protected:  // Implementation
+  DelaySchedulerBase(size_t queue_size, callback_t callback,
+                     bool call_on_destruct)
+      : deletion_queue_(queue_size),
+        callback_(callback),
+        call_on_destruct_(call_on_destruct) {}
+  virtual ~DelaySchedulerBase();
+
+  void ScheduleAt_impl(void* info, const clock::time_point& timeout_time);
+  [[nodiscard]] bool TryScheduleAt_impl(void* info,
+                                        const clock::time_point& timeout_time);
+
+  /// Checks if the slot is due and if so, call back for it.
+  bool TryCollectOne_impl(deletion_record_t& slot);
+
+  [[nodiscard]] bool TryScheduleAtOne_impl(deletion_record_t& slot, void* info,
+                                           clock::time_point due);
+
+ private:
+  deletion_queue_t deletion_queue_;
+  callback_t callback_;
+  bool call_on_destruct_;
+};
+}  // namespace internal
+
+/// A lazy scheduler/timer.
+/// Will wait at least the specified duration before invoking the callbacks but
+/// might wait until it is destructed. Lockless thread-safe, will spinlock
+/// though if the wait queue is full (except for `Try`... methods). Might use
+/// any thread that calls any member to invoke callbacks of due wait items.
+template <typename INFO>
+class DelayScheduler : internal::DelaySchedulerBase {
+ public:
+  DelayScheduler(size_t queue_size, std::function<void(INFO*)> callback,
+                 bool call_on_destruct)
+      : DelaySchedulerBase(
+            queue_size,
+            [callback](void* info) { callback(reinterpret_cast<INFO*>(info)); },
+            call_on_destruct){};
+  DelayScheduler(const DelayScheduler&) = delete;
+  DelayScheduler& operator=(const DelayScheduler&) = delete;
+  virtual ~DelayScheduler() {}
+
+  // From base class:
+  // void Collect();
+
+  /// Schedule an object for deletion at some point after `timeout_time` using
+  /// `callback(info);`. Will collect any wait items it encounters which can be
+  /// 0 or all, use `Collect()` to collect all due wait items. Blocks until a
+  /// free wait slot is found.
+  template <class Clock, class Duration>
+  void ScheduleAt(
+      INFO* info,
+      const std::chrono::time_point<Clock, Duration>& timeout_time) {
+    ScheduleAt(info,
+               std::chrono::time_point_cast<clock::time_point>(timeout_time));
+  }
+  /// Like `ScheduleAt` but does not block on full list.
+  template <class Clock, class Duration>
+  [[nodiscard]] bool TryScheduleAt(
+      INFO* info,
+      const std::chrono::time_point<Clock, Duration>& timeout_time) {
+    return TryScheduleAt(
+        info, std::chrono::time_point_cast<clock::time_point>(timeout_time));
+  }
+
+  void ScheduleAt(INFO* info, const clock::time_point& timeout_time) {
+    ScheduleAt_impl(info, timeout_time);
+  }
+  [[nodiscard]] bool TryScheduleAt(INFO* info,
+                                   const clock::time_point& timeout_time) {
+    return TryScheduleAt_impl(info, timeout_time);
+  }
+
+  /// Schedule a callback at some point after `rel_time` has passed.
+  template <class Rep, class Period>
+  void ScheduleAfter(INFO* info,
+                     const std::chrono::duration<Rep, Period>& rel_time) {
+    ScheduleAt(info,
+               clock::now() + std::chrono::ceil<clock::duration>(rel_time));
+  }
+  /// Like `ScheduleAfter` but does not block.
+  template <class Rep, class Period>
+  [[nodiscard]] bool TryScheduleAfter(
+      INFO* info, const std::chrono::duration<Rep, Period>& rel_time) {
+    return TryScheduleAt(
+        info, clock::now() + std::chrono::ceil<clock::duration>(rel_time));
+  }
+};
+
+}  // namespace xe
+
+#endif

--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -224,6 +224,7 @@ class Logger {
 
     write_thread_ =
         xe::threading::Thread::Create({}, [this]() { WriteThread(); });
+    assert_not_null(write_thread_);
     write_thread_->set_name("Logging Writer");
   }
 

--- a/src/xenia/base/socket_win.cc
+++ b/src/xenia/base/socket_win.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2015 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -91,6 +91,7 @@ class Win32Socket : public Socket {
     // notifications.
     // Set true to start so we'll force a query of the socket on first run.
     event_ = xe::threading::Event::CreateManualResetEvent(true);
+    assert_not_null(event_);
     WSAEventSelect(socket_, event_->native_handle(), FD_READ | FD_CLOSE);
 
     // Keepalive for a looong time, as we may be paused by the debugger/etc.
@@ -279,6 +280,7 @@ class Win32SocketServer : public SocketServer {
         accept_callback_(std::move(client));
       }
     });
+    assert_not_null(accept_thread_);
 
     return true;
   }

--- a/src/xenia/base/threading_posix.cc
+++ b/src/xenia/base/threading_posix.cc
@@ -975,6 +975,10 @@ class PosixSemaphore : public PosixConditionHandle<Semaphore> {
 
 std::unique_ptr<Semaphore> Semaphore::Create(int initial_count,
                                              int maximum_count) {
+  if (initial_count < 0 || initial_count > maximum_count ||
+      maximum_count <= 0) {
+    return nullptr;
+  }
   return std::make_unique<PosixSemaphore>(initial_count, maximum_count);
 }
 

--- a/src/xenia/base/threading_win.cc
+++ b/src/xenia/base/threading_win.cc
@@ -66,7 +66,8 @@ static void set_name(HANDLE thread, const std::string_view name) {
     auto func =
         (SetThreadDescriptionFn)GetProcAddress(kernel, "SetThreadDescription");
     if (func) {
-      func(thread, reinterpret_cast<PCWSTR>(xe::to_utf16(name).c_str()));
+      auto u16name = xe::to_utf16(name);
+      func(thread, reinterpret_cast<PCWSTR>(u16name.c_str()));
     }
   }
   raise_thread_name_exception(thread, std::string(name));

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -41,7 +41,9 @@ CommandProcessor::CommandProcessor(GraphicsSystem* graphics_system,
       trace_writer_(graphics_system->memory()->physical_membase()),
       worker_running_(true),
       write_ptr_index_event_(xe::threading::Event::CreateAutoResetEvent(false)),
-      write_ptr_index_(0) {}
+      write_ptr_index_(0) {
+  assert_not_null(write_ptr_index_event_);
+}
 
 CommandProcessor::~CommandProcessor() = default;
 

--- a/src/xenia/gpu/trace_player.cc
+++ b/src/xenia/gpu/trace_player.cc
@@ -30,6 +30,7 @@ TracePlayer::TracePlayer(GraphicsSystem* graphics_system)
                    kMemoryProtectRead | kMemoryProtectWrite);
 
   playback_event_ = xe::threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(playback_event_);
 }
 
 TracePlayer::~TracePlayer() { delete[] edram_snapshot_; }

--- a/src/xenia/kernel/util/shim_utils.h
+++ b/src/xenia/kernel/util/shim_utils.h
@@ -84,18 +84,18 @@ inline uint64_t get_arg_64(PPCContext* ppc_context, uint8_t index) {
   return SHIM_MEM_64(stack_address);
 }
 
-inline std::string TranslateAnsiString(const Memory* memory,
-                                       const X_ANSI_STRING* ansi_string) {
+inline std::string_view TranslateAnsiString(const Memory* memory,
+                                            const X_ANSI_STRING* ansi_string) {
   if (!ansi_string || !ansi_string->length) {
     return "";
   }
-  return std::string(
+  return std::string_view(
       memory->TranslateVirtual<const char*>(ansi_string->pointer),
       ansi_string->length);
 }
 
-inline std::string TranslateAnsiStringAddress(const Memory* memory,
-                                              uint32_t guest_address) {
+inline std::string_view TranslateAnsiStringAddress(const Memory* memory,
+                                                   uint32_t guest_address) {
   if (!guest_address) {
     return "";
   }
@@ -440,7 +440,7 @@ inline void AppendParam(StringBuffer* string_buffer,
   if (record) {
     auto name_string =
         kernel_memory()->TranslateVirtual<X_ANSI_STRING*>(record->name_ptr);
-    std::string name =
+    std::string_view name =
         name_string == nullptr
             ? "(null)"
             : util::TranslateAnsiString(kernel_memory(), name_string);

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -614,8 +614,7 @@ dword_result_t NtOpenSymbolicLinkObject_entry(
   auto object_name =
       kernel_memory()->TranslateVirtual<X_ANSI_STRING*>(object_attrs->name_ptr);
 
-  std::string target_path =
-      util::TranslateAnsiString(kernel_memory(), object_name);
+  auto target_path = util::TranslateAnsiString(kernel_memory(), object_name);
 
   // Enforce that the path is ASCII.
   if (!IsValidPath(target_path, false)) {

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
@@ -7,6 +7,7 @@
  ******************************************************************************
  */
 
+#include "xenia/base/assert.h"
 #include "xenia/base/logging.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
@@ -31,10 +32,15 @@ dword_result_t ObOpenObjectByName_entry(lpunknown_t obj_attributes_ptr,
   // r5 = 0
   // r6 = out_ptr (handle?)
 
-  auto name = util::TranslateAnsiStringAddress(
-      kernel_memory(),
-      xe::load_and_swap<uint32_t>(kernel_memory()->TranslateVirtual(
-          obj_attributes_ptr.guest_address() + 4)));
+  if (!obj_attributes_ptr) {
+    return X_STATUS_INVALID_PARAMETER;
+  }
+
+  auto obj_attributes = kernel_memory()->TranslateVirtual<X_OBJECT_ATTRIBUTES*>(
+      obj_attributes_ptr);
+  assert_true(obj_attributes->name_ptr != 0);
+  auto name = util::TranslateAnsiStringAddress(kernel_memory(),
+                                               obj_attributes->name_ptr);
 
   X_HANDLE handle = X_INVALID_HANDLE_VALUE;
   X_STATUS result =

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
@@ -144,10 +144,10 @@ DECLARE_XBOXKRNL_EXPORT1(ObDereferenceObject, kNone, kImplemented);
 
 dword_result_t ObCreateSymbolicLink_entry(pointer_t<X_ANSI_STRING> path_ptr,
                                           pointer_t<X_ANSI_STRING> target_ptr) {
-  auto path = util::TranslateAnsiString(kernel_memory(), path_ptr);
-  auto target = util::TranslateAnsiString(kernel_memory(), target_ptr);
-  path = xe::utf8::canonicalize_guest_path(path);
-  target = xe::utf8::canonicalize_guest_path(target);
+  auto path = xe::utf8::canonicalize_guest_path(
+      util::TranslateAnsiString(kernel_memory(), path_ptr));
+  auto target = xe::utf8::canonicalize_guest_path(
+      util::TranslateAnsiString(kernel_memory(), target_ptr));
 
   if (xe::utf8::starts_with(path, u8"\\??\\")) {
     path = path.substr(4);  // Strip the full qualifier

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -455,7 +455,7 @@ dword_result_t NtCreateEvent_entry(
         existing_object->RetainHandle();
         *handle_ptr = existing_object->handle();
       }
-      return X_STATUS_SUCCESS;
+      return X_STATUS_OBJECT_NAME_EXISTS;
     } else {
       return X_STATUS_INVALID_HANDLE;
     }
@@ -576,7 +576,7 @@ DECLARE_XBOXKRNL_EXPORT1(KeReleaseSemaphore, kThreading, kImplemented);
 dword_result_t NtCreateSemaphore_entry(lpdword_t handle_ptr,
                                        lpvoid_t obj_attributes_ptr,
                                        dword_t count, dword_t limit) {
-  // Check for an existing timer with the same name.
+  // Check for an existing semaphore with the same name.
   auto existing_object =
       LookupNamedObject<XSemaphore>(kernel_state(), obj_attributes_ptr);
   if (existing_object) {
@@ -585,7 +585,7 @@ dword_result_t NtCreateSemaphore_entry(lpdword_t handle_ptr,
         existing_object->RetainHandle();
         *handle_ptr = existing_object->handle();
       }
-      return X_STATUS_SUCCESS;
+      return X_STATUS_OBJECT_NAME_EXISTS;
     } else {
       return X_STATUS_INVALID_HANDLE;
     }
@@ -647,7 +647,7 @@ dword_result_t NtCreateMutant_entry(
         existing_object->RetainHandle();
         *handle_out = existing_object->handle();
       }
-      return X_STATUS_SUCCESS;
+      return X_STATUS_OBJECT_NAME_EXISTS;
     } else {
       return X_STATUS_INVALID_HANDLE;
     }
@@ -709,7 +709,7 @@ dword_result_t NtCreateTimer_entry(lpdword_t handle_ptr,
         existing_object->RetainHandle();
         *handle_ptr = existing_object->handle();
       }
-      return X_STATUS_SUCCESS;
+      return X_STATUS_OBJECT_NAME_EXISTS;
     } else {
       return X_STATUS_INVALID_HANDLE;
     }

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -74,10 +74,12 @@ object_ref<T> LookupNamedObject(KernelState* kernel_state,
   if (!obj_attributes_ptr) {
     return nullptr;
   }
-  auto name = util::TranslateAnsiStringAddress(
-      kernel_state->memory(),
-      xe::load_and_swap<uint32_t>(
-          kernel_state->memory()->TranslateVirtual(obj_attributes_ptr + 4)));
+  auto obj_attributes =
+      kernel_state->memory()->TranslateVirtual<X_OBJECT_ATTRIBUTES*>(
+          obj_attributes_ptr);
+  assert_true(obj_attributes->name_ptr != 0);
+  auto name = util::TranslateAnsiStringAddress(kernel_state->memory(),
+                                               obj_attributes->name_ptr);
   if (!name.empty()) {
     X_HANDLE handle = X_INVALID_HANDLE_VALUE;
     X_RESULT result =

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -590,7 +590,13 @@ dword_result_t NtCreateSemaphore_entry(lpdword_t handle_ptr,
   }
 
   auto sem = object_ref<XSemaphore>(new XSemaphore(kernel_state()));
-  sem->Initialize((int32_t)count, (int32_t)limit);
+  if (!sem->Initialize((int32_t)count, (int32_t)limit)) {
+    if (handle_ptr) {
+      *handle_ptr = 0;
+    }
+    sem->ReleaseHandle();
+    return X_STATUS_INVALID_PARAMETER;
+  }
 
   // obj_attributes may have a name inside of it, if != NULL.
   if (obj_attributes_ptr) {

--- a/src/xenia/kernel/xevent.cc
+++ b/src/xenia/kernel/xevent.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -30,6 +30,7 @@ void XEvent::Initialize(bool manual_reset, bool initial_state) {
   } else {
     event_ = xe::threading::Event::CreateAutoResetEvent(initial_state);
   }
+  assert_not_null(event_);
 }
 
 void XEvent::InitializeNative(void* native_ptr, X_DISPATCH_HEADER* header) {
@@ -53,6 +54,7 @@ void XEvent::InitializeNative(void* native_ptr, X_DISPATCH_HEADER* header) {
   } else {
     event_ = xe::threading::Event::CreateAutoResetEvent(initial_state);
   }
+  assert_not_null(event_);
 }
 
 int32_t XEvent::Set(uint32_t priority_increment, bool wait) {
@@ -112,6 +114,7 @@ object_ref<XEvent> XEvent::Restore(KernelState* kernel_state,
   } else {
     evt->event_ = xe::threading::Event::CreateAutoResetEvent(false);
   }
+  assert_not_null(evt->event_);
 
   if (signaled) {
     evt->event_->Set();

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2020 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -26,10 +26,12 @@ XFile::XFile(KernelState* kernel_state, vfs::File* file, bool synchronous)
       file_(file),
       is_synchronous_(synchronous) {
   async_event_ = threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(async_event_);
 }
 
 XFile::XFile() : XObject(kObjectType) {
   async_event_ = threading::Event::CreateAutoResetEvent(false);
+  assert_not_null(async_event_);
 }
 
 XFile::~XFile() {

--- a/src/xenia/kernel/xiocompletion.cc
+++ b/src/xenia/kernel/xiocompletion.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2015 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -15,6 +15,7 @@ namespace kernel {
 XIOCompletion::XIOCompletion(KernelState* kernel_state)
     : XObject(kernel_state, kObjectType) {
   notification_semaphore_ = threading::Semaphore::Create(0, kMaxNotifications);
+  assert_not_null(notification_semaphore_);
 }
 
 XIOCompletion::~XIOCompletion() = default;

--- a/src/xenia/kernel/xmutant.cc
+++ b/src/xenia/kernel/xmutant.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -28,6 +28,7 @@ void XMutant::Initialize(bool initial_owner) {
   assert_false(mutant_);
 
   mutant_ = xe::threading::Mutant::Create(initial_owner);
+  assert_not_null(mutant_);
 }
 
 void XMutant::InitializeNative(void* native_ptr, X_DISPATCH_HEADER* header) {

--- a/src/xenia/kernel/xnotifylistener.cc
+++ b/src/xenia/kernel/xnotifylistener.cc
@@ -2,13 +2,14 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
 
 #include "xenia/kernel/xnotifylistener.h"
 
+#include "xenia/base/assert.h"
 #include "xenia/base/byte_stream.h"
 #include "xenia/base/logging.h"
 #include "xenia/kernel/kernel_state.h"
@@ -25,6 +26,7 @@ void XNotifyListener::Initialize(uint64_t mask, uint32_t max_version) {
   assert_false(wait_handle_);
 
   wait_handle_ = xe::threading::Event::CreateManualResetEvent(false);
+  assert_not_null(wait_handle_);
   mask_ = mask;
   max_version_ = max_version;
 

--- a/src/xenia/kernel/xobject.cc
+++ b/src/xenia/kernel/xobject.cc
@@ -172,7 +172,7 @@ void XObject::SetAttributes(uint32_t obj_attributes_ptr) {
       memory(), xe::load_and_swap<uint32_t>(
                     memory()->TranslateVirtual(obj_attributes_ptr + 4)));
   if (!name.empty()) {
-    name_ = std::move(name);
+    name_ = std::string(name);
     kernel_state_->object_table()->AddNameMapping(name_, handles_[0]);
   }
 }

--- a/src/xenia/kernel/xobject.cc
+++ b/src/xenia/kernel/xobject.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -410,7 +410,9 @@ object_ref<XObject> XObject::GetNativeObject(KernelState* kernel_state,
       case 5:  // SemaphoreObject
       {
         auto sem = new XSemaphore(kernel_state);
-        sem->InitializeNative(native_ptr, header);
+        auto success = sem->InitializeNative(native_ptr, header);
+        // Can't report failure to the guest at late initialization:
+        assert_true(success);
         object = sem;
       } break;
       case 3:   // ProcessObject

--- a/src/xenia/kernel/xsemaphore.cc
+++ b/src/xenia/kernel/xsemaphore.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -20,22 +20,24 @@ XSemaphore::XSemaphore(KernelState* kernel_state)
 
 XSemaphore::~XSemaphore() = default;
 
-void XSemaphore::Initialize(int32_t initial_count, int32_t maximum_count) {
+bool XSemaphore::Initialize(int32_t initial_count, int32_t maximum_count) {
   assert_false(semaphore_);
 
   CreateNative(sizeof(X_KSEMAPHORE));
 
   maximum_count_ = maximum_count;
   semaphore_ = xe::threading::Semaphore::Create(initial_count, maximum_count);
+  return !!semaphore_;
 }
 
-void XSemaphore::InitializeNative(void* native_ptr, X_DISPATCH_HEADER* header) {
+bool XSemaphore::InitializeNative(void* native_ptr, X_DISPATCH_HEADER* header) {
   assert_false(semaphore_);
 
   auto semaphore = reinterpret_cast<X_KSEMAPHORE*>(native_ptr);
   maximum_count_ = semaphore->limit;
   semaphore_ = xe::threading::Semaphore::Create(semaphore->header.signal_state,
                                                 semaphore->limit);
+  return !!semaphore_;
 }
 
 int32_t XSemaphore::ReleaseSemaphore(int32_t release_count) {
@@ -85,6 +87,7 @@ object_ref<XSemaphore> XSemaphore::Restore(KernelState* kernel_state,
 
   sem->semaphore_ =
       threading::Semaphore::Create(free_count, sem->maximum_count_);
+  assert_not_null(sem->semaphore_);
 
   return object_ref<XSemaphore>(sem);
 }

--- a/src/xenia/kernel/xsemaphore.h
+++ b/src/xenia/kernel/xsemaphore.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -30,8 +30,9 @@ class XSemaphore : public XObject {
   explicit XSemaphore(KernelState* kernel_state);
   ~XSemaphore() override;
 
-  void Initialize(int32_t initial_count, int32_t maximum_count);
-  void InitializeNative(void* native_ptr, X_DISPATCH_HEADER* header);
+  [[nodiscard]] bool Initialize(int32_t initial_count, int32_t maximum_count);
+  [[nodiscard]] bool InitializeNative(void* native_ptr,
+                                      X_DISPATCH_HEADER* header);
 
   int32_t ReleaseSemaphore(int32_t release_count);
 

--- a/src/xenia/kernel/xsymboliclink.cc
+++ b/src/xenia/kernel/xsymboliclink.cc
@@ -24,8 +24,8 @@ XSymbolicLink::~XSymbolicLink() {}
 
 void XSymbolicLink::Initialize(const std::string_view path,
                                const std::string_view target) {
-  path_ = path;
-  target_ = target;
+  path_ = std::string(path);
+  target_ = std::string(target);
   // TODO(gibbed): kernel_state_->RegisterSymbolicLink(this);
 }
 

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2020 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -1057,6 +1057,7 @@ object_ref<XThread> XThread::Restore(KernelState* kernel_state,
       // Release the self-reference to the thread.
       thread->ReleaseHandle();
     });
+    assert_not_null(thread->thread_);
 
     // Notify processor we were recreated.
     thread->emulator()->processor()->OnThreadCreated(

--- a/src/xenia/kernel/xtimer.cc
+++ b/src/xenia/kernel/xtimer.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -35,6 +35,7 @@ void XTimer::Initialize(uint32_t timer_type) {
       assert_always();
       break;
   }
+  assert_not_null(timer_);
 }
 
 X_STATUS XTimer::SetTimer(int64_t due_time, uint32_t period_ms,


### PR DESCRIPTION
~~Fixes #1678~~ (there are other pending issues with the posix threading code) 

In the general scope of #1430 

This is an attempt to fix the spurious Linux CI fails we are seeing.
I mainly attribute them to the misuse of `cond_.notify_one()` (see #1678)

Additionally I replaced a lot of `Sleep` calls used for synchronisation with spin waits because timing is very unreliable on CI due to heavy over-provisioning. 