### PR TITLE
Corrected the premake binary search functionality

### DIFF
--- a/tools/build/helpers.py
+++ b/tools/build/helpers.py
@@ -1,0 +1,36 @@
+import os
+
+
+def is_executable(path) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def get_bin(binary):
+    """Checks whether the given binary is present and returns the path.
+
+    Args:
+      binary: binary name (without .exe, etc).
+
+    Returns:
+      Full path to the binary or None if not found.
+    """
+    for path in os.environ['PATH'].split(os.pathsep):
+        path = path.strip('"')
+        exe_file = os.path.join(path, binary)
+        if is_executable(exe_file):
+            return exe_file
+        if is_executable(exe_file + '.exe'):
+            return exe_file + '.exe'
+    return None
+
+
+def has_bin(binary):
+    """Checks whether the given binary is present in the PATH.
+
+    Args:
+      binary: binary name (without .exe, etc).
+
+    Returns:
+      True if the binary exists.
+    """
+    return get_bin(binary) is not None

--- a/tools/build/premake
+++ b/tools/build/premake
@@ -12,12 +12,14 @@ import json
 import os
 import shutil
 import subprocess
+import pathlib
 import sys
 import re
+from helpers import is_executable
 
 
 self_path = os.path.dirname(os.path.abspath(__file__))
-root_path = os.path.join(self_path, '..', '..')
+root_path = pathlib.Path(self_path).parent.parent.absolute()
 premake_submodule_path = os.path.join(root_path, 'third_party', 'premake-core')
 premake_path = premake_submodule_path
 
@@ -54,15 +56,15 @@ setup_premake_path_override()
 def main():
   # First try the freshly-built premake.
   premake5_bin = os.path.join(premake_path, 'bin', 'release', 'premake5')
-  if not has_bin(premake5_bin):
+  if not is_executable(premake5_bin):
     # No fresh build, so fallback to checked in copy (which we may not have).
     premake5_bin = os.path.join(self_path, 'bin', 'premake5')
-  if not has_bin(premake5_bin):
+  if not is_executable(premake5_bin):
     # Still no valid binary, so build it.
     print('premake5 executable not found, attempting build...')
     build_premake()
     premake5_bin = os.path.join(premake_path, 'bin', 'release', 'premake5')
-  if not has_bin(premake5_bin):
+  if not is_executable(premake5_bin):
     # Nope, boned.
     print('ERROR: cannot build premake5 executable.')
     sys.exit(1)
@@ -150,22 +152,6 @@ def clone_premake_to_internal_storage():
       premake_submodule_path,
       premake_path,
       ])
-
-
-def has_bin(bin):
-  """Checks whether the given binary is present.
-  """
-  for path in os.environ["PATH"].split(os.pathsep):
-    if sys.platform == 'win32':
-      exe_file = os.path.join(path, bin + '.exe')
-      if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-        return True
-    else:
-      path = path.strip('"')
-      exe_file = os.path.join(path, bin)
-      if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-        return True
-  return None
 
 
 def shell_call(command, throw_on_error=True, stdout_path=None, stderr_path=None, shell=False):

--- a/tools/build/premake
+++ b/tools/build/premake
@@ -15,7 +15,7 @@ import subprocess
 import pathlib
 import sys
 import re
-from helpers import is_executable
+from helpers import is_executable, get_bin, has_bin
 
 
 self_path = os.path.dirname(os.path.abspath(__file__))
@@ -54,26 +54,32 @@ setup_premake_path_override()
 
 
 def main():
-  # First try the freshly-built premake.
-  premake5_bin = os.path.join(premake_path, 'bin', 'release', 'premake5')
-  if not is_executable(premake5_bin):
-    # No fresh build, so fallback to checked in copy (which we may not have).
-    premake5_bin = os.path.join(self_path, 'bin', 'premake5')
-  if not is_executable(premake5_bin):
-    # Still no valid binary, so build it.
+  premake_build_bin = os.path.join(premake_path, 'bin', 'release', 'premake5')
+  premake_local_bin = os.path.join(self_path, 'bin', 'premake5')
+  premake5_bin = None
+  # First check if premake is available at the system level
+  if has_bin('premake5'):
+    premake5_bin = get_bin('premake5')
+    print('using the installed version of premake')
+  # Next try the freshly-built premake.
+  elif is_executable(premake_build_bin):
+    premake5_bin = premake_build_bin
+    print('using local build of premake')
+  # No fresh build, so fallback to checked in copy (which we may not have).
+  elif is_executable(premake_local_bin):
+    premake5_bin = premake_local_bin
+    print('using the local prebuilt premake')
+  # Still no valid binary, so build it.
+  else:
     print('premake5 executable not found, attempting build...')
     build_premake()
-    premake5_bin = os.path.join(premake_path, 'bin', 'release', 'premake5')
-  if not is_executable(premake5_bin):
-    # Nope, boned.
-    print('ERROR: cannot build premake5 executable.')
-    sys.exit(1)
-
-  # Ensure the submodule has been checked out.
-  if not os.path.exists(os.path.join(premake_path, 'scripts', 'package.lua')):
-    print('third_party/premake-core was not present; run xb setup...')
-    sys.exit(1)
-    return
+    if is_executable(premake_build_bin):
+      premake5_bin = premake_build_bin
+      print('using local build of premake')
+    else:
+      # Nope, boned.
+      print('ERROR: cannot build premake5 executable.')
+      sys.exit(1)
 
   if sys.platform == 'win32':
     # Append the executable extension on windows.
@@ -91,6 +97,12 @@ def main():
 def build_premake():
   """Builds premake from source.
   """
+  # Ensure the submodule has been checked out.
+  if not os.path.exists(os.path.join(premake_path, 'scripts', 'package.lua')):
+    print('third_party/premake-core was not present; run xb setup...')
+    sys.exit(1)
+    return
+
   # Ensure that on Android, premake-core is in the internal storage.
   clone_premake_to_internal_storage()
   cwd = os.getcwd()

--- a/xenia-build
+++ b/xenia-build
@@ -17,6 +17,7 @@ import re
 import shutil
 import subprocess
 import sys
+from tools.build.helpers import has_bin, get_bin
 
 __author__ = 'ben.vanik@gmail.com (Ben Vanik)'
 
@@ -190,41 +191,6 @@ def print_box(msg):
         '│{1: ^{2}}║\n'
         '╘{0:═^{2}}╝\n'
         .format('', msg, len(msg) + 2))
-
-
-def has_bin(binary):
-    """Checks whether the given binary is present.
-
-    Args:
-      binary: binary name (without .exe, etc).
-
-    Returns:
-      True if the binary exists.
-    """
-    bin_path = get_bin(binary)
-    if not bin_path:
-        return False
-    return True
-
-
-def get_bin(binary):
-    """Checks whether the given binary is present and returns the path.
-
-    Args:
-      binary: binary name (without .exe, etc).
-
-    Returns:
-      Full path to the binary or None if not found.
-    """
-    for path in os.environ['PATH'].split(os.pathsep):
-        path = path.strip('"')
-        exe_file = os.path.join(path, binary)
-        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-            return exe_file
-        exe_file += '.exe'
-        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-            return exe_file
-    return None
 
 
 def shell_call(command, throw_on_error=True, stdout_path=None, stderr_path=None, shell=False):


### PR DESCRIPTION
Currently the build premake step is failing on linux due to a dependency issue in premake. This issue propmpted me to add a prebuilt premake to my local project but I noticed that it was not being acknowledge during the xb  build process. These changes fix the executable search logic in the xb and premake python scripts so that drop in prebuilt binaries can be used.