### PR TITLE
[BASE] Fixed VirtualQuery possibly uninitialized parameter.

### DIFF
--- a/src/xenia/base/memory_win.cc
+++ b/src/xenia/base/memory_win.cc
@@ -162,7 +162,7 @@ bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
   MEMORY_BASIC_INFORMATION info;
   ZeroMemory(&info, sizeof(info));
 
-  SIZE_T result = VirtualQuery(base_address, &info, length);
+  SIZE_T result = VirtualQuery(base_address, &info, sizeof(info));
   if (!result) {
     return false;
   }


### PR DESCRIPTION
Here we pass our possibly uninitialized length parameter as a parameter to VirtualQuery, when in fact what we should pass there is sizeof(info).



https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualquery