### PR TITLE
[App/UI/Kernel] Add console region setting and locale menu

### DIFF
--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -25,6 +25,15 @@
 #include "xenia/ui/windowed_app_context.h"
 #include "xenia/xbox.h"
 
+enum class MenuIndex {
+  kFile,
+  kCpu,
+  kGpu,
+  kDisplay,
+  kLanguageRegion,
+  kHelp,
+};
+
 namespace xe {
 namespace app {
 
@@ -139,6 +148,7 @@ class EmulatorWindow {
   void GpuTraceFrame();
   void GpuClearCaches();
   void ToggleDisplayConfigDialog();
+  void SelectLocaleSetting(int setting, int value);
   void ShowCompatibility();
   void ShowFAQ();
   void ShowBuildCommit();

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -25,15 +25,6 @@
 #include "xenia/ui/windowed_app_context.h"
 #include "xenia/xbox.h"
 
-enum class MenuIndex {
-  kFile,
-  kCpu,
-  kGpu,
-  kDisplay,
-  kLanguageRegion,
-  kHelp,
-};
-
 namespace xe {
 namespace app {
 

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -612,6 +612,16 @@ void EmulatorApp::EmulatorThread() {
       xe::FatalError(fmt::format("Failed to launch target: {:08X}", result));
       app_context().RequestDeferredQuit();
       return;
+    } else {
+      auto window = emulator_window_->window();
+      if (window) {
+        window->SetMainMenuItemEnabled(
+            static_cast<int32_t>(MenuIndex::kLanguageRegion), false);
+      } else {
+        XELOGI(
+            "EmulatorApp::EmulatorThread: Failed to disable main menu item {}.",
+            static_cast<int32_t>(MenuIndex::kLanguageRegion));
+      }
     }
   }
 

--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -24,6 +24,8 @@
 
 #include "third_party/fmt/include/fmt/format.h"
 
+DECLARE_string(console_region);
+
 namespace xe {
 namespace kernel {
 namespace xam {
@@ -200,8 +202,41 @@ dword_result_t XGetAVPack_entry() {
 }
 DECLARE_XAM_EXPORT1(XGetAVPack, kNone, kStub);
 
-uint32_t xeXGetGameRegion() { return 0xFFFFu; }
+// Going by the theory based on some unreasonable amount of
+// experimentation, I'll say that the top byte is the region here:
+// 00 is most likely USA, 01 Asia, 02 Europe, ???, FF = All regions?
+// And the lower byte is some sort of mask for sub-regions?
+// 0x0101 is the only one that displays the RIOT ACT title screen in
+// 4D5307DC (Crackdown), because this is only a copyrighted title in
+// Japan specifically, 0x01FF displays the standard CRACKDOWN title,
+// so 0x0101 is most likely Japan and 0x01<anything else> is probably
+// different sub regions of Asia?
+// Thus the logic behind these return values is:
+// 0xFFFF - Any region, all sub regions (basically region free)
+// 0x00FF - US, all sub regions
+// 0x0101 - Asia region, Japan sub region
+// 0x01FF - Asia region, all sub regions (Chinese/Hong Kong consoles?)
+// 0x02FF - Europe, all sub regions
+// 0x0300 through 0x06FF - Unknown (World, unused?)
+// 0x07FF - Devkit, according to text displayed on screen in DashLaunch.
+//          Probably not very useful for now? Not added.
+uint32_t xeXGetGameRegion() {
+  if (cvars::console_region == "us") {
+    return 0x00FFu;
+  } else if (cvars::console_region == "jp") {
+    return 0x0101u;
+  } else if (cvars::console_region == "asia") {
+    return 0x01FFu;
+  } else if (cvars::console_region == "eu") {
+    return 0x02FFu;
+  }
 
+  // On any invalid value or "rf", just return region free as before.
+  return 0xFFFFu;
+}
+
+// It seems very likely that this function is supposed to return the console's
+// game region rather than the region of the game currently loaded.
 dword_result_t XGetGameRegion_entry() { return xeXGetGameRegion(); }
 DECLARE_XAM_EXPORT1(XGetGameRegion, kNone, kStub);
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.cc
@@ -7,6 +7,7 @@
  ******************************************************************************
  */
 
+#include "xenia/kernel/xboxkrnl/xboxkrnl_xconfig.h"
 #include "xenia/base/logging.h"
 #include "xenia/cpu/processor.h"
 #include "xenia/kernel/kernel_state.h"
@@ -37,9 +38,50 @@ DEFINE_int32(user_country, 103,
              " 102=UA 103=US 104=UY 105=UZ 106=VE 107=VN 108=YE 109=ZA\n",
              "XConfig");
 
+DEFINE_string(
+    console_region, "rf",
+    "Console region. [rf, us, eu, jp, asia]\n"
+    "This config variable allows you to change the main region reported\n"
+    "by the console. Only change this from the default rf (region free)\n"
+    "if language settings in game are not working as expected.\n",
+    "XConfig");
+
 namespace xe {
 namespace kernel {
 namespace xboxkrnl {
+
+void xcSaveRegionSetting(XCRegionSettingType type, int32_t setting_value) {
+  switch (type) {
+    case XCRegionSettingType::kUserLanguage:
+      OVERRIDE_int32(user_language, setting_value);
+      break;
+    case XCRegionSettingType::kUserCountry:
+      OVERRIDE_int32(user_country, setting_value);
+      break;
+    case XCRegionSettingType::kConsoleRegion:
+      switch (static_cast<XCConsoleRegion>(setting_value)) {
+        case XCConsoleRegion::kUS:
+          OVERRIDE_string(console_region, "us");
+          break;
+        case XCConsoleRegion::kJapan:
+          OVERRIDE_string(console_region, "jp");
+          break;
+        case XCConsoleRegion::kAsia:
+          OVERRIDE_string(console_region, "asia");
+          break;
+        case XCConsoleRegion::kEurope:
+          OVERRIDE_string(console_region, "eu");
+          break;
+        case XCConsoleRegion::kRegionFree:
+        default:
+          OVERRIDE_string(console_region, "rf");
+          break;
+      }
+      break;
+    default:
+      break;
+  }
+}
 
 X_STATUS xeExGetXConfigSetting(uint16_t category, uint16_t setting,
                                void* buffer, uint16_t buffer_size,

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.h
@@ -1,0 +1,40 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XBOXKRNL_XBOXKRNL_XCONFIG_H_
+#define XENIA_KERNEL_XBOXKRNL_XBOXKRNL_XCONFIG_H_
+
+#include "xenia/kernel/util/shim_utils.h"
+#include "xenia/xbox.h"
+
+enum class XCConsoleRegion {
+  kUS,
+  kJapan,
+  kAsia,
+  kEurope,
+  kRegionFree,
+};
+
+enum class XCRegionSettingType {
+  kUserLanguage,
+  kUserCountry,
+  kConsoleRegion,
+};
+
+namespace xe {
+namespace kernel {
+namespace xboxkrnl {
+
+void xcSaveRegionSetting(XCRegionSettingType type, int32_t setting_value);
+
+}  // namespace xboxkrnl
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XBOXKRNL_XBOXKRNL_XCONFIG_H_

--- a/src/xenia/ui/menu_item.cc
+++ b/src/xenia/ui/menu_item.cc
@@ -60,7 +60,12 @@ void MenuItem::RemoveChild(MenuItem* child_item) {
   }
 }
 
-MenuItem* MenuItem::child(size_t index) { return children_[index].get(); }
+MenuItem* MenuItem::child(size_t index) {
+  // Return nullptr if the child index is out of range.
+  if (index >= children_.size()) return nullptr;
+
+  return children_[index].get();
+}
 
 void MenuItem::OnSelected() {
   if (callback_) {

--- a/src/xenia/ui/menu_item.h
+++ b/src/xenia/ui/menu_item.h
@@ -60,6 +60,7 @@ class MenuItem {
   MenuItem* child(size_t index);
 
   virtual void SetEnabled(bool enabled) {}
+  virtual void SetChecked(int idx, bool checked) {}
 
  protected:
   MenuItem(Type type, const std::string& text, const std::string& hotkey,

--- a/src/xenia/ui/window.cc
+++ b/src/xenia/ui/window.cc
@@ -13,6 +13,7 @@
 #include <iterator>
 
 #include "third_party/imgui/imgui.h"
+#include "xenia/app/emulator_window.h"
 #include "xenia/base/assert.h"
 #include "xenia/base/clock.h"
 #include "xenia/base/logging.h"
@@ -276,6 +277,8 @@ void Window::SetIcon(const void* buffer, size_t size) {
   }
 }
 
+MenuItem* Window::GetMainMenu() { return main_menu_.get(); }
+
 void Window::SetMainMenu(std::unique_ptr<MenuItem> new_main_menu) {
   // The primary reason for this comparison (of two unique pointers) is
   // nullptr == nullptr.
@@ -327,6 +330,18 @@ void Window::SetMainMenuEnabled(bool enabled) {
   if (destruction_receiver.IsWindowDestroyed()) {
     return;
   }
+}
+
+void Window::SetMainMenuItemEnabled(int index, bool enabled) {
+  if (!main_menu_) {
+    return;
+  }
+  WindowDestructionReceiver destruction_receiver(this);
+  main_menu_->child(index)->SetEnabled(enabled);
+  if (destruction_receiver.IsWindowDestroyed()) {
+    return;
+  }
+  CompleteMainMenuItemsUpdate();
 }
 
 void Window::CaptureMouse() {

--- a/src/xenia/ui/window.cc
+++ b/src/xenia/ui/window.cc
@@ -279,6 +279,14 @@ void Window::SetIcon(const void* buffer, size_t size) {
 
 MenuItem* Window::GetMainMenu() { return main_menu_.get(); }
 
+MenuItem* Window::GetMenuByIndex(MenuIndex index_) {
+  int32_t index = static_cast<int32_t>(index_);
+  if (index >= xe::countof(menu_item_index) || menu_item_index[index] == -1) {
+    XELOGW("Window::GetMenuByIndex: Invalid menu requested: {}", index);
+  }
+  return main_menu_->child(menu_item_index[index]);
+}
+
 void Window::SetMainMenu(std::unique_ptr<MenuItem> new_main_menu) {
   // The primary reason for this comparison (of two unique pointers) is
   // nullptr == nullptr.
@@ -336,8 +344,13 @@ void Window::SetMainMenuItemEnabled(int index, bool enabled) {
   if (!main_menu_) {
     return;
   }
+  if (index >= xe::countof(menu_item_index) || menu_item_index[index] == -1) {
+    XELOGW("Window::SetMainMenuItemEnabled: Invalid menu item requested: {}",
+           index);
+    return;
+  }
   WindowDestructionReceiver destruction_receiver(this);
-  main_menu_->child(index)->SetEnabled(enabled);
+  main_menu_->child(menu_item_index[index])->SetEnabled(enabled);
   if (destruction_receiver.IsWindowDestroyed()) {
     return;
   }

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -298,8 +298,10 @@ class Window {
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.
   void SetMainMenu(std::unique_ptr<MenuItem> new_main_menu);
+  MenuItem* GetMainMenu();
   void CompleteMainMenuItemsUpdate();
   void SetMainMenuEnabled(bool enabled);
+  void SetMainMenuItemEnabled(int index, bool enabled);
 
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -26,6 +26,16 @@
 #include "xenia/ui/window_listener.h"
 #include "xenia/ui/windowed_app_context.h"
 
+enum class MenuIndex {
+  kFile,
+  kCpu,
+  kGpu,
+  kDisplay,
+  kLanguageRegion,
+  kHelp,
+  kNumMenuItems,
+};
+
 namespace xe {
 namespace ui {
 
@@ -299,9 +309,13 @@ class Window {
   // in the implementation.
   void SetMainMenu(std::unique_ptr<MenuItem> new_main_menu);
   MenuItem* GetMainMenu();
+  MenuItem* GetMenuByIndex(MenuIndex index_);
   void CompleteMainMenuItemsUpdate();
   void SetMainMenuEnabled(bool enabled);
   void SetMainMenuItemEnabled(int index, bool enabled);
+  void SetMenuItemIndex(MenuIndex menu, int index) {
+    menu_item_index[static_cast<uint64_t>(menu)] = index;
+  };
 
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.
@@ -712,6 +726,8 @@ class Window {
   CursorVisibility cursor_visibility_ = CursorVisibility::kVisible;
 
   bool has_focus_ = false;
+  int8_t menu_item_index[static_cast<uint64_t>(MenuIndex::kNumMenuItems)] = {
+      -1};
 
   Presenter* presenter_ = nullptr;
   std::unique_ptr<Surface> presenter_surface_;

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -1316,6 +1316,30 @@ void Win32MenuItem::SetEnabled(bool enabled) {
   }
 }
 
+void Win32MenuItem::SetChecked(int idx, bool checked) {
+  UINT i = 0;
+  MENUITEMINFO menu_item_info = {0};
+  menu_item_info.cbSize = sizeof(MENUITEMINFO);
+  menu_item_info.fMask = MIIM_STATE;
+  menu_item_info.fState = (checked) ? MFS_CHECKED : MFS_UNCHECKED;
+
+  // FIXME:
+  // For some reason, accessing handle_ directly from a Win32MenuItem
+  // results in a null pointer, and the only way to actually get the handle
+  // for a child menu item that I could find was this iterator.
+  // The performance impact of iterating over all the menu items is of
+  // course negligible, but it still looks kind of weird.
+  for (auto iter = children_.begin(); iter != children_.end(); ++iter, ++i) {
+    if (idx == i) {
+      if (!SetMenuItemInfo(handle_, i, true, &menu_item_info)) {
+        XELOGI("SetMenuItemInfo failed for some reason: {} ({})",
+               GetLastError(), (uint64_t)handle_);
+      }
+      return;
+    }
+  }
+}
+
 void Win32MenuItem::OnChildAdded(MenuItem* generic_child_item) {
   auto child_item = static_cast<Win32MenuItem*>(generic_child_item);
 

--- a/src/xenia/ui/window_win.h
+++ b/src/xenia/ui/window_win.h
@@ -161,6 +161,7 @@ class Win32MenuItem : public MenuItem {
   HMENU handle() const { return handle_; }
 
   void SetEnabled(bool enabled) override;
+  void SetChecked(int idx, bool checked) override;
 
   using MenuItem::OnSelected;
 


### PR DESCRIPTION
This adds a console region setting to the XConfig section of the Xenia config file and changes the behavior of `xeXGetGameRegion`, allowing for things like region-specific startup screens and language options to be available in games, such as the RIOT ACT title screen in Crackdown (`4D5307DC`) and the Piracy Warning and Japanese-specific title screen in Sonic Generations (`53450848`). It also enables use of the Japanese dub in Ace Combat 6 (not confirmed by me) and while Xenia master cannot currently load them, it also enables correct function of the language packs for Resident Evil 6.

Also adds a menu to the Xenia window for configuring the user language, user country and console region settings without having to manually edit the config file and typing in values. The menu checkmark code is a bit... strange, but the comment in `window_win.cc` explains why it currently looks the way it does. (This menu is disabled while a title is running.)

While Crackdown currently crashes on Xenia master due to an incorrect return code when loading a saved game, here are some example screenshots:
![image](https://user-images.githubusercontent.com/21002523/191371311-c02327a9-b1bc-4b36-b115-4b2342019672.png)
