### PR TITLE
[Base] Set the path for posix file info

### DIFF
--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -225,6 +225,7 @@ std::vector<FileInfo> ListFiles(const std::filesystem::path& path) {
     info.create_timestamp = convertUnixtimeToWinFiletime(st.st_ctime);
     info.access_timestamp = convertUnixtimeToWinFiletime(st.st_atime);
     info.write_timestamp = convertUnixtimeToWinFiletime(st.st_mtime);
+    info.path = path;
     if (ent->d_type == DT_DIR) {
       info.type = FileInfo::Type::kDirectory;
       info.total_size = 0;


### PR DESCRIPTION
Partial fix for #2119. The path to the file was not being set on posix devices and was preventing fragment files from being opened.