### PR TITLE
Add #include <cfloat> to fix build error on Linux.

### DIFF
--- a/src/xenia/gpu/shader_interpreter.cc
+++ b/src/xenia/gpu/shader_interpreter.cc
@@ -9,6 +9,7 @@
 
 #include "xenia/gpu/shader_interpreter.h"
 
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 


### PR DESCRIPTION
Was failing to build on Linux, This PR adds "#include <cfloat>" to fix it.