### PR TITLE
[x64] Add AVX512 optimization for `NOT_V128`

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -2891,6 +2891,10 @@ struct NOT_I64 : Sequence<NOT_I64, I<OPCODE_NOT, I64Op, I64Op>> {
 };
 struct NOT_V128 : Sequence<NOT_V128, I<OPCODE_NOT, V128Op, V128Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
+    if (e.IsFeatureEnabled(kX64EmitAVX512Ortho)) {
+      e.vpternlogd(i.dest, i.src1, i.src1, 0b01010101);
+      return;
+    }
     // dest = src ^ 0xFFFF...
     e.vpxor(i.dest, i.src1, e.GetXmmConstPtr(XMMFFFF /* FF... */));
   }


### PR DESCRIPTION
Passes unit tests on my i9-11900k.

Just a single-instruction implementation of bitwise-not with no memory dependency.