### PR TITLE
[WIP] [GPU] Allow setting vsync interval using numerator/denominator

### DIFF
--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -48,3 +48,13 @@ DEFINE_int32(query_occlusion_fake_sample_count, 1000,
              "EVENT_WRITE_ZPD by this number. Setting this to 0 means "
              "everything is reported as occluded.",
              "GPU");
+
+DEFINE_double(
+    vsync_num, 1000.0,
+    "VSync numerator. Leave this at 1000 for \"flat\" VSync rates, such as  "
+    "30, 60, 120. For somewhat NTSC-conforming frame rates, such as 29.97, "
+    "59.94, 119.88, this should be set to 1001.0",
+    "GPU");
+DEFINE_double(vsync_den, 60.0,
+              "VSync denominator, can be considered the \"target VSync rate\".",
+              "GPU");


### PR DESCRIPTION
Adds support for setting a custom internal VSync interval for Xenia.
* Makes it easier to run certain titles at a different frame rate (as long as the title's engine can actually handle it).
* Stabilizes the frame rate a lot closer to 30/60 in games that are locked to 2/1 vblanks per present call, where the original implementation would often drop down to 28.x/58.x frames per second and only ever briefly spike to 30 or 60.

Problem:
As you might be able to tell from my comments and the `#ifdef`s in `graphics_systemcc`, there are some irregularities.
The implementation that currently works is using `clock()` and the host system timer rather than `Clock::QueryGuestTickCount()` as the original implementation did, this due to the fact that something seems to be "off" with the guest system timer, resulting in an output frame rate of 56-57 instead of the expected ~60.
I unfortunately don't know how to investigate the root cause for this myself, which is why I'm posting this here as a draft to check if someone can help me figure this out, or otherwise if using  `clock()` or something else similar based on the host timer is an acceptable solution.

Example screenshots, from the top: Original implemenation, new implementation using `clock()`, new implementation using `Clock::QueryGuestTickCount()`
![image](https://user-images.githubusercontent.com/21002523/192138783-231bae8e-51ad-4691-b79c-ce48215168b5.png)
