### PR TITLE
[PPC] Implement `vsubcuw`

### DIFF
--- a/src/xenia/cpu/ppc/ppc_emit_altivec.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_altivec.cc
@@ -1657,7 +1657,11 @@ int InstrEmit_vsrw128(PPCHIRBuilder& f, const InstrData& i) {
 }
 
 int InstrEmit_vsubcuw(PPCHIRBuilder& f, const InstrData& i) {
-  XEINSTRNOTIMPLEMENTED();
+  Value* underflow =
+      f.VectorCompareUGE(f.LoadVR(i.VX.VA), f.LoadVR(i.VX.VB), INT32_TYPE);
+  Value* borrow =
+      f.VectorShr(underflow, f.LoadConstantVec128(vec128i(31)), INT32_TYPE);
+  f.StoreVR(i.VX.VD, borrow);
   return 1;
 }
 


### PR DESCRIPTION
Other half of #2125. I don't know of any title that utilizes this instruction, but I went ahead and implemented it for completeness.

Verified the implementation with `instr__gen_vsubcuw` from #1348. Can be grabbed with:
```
git checkout origin/gen_tests -- src\xenia\cpu\ppc\testing\*vsubcuw.s
```

![image](https://user-images.githubusercontent.com/644247/232565383-72c975e7-499f-469e-a45e-edd5eb3d3516.png)
