### PR TITLE
[Kernel/Thread] Set TLS slot to 0 while freeing

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -138,7 +138,17 @@ void KernelState::set_process_type(uint32_t value) {
 
 uint32_t KernelState::AllocateTLS() { return uint32_t(tls_bitmap_.Acquire()); }
 
-void KernelState::FreeTLS(uint32_t slot) { tls_bitmap_.Release(slot); }
+void KernelState::FreeTLS(uint32_t slot) {
+  const std::vector<object_ref<XThread>> threads =
+      object_table()->GetObjectsByType<XThread>();
+
+  for (const object_ref<XThread>& thread : threads) {
+    if (thread->is_guest_thread()) {
+      thread->SetTLSValue(slot, 0);
+    }
+  }
+  tls_bitmap_.Release(slot);
+}
 
 void KernelState::RegisterTitleTerminateNotification(uint32_t routine,
                                                      uint32_t priority) {


### PR DESCRIPTION
This fixes https://github.com/xenia-project/game-compatibility/issues/721 requirement for ``protect_zero = false`` and further random crashes