### PR TITLE
[Kernel] Support for loading achievement data

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -55,6 +55,8 @@
 #include "xenia/cpu/backend/x64/x64_backend.h"
 #endif  // XE_ARCH
 
+DECLARE_int32(user_language);
+
 DEFINE_double(time_scalar, 1.0,
               "Scalar used to speed or slow time (1x, 2x, 1/2x, etc).",
               "General");
@@ -795,23 +797,28 @@ X_STATUS Emulator::CompleteLaunch(const std::filesystem::path& path,
     }
     game_config_load_callback_loop_next_index_ = SIZE_MAX;
 
-    uint32_t resource_data = 0;
-    uint32_t resource_size = 0;
-    if (XSUCCEEDED(module->GetSection(title_id.c_str(), &resource_data,
-                                      &resource_size))) {
-      kernel::util::XdbfGameData db(
-          module->memory()->TranslateVirtual(resource_data), resource_size);
-      if (db.is_valid()) {
-        // TODO(gibbed): get title respective to user locale.
-        title_name_ = db.title(XLanguage::kEnglish);
-        if (title_name_.empty()) {
-          // If English title is unavailable, get the title in default locale.
-          title_name_ = db.title();
-        }
-        auto icon_block = db.icon();
-        if (icon_block) {
-          display_window_->SetIcon(icon_block.buffer, icon_block.size);
-        }
+    const kernel::util::XdbfGameData db = kernel_state_->module_xdbf(module);
+    if (db.is_valid()) {
+      XLanguage language =
+          db.GetExistingLanguage(static_cast<XLanguage>(cvars::user_language));
+      title_name_ = db.title(language);
+
+      XELOGI("-------------------- ACHIEVEMENTS --------------------");
+      const std::vector<kernel::util::XdbfAchievementTableEntry>
+          achievement_list = db.GetAchievements();
+      for (const kernel::util::XdbfAchievementTableEntry& entry :
+           achievement_list) {
+        std::string label = db.GetStringTableEntry(language, entry.label_id);
+        std::string desc =
+            db.GetStringTableEntry(language, entry.description_id);
+
+        XELOGI("{} - {} - {} - {}", entry.id, label, desc, entry.gamerscore);
+      }
+      XELOGI("----------------- END OF ACHIEVEMENTS ----------------");
+
+      auto icon_block = db.icon();
+      if (icon_block) {
+        display_window_->SetIcon(icon_block.buffer, icon_block.size);
       }
     }
   }

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -104,6 +104,26 @@ uint32_t KernelState::title_id() const {
   return 0;
 }
 
+util::XdbfGameData KernelState::title_xdbf() const {
+  return module_xdbf(executable_module_);
+}
+
+util::XdbfGameData KernelState::module_xdbf(
+    object_ref<UserModule> exec_module) const {
+  assert_not_null(exec_module);
+
+  uint32_t resource_data = 0;
+  uint32_t resource_size = 0;
+  if (XSUCCEEDED(exec_module->GetSection(
+          fmt::format("{:08X}", exec_module->title_id()).c_str(),
+          &resource_data, &resource_size))) {
+    util::XdbfGameData db(memory()->TranslateVirtual(resource_data),
+                          resource_size);
+    return db;
+  }
+  return util::XdbfGameData(nullptr, resource_size);
+}
+
 uint32_t KernelState::process_type() const {
   auto pib =
       memory_->TranslateVirtual<ProcessInfoBlock*>(process_info_block_address_);

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -23,6 +23,7 @@
 #include "xenia/cpu/export_resolver.h"
 #include "xenia/kernel/util/native_list.h"
 #include "xenia/kernel/util/object_table.h"
+#include "xenia/kernel/util/xdbf_utils.h"
 #include "xenia/kernel/xam/app_manager.h"
 #include "xenia/kernel/xam/content_manager.h"
 #include "xenia/kernel/xam/user_profile.h"
@@ -99,6 +100,8 @@ class KernelState {
   vfs::VirtualFileSystem* file_system() const { return file_system_; }
 
   uint32_t title_id() const;
+  util::XdbfGameData title_xdbf() const;
+  util::XdbfGameData module_xdbf(object_ref<UserModule> exec_module) const;
 
   xam::AppManager* app_manager() const { return app_manager_.get(); }
   xam::ContentManager* content_manager() const {

--- a/src/xenia/kernel/util/xdbf_utils.cc
+++ b/src/xenia/kernel/util/xdbf_utils.cc
@@ -16,6 +16,11 @@ namespace util {
 constexpr fourcc_t kXdbfSignatureXdbf = make_fourcc("XDBF");
 constexpr fourcc_t kXdbfSignatureXstc = make_fourcc("XSTC");
 constexpr fourcc_t kXdbfSignatureXstr = make_fourcc("XSTR");
+constexpr fourcc_t kXdbfSignatureXach = make_fourcc("XACH");
+
+constexpr uint64_t kXdbfIdTitle = 0x8000;
+constexpr uint64_t kXdbfIdXstc = 0x58535443;
+constexpr uint64_t kXdbfIdXach = 0x58414348;
 
 XdbfWrapper::XdbfWrapper(const uint8_t* data, size_t data_size)
     : data_(data), data_size_(data_size) {
@@ -64,12 +69,12 @@ std::string XdbfWrapper::GetStringTableEntry(XLanguage language,
   }
 
   auto xstr_head =
-      reinterpret_cast<const XdbfXstrHeader*>(language_block.buffer);
+      reinterpret_cast<const XdbfSectionHeader*>(language_block.buffer);
   assert_true(xstr_head->magic == kXdbfSignatureXstr);
   assert_true(xstr_head->version == 1);
 
-  const uint8_t* ptr = language_block.buffer + sizeof(XdbfXstrHeader);
-  for (uint16_t i = 0; i < xstr_head->string_count; ++i) {
+  const uint8_t* ptr = language_block.buffer + sizeof(XdbfSectionHeader);
+  for (uint16_t i = 0; i < xstr_head->count; ++i) {
     auto entry = reinterpret_cast<const XdbfStringTableEntry*>(ptr);
     ptr += sizeof(XdbfStringTableEntry);
     if (entry->id == string_id) {
@@ -81,8 +86,35 @@ std::string XdbfWrapper::GetStringTableEntry(XLanguage language,
   return "";
 }
 
-constexpr uint64_t kXdbfIdTitle = 0x8000;
-constexpr uint64_t kXdbfIdXstc = 0x58535443;
+std::vector<XdbfAchievementTableEntry> XdbfWrapper::GetAchievements() const {
+  std::vector<XdbfAchievementTableEntry> achievements;
+
+  auto achievement_table = GetEntry(XdbfSection::kMetadata, kXdbfIdXach);
+  if (!achievement_table) {
+    return achievements;
+  }
+
+  auto xach_head =
+      reinterpret_cast<const XdbfSectionHeader*>(achievement_table.buffer);
+  assert_true(xach_head->magic == kXdbfSignatureXach);
+  assert_true(xach_head->version == 1);
+
+  const uint8_t* ptr = achievement_table.buffer + sizeof(XdbfSectionHeader);
+  for (uint16_t i = 0; i < xach_head->count; ++i) {
+    auto entry = reinterpret_cast<const XdbfAchievementTableEntry*>(ptr);
+    ptr += sizeof(XdbfAchievementTableEntry);
+    achievements.push_back(*entry);
+  }
+  return achievements;
+
+}
+
+XLanguage XdbfGameData::GetExistingLanguage(XLanguage language_to_check) const {
+  // A bit of a hack. Check if title in specific language exist.
+  // If it doesn't then for sure language is not supported.
+  return title(language_to_check).empty() ? default_language()
+                                          : language_to_check;
+}
 
 XdbfBlock XdbfGameData::icon() const {
   return GetEntry(XdbfSection::kImage, kXdbfIdTitle);


### PR DESCRIPTION
Full list of changes:
- Removed dummy achievement loading and provide real data.
- Added iterating achievements and their details on boot (with regards to selected user language).
- Load localized title information based on user selected language instead of defaulting to english.
- Created method to load XdbfGameData (Splitted into 2 for case if we want to provide from which module or not).
- Changed ``XdbfXstrHeader`` -> ``XdbfSectionHeader``.