### PR TITLE
[Testing] Fix building on Linux

### DIFF
--- a/src/xenia/vfs/testing/premake5.lua
+++ b/src/xenia/vfs/testing/premake5.lua
@@ -3,6 +3,8 @@ include(project_root.."/tools/build")
 
 test_suite("xenia-vfs-tests", project_root, ".", {
   links = {
+    "fmt",
+    "xenia-base",
     "xenia-vfs",
   },
 })


### PR DESCRIPTION
This fixes building Xenia on my Arch Linux machine. Without these changes, building throws the following error:
```
==== Building xenia-debug-ui (debug_linux) ====
Creating obj/Linux/Debug/Linux/Debug/xenia-debug-ui
debug_window.cc
/usr/bin/ld: obj/Linux/Debug/Linux/Debug/xenia-vfs-tests/console_app_main_posix.o: in function `main':
/.../xenia/build/../src/xenia/base/console_app_main_posix.cc:21:(.text+0x7d): undefined reference to `cvar::ParseLaunchArguments(int&, char**&, std::basic_string_view<char, std::char_traits<char> >, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)'
/usr/bin/ld: /.../xenia/build/../src/xenia/base/console_app_main_posix.cc:26:(.text+0xcb): undefined reference to `xe::InitializeLogging(std::basic_string_view<char, std::char_traits<char> >)'
/usr/bin/ld: /.../xenia/build/../src/xenia/base/console_app_main_posix.cc:35:(.text+0x180): undefined reference to `xe::ShutdownLogging()'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [xenia-vfs-tests.make:121: bin/Linux/Debug/xenia-vfs-tests] Error 1
make: *** [Makefile:419: xenia-vfs-tests] Error 2
make: *** Waiting for unfinished jobs....
```

I also had to modify the build system to find my system's version of premake5, I can PR that as well if desired.