### PR TITLE
[x64] Add AVX512 optimizations for `OPCODE_SELECT`{V128,F64}

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -35,6 +35,7 @@
 #include "xenia/cpu/backend/x64/x64_emitter.h"
 #include "xenia/cpu/backend/x64/x64_op.h"
 #include "xenia/cpu/backend/x64/x64_tracers.h"
+#include "xenia/cpu/backend/x64/x64_util.h"
 #include "xenia/cpu/hir/hir_builder.h"
 #include "xenia/cpu/processor.h"
 
@@ -745,19 +746,28 @@ struct SELECT_V128_V128
     : Sequence<SELECT_V128_V128,
                I<OPCODE_SELECT, V128Op, V128Op, V128Op, V128Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    Xmm src1 = i.src1.is_constant ? e.xmm0 : i.src1;
+    const Xmm src1 = i.src1.is_constant ? e.xmm0 : i.src1;
     if (i.src1.is_constant) {
       e.LoadConstantXmm(src1, i.src1.constant());
     }
 
-    Xmm src2 = i.src2.is_constant ? e.xmm1 : i.src2;
+    const Xmm src2 = i.src2.is_constant ? e.xmm1 : i.src2;
     if (i.src2.is_constant) {
       e.LoadConstantXmm(src2, i.src2.constant());
     }
 
-    Xmm src3 = i.src3.is_constant ? e.xmm2 : i.src3;
+    const Xmm src3 = i.src3.is_constant ? e.xmm2 : i.src3;
     if (i.src3.is_constant) {
       e.LoadConstantXmm(src3, i.src3.constant());
+    }
+
+    if (e.IsFeatureEnabled(kX64EmitAVX512Ortho)) {
+      e.vmovdqa(e.xmm3, src1);
+      e.vpternlogd(e.xmm3, src2, src3,
+                   (~TernaryOperand::a & TernaryOperand::b) |
+                       (TernaryOperand::c & TernaryOperand::a));
+      e.vmovdqa(i.dest, e.xmm3);
+      return;
     }
 
     // src1 ? src2 : src3;

--- a/src/xenia/cpu/backend/x64/x64_util.h
+++ b/src/xenia/cpu/backend/x64/x64_util.h
@@ -1,0 +1,46 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2022 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_CPU_BACKEND_X64_X64_UTIL_H_
+#define XENIA_CPU_BACKEND_X64_X64_UTIL_H_
+
+#include "xenia/base/vec128.h"
+#include "xenia/cpu/backend/x64/x64_backend.h"
+#include "xenia/cpu/backend/x64/x64_emitter.h"
+
+namespace xe {
+namespace cpu {
+namespace backend {
+namespace x64 {
+
+// Used to generate ternary logic truth-tables for vpternlog
+// Use these to directly refer to terms and perform binary operations upon them
+// and the resulting value will be the ternary lookup table
+// ex:
+//  (TernaryOperand::a | ~TernaryOperand::b) & TernaryOperand::c
+//      = 0b10100010
+//      = 0xa2
+//  vpternlog a, b, c, 0xa2
+//
+//  ~(TernaryOperand::a ^ TernaryOperand::b) & TernaryOperand::c
+//      = 0b10000010
+//      = 0x82
+//  vpternlog a, b, c, 0x82
+namespace TernaryOperand {
+constexpr uint8_t a = 0b11110000;
+constexpr uint8_t b = 0b11001100;
+constexpr uint8_t c = 0b10101010;
+}  // namespace TernaryOperand
+
+}  // namespace x64
+}  // namespace backend
+}  // namespace cpu
+}  // namespace xe
+
+#endif  // XENIA_CPU_BACKEND_X64_X64_UTIL_H_


### PR DESCRIPTION
Accelerates these two data-types in particular since the F32 variant is not actually utilized by anything it seems.

Tested using `instr_gen_fsel.s` and `instr_gen_vsel.s` from #1348.

Adds the `x64_util.h` header that will later house other utility-functions for x64 instructions that include extra encoding bits like `vpternlog*`, `vcmp`, `vpcmp`, `vfixupimm*`, `vrange`, etc