### PR TITLE
[PPC] Fix memory assert formatting

### DIFF
--- a/src/xenia/cpu/ppc/testing/ppc_testing_main.cc
+++ b/src/xenia/cpu/ppc/testing/ppc_testing_main.cc
@@ -349,8 +349,8 @@ class TestRunner {
           uint32_t expected = std::strtoul(ccs, nullptr, 16);
           uint8_t actual = *p;
 
-          expecteds.AppendFormat(" %02X", expected);
-          actuals.AppendFormat(" %02X", actual);
+          expecteds.AppendFormat(" {:02X}", expected);
+          actuals.AppendFormat(" {:02X}", actual);
 
           if (expected != actual) {
             any_failed = true;


### PR DESCRIPTION
This was still using printf-style format specifiers. Causing memory
asserts to show up like this while testing.

```
!> 0000438C Memory 10001040 assert failed:
!> 0000438C   Expected: %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X
!> 0000438C     Actual: %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X
!> 0000438C     TEST FAILED
```

Updated them so they format correctly:

```
!> 00002CCC Memory 10001040 assert failed:
!> 00002CCC   Expected: FC FD FE FF 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
!> 00002CCC     Actual: FC FD FE FF 00 00 00 00 00 00 00 00 00 00 00 00
!> 00002CCC     TEST FAILED
```