### PR TITLE
fixing potential OOB window write when unpacking chm files

### DIFF
--- a/third_party/mspack/lzxd.c
+++ b/third_party/mspack/lzxd.c
@@ -781,6 +781,10 @@ int lzxd_decompress(struct lzxd_stream *lzx, off_t out_bytes) {
       case LZX_BLOCKTYPE_UNCOMPRESSED:
         /* as this_run is limited not to wrap a frame, this also means it
          * won't wrap the window (as the window is a multiple of 32k) */
+        if (window_posn + this_run > lzx->window_size) {
+                D(("match ran over window boundary"))
+                return lzx->error = MSPACK_ERR_DECRUNCH;
+        }
         rundest = &window[window_posn];
         window_posn += this_run;
         while (this_run > 0) {
@@ -903,8 +907,10 @@ void lzxd_free(struct lzxd_stream *lzx) {
   struct mspack_system *sys;
   if (lzx) {
     sys = lzx->sys;
-    sys->free(lzx->inbuf);
-    sys->free(lzx->window);
+    if(lzx->inbuf)
+        sys->free(lzx->inbuf);
+    if(lzx->window)
+        sys->free(lzx->window);
     sys->free(lzx);
   }
 }


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in file third_party/mspack/lzxd.c that was cloned from clam but did not receive the security patch. The original issue was reported and fixed under https://github.com/Cisco-Talos/clamav/commit/a83773682e856ad6529ba6db8d1792e6d515d7f1.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/cve-2017-6419
https://github.com/Cisco-Talos/clamav/commit/a83773682e856ad6529ba6db8d1792e6d515d7f1