### PR TITLE
[BASE] Prevent crashing if special characters are in the launch path

### DIFF
--- a/src/xenia/base/main_win.cc
+++ b/src/xenia/base/main_win.cc
@@ -96,8 +96,14 @@ bool ParseWin32LaunchArguments(
   char** argv = reinterpret_cast<char**>(alloca(sizeof(char*) * argc));
   for (int n = 0; n < argc; n++) {
     size_t len = std::wcstombs(nullptr, wargv[n], 0);
-    argv[n] = reinterpret_cast<char*>(alloca(sizeof(char) * (len + 1)));
-    std::wcstombs(argv[n], wargv[n], len + 1);
+
+    if (len != -1) {
+      argv[n] = reinterpret_cast<char*>(alloca(sizeof(char) * (len + 1)));
+      std::wcstombs(argv[n], wargv[n], len + 1);
+    } else {
+      // Prevent cxxopts from indexing out of bounds.
+      argc--;
+    }
   }
 
   LocalFree(wargv);


### PR DESCRIPTION
Fixes https://github.com/xenia-project/xenia/issues/2210

A path containing characters that cannot be converted to a multibyte string would fail and cause cxxopts to assign the cvar target to argument 0 (current process). This can be prevented by checking if `wcstombs` returns -1 and decrement argc to prevent cxxopts from indexing out of bounds.