### PR TITLE
[LINUX/CPU] Fixed MulHi in value.cc for Linux systems.

### DIFF
--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -410,12 +410,14 @@ void Value::MulHi(Value* other, bool is_unsigned) {
 #else
       if (is_unsigned) {
         constant.i64 = static_cast<uint64_t>(
-            static_cast<unsigned __int128>(constant.i64) *
-            static_cast<unsigned __int128>(other->constant.i64));
+            (static_cast<unsigned __int128>(constant.i64) *
+             static_cast<unsigned __int128>(other->constant.i64)) >>
+            64);
       } else {
-        constant.i64 =
-            static_cast<uint64_t>(static_cast<__int128>(constant.i64) *
-                                  static_cast<__int128>(other->constant.i64));
+        constant.i64 = static_cast<uint64_t>(
+            (static_cast<__int128>(constant.i64) *
+             static_cast<__int128>(other->constant.i64)) >>
+            64);
       }
 #endif  // XE_COMPILER_MSVC
       break;


### PR DESCRIPTION
In cpu/hir/value.cc in the Linux code we used to take the low 64 bits of the 128 bit result when we should take the high bits instead.