### PR TITLE
[UI] Resolved issue with next window disappearing after providing input

### DIFF
--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -94,12 +94,12 @@ void ImGuiDrawer::RemoveDialog(ImGuiDialog* dialog) {
       presenter_->RemoveUIDrawerFromUIThread(this);
     }
     window_->RemoveInputListener(this);
-    // Clear all input since no input will be received anymore, and when the
-    // drawer becomes active again, it'd have an outdated input state otherwise
-    // which will be persistent until new events actualize individual input
-    // properties.
-    ClearInput();
   }
+  // Clear all input since no input will be received anymore, and when the
+  // drawer becomes active again, it'd have an outdated input state otherwise
+  // which will be persistent until new events actualize individual input
+  // properties.
+  ClearInput();
 }
 
 void ImGuiDrawer::Initialize() {


### PR DESCRIPTION
Steps to reproduce:
1. Open input window in game that support it.
2. Enter something and confirm with Enter.
3. Open window again.

Cause:
Closing window wasn't clearing input that was provided and it was still in queue in state pressed down (especially enter button)

PS. Not sure if this solution works correctly in every case (multiple input windows), but I've never seen any game that would open many windows at the same time, so it is good enough.