### PR TITLE
[PPC] Implement `vaddcuw`

### DIFF
--- a/src/xenia/cpu/ppc/ppc_emit_altivec.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_altivec.cc
@@ -358,8 +358,13 @@ int InstrEmit_mtvscr(PPCHIRBuilder& f, const InstrData& i) {
 }
 
 int InstrEmit_vaddcuw(PPCHIRBuilder& f, const InstrData& i) {
-  XEINSTRNOTIMPLEMENTED();
-  return 1;
+  Value* sum = f.VectorAdd(f.LoadVR(i.VX.VA), f.LoadVR(i.VX.VB), INT32_TYPE,
+                           ARITHMETIC_UNSIGNED);
+  Value* overflow = f.VectorCompareUGT(f.LoadVR(i.VX.VA), sum, INT32_TYPE);
+  Value* carry =
+      f.VectorShr(overflow, f.LoadConstantVec128(vec128i(31)), INT32_TYPE);
+  f.StoreVR(i.VX.VD, carry);
+  return 0;
 }
 
 int InstrEmit_vaddfp_(PPCHIRBuilder& f, uint32_t vd, uint32_t va, uint32_t vb) {


### PR DESCRIPTION
I don't know of any title that utilizes this instruction, but I went ahead and implemented it for completeness.

Verified the implementation with `instr__gen_vaddcuw` from #1348. Can be grabbed with:
```
git checkout origin/gen_tests -- src\xenia\cpu\ppc\testing\*vaddcuw.s
```

![vaddcuw](https://user-images.githubusercontent.com/644247/216858917-e9dcde5a-d589-4c5c-910c-4e9e23a75d56.png)
