### PR TITLE
[STFS] Add critical section to file reading

### DIFF
--- a/src/xenia/vfs/devices/stfs_container_file.cc
+++ b/src/xenia/vfs/devices/stfs_container_file.cc
@@ -52,12 +52,15 @@ X_STATUS StfsContainerFile::ReadSync(void* buffer, size_t buffer_length,
     size_t read_length =
         std::min(record.length - read_offset, remaining_length);
 
-    auto& file = entry_->files()->at(record.file);
-    xe::filesystem::Seek(file, record.offset + read_offset, SEEK_SET);
-    auto num_read = fread(p, 1, read_length, file);
+    auto global_lock = global_critical_region_.Acquire();
+    {
+      auto& file = entry_->files()->at(record.file);
+      xe::filesystem::Seek(file, record.offset + read_offset, SEEK_SET);
+      auto num_read = fread(p, 1, read_length, file);
 
-    *out_bytes_read += num_read;
-    p += num_read;
+      *out_bytes_read += num_read;
+      p += num_read;
+    }
     src_offset += record.length;
     remaining_length -= read_length;
     if (remaining_length == 0) {

--- a/src/xenia/vfs/devices/stfs_container_file.h
+++ b/src/xenia/vfs/devices/stfs_container_file.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_VFS_DEVICES_STFS_CONTAINER_FILE_H_
 #define XENIA_VFS_DEVICES_STFS_CONTAINER_FILE_H_
 
+#include "xenia/base/mutex.h"
 #include "xenia/vfs/file.h"
 
 #include "xenia/xbox.h"
@@ -35,6 +36,7 @@ class StfsContainerFile : public File {
   X_STATUS SetLength(size_t length) override { return X_STATUS_ACCESS_DENIED; }
 
  private:
+  xe::global_critical_region global_critical_region_;
   StfsContainerEntry* entry_;
 };
 


### PR DESCRIPTION
Affected titles:
https://github.com/xenia-project/game-compatibility/issues/827
https://github.com/xenia-project/game-compatibility/issues/125 

Description:
These titles use multiple threads to load same file, which in case of extracted file doesn't make any issue, however for STFS package it is huge problem as it can randomly receive incorrect data.

I checked it multiple times and calculated hashes of loaded data between extracted and packed game.
Conclusion for me is simple, at certain point thread starts getting invalid data, which is simply resolved by including critical section