### PR TITLE
[CPU] Increase amount of possible labels used in FinalizationPass

### DIFF
--- a/src/xenia/cpu/compiler/passes/finalization_pass.cc
+++ b/src/xenia/cpu/compiler/passes/finalization_pass.cc
@@ -46,8 +46,8 @@ bool FinalizationPass::Run(HIRBuilder* builder) {
       if (!label->name) {
         const size_t label_len = 6 + 4;
         char* name = reinterpret_cast<char*>(arena->Alloc(label_len + 1, 1));
-        assert_true(label->id <= 9999);
-        auto end = fmt::format_to_n(name, label_len, "_label{}", label->id);
+        assert_true(label->id <= 65535);
+        auto end = fmt::format_to_n(name, label_len, "_label{:04X}", label->id);
         name[end.size] = '\0';
         label->name = name;
       }


### PR DESCRIPTION
Related to: https://github.com/xenia-project/xenia/issues/1817

I've got title mentioned in this issue (https://github.com/xenia-project/game-compatibility/issues/245) and found out after hitting assertion and checking which function causes issues that indeed it is caused by lack of space for labels.

They have this huge routine in their code that causes this crash: 
![image](https://user-images.githubusercontent.com/153369/198376664-9ae7cd5b-effb-4085-9f67-00911dc029d0.png)


I've decided that instead of increasing label_len it will be better to just use hexadecimal notation.