### PR TITLE
Implement XamContentOpenFile

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -316,6 +316,7 @@ X_STATUS Emulator::LaunchXexFile(const std::filesystem::path& path) {
 
   // Create symlinks to the device.
   file_system_->RegisterSymbolicLink("game:", mount_path);
+  file_system_->RegisterSymbolicLink("update:", mount_path);
   file_system_->RegisterSymbolicLink("d:", mount_path);
 
   // Get just the filename (foo.xex).
@@ -342,6 +343,7 @@ X_STATUS Emulator::LaunchDiscImage(const std::filesystem::path& path) {
 
   // Create symlinks to the device.
   file_system_->RegisterSymbolicLink("game:", mount_path);
+  file_system_->RegisterSymbolicLink("update:", mount_path);
   file_system_->RegisterSymbolicLink("d:", mount_path);
 
   // Launch the game.
@@ -365,6 +367,7 @@ X_STATUS Emulator::LaunchStfsContainer(const std::filesystem::path& path) {
   }
 
   file_system_->RegisterSymbolicLink("game:", mount_path);
+  file_system_->RegisterSymbolicLink("update:", mount_path);
   file_system_->RegisterSymbolicLink("d:", mount_path);
 
   // Launch the game.

--- a/src/xenia/kernel/xam/content_manager.h
+++ b/src/xenia/kernel/xam/content_manager.h
@@ -19,6 +19,7 @@
 #include "xenia/base/mutex.h"
 #include "xenia/base/string_key.h"
 #include "xenia/base/string_util.h"
+#include "xenia/vfs/devices/host_path_device.h"
 #include "xenia/xbox.h"
 
 namespace xe {
@@ -121,7 +122,7 @@ class ContentPackage {
  public:
   ContentPackage(KernelState* kernel_state, const std::string_view root_name,
                  const XCONTENT_AGGREGATE_DATA& data,
-                 const std::filesystem::path& package_path);
+                 const std::filesystem::path& package_path, bool stfs = false);
   ~ContentPackage();
 
   const XCONTENT_AGGREGATE_DATA& GetPackageContentData() const {
@@ -151,6 +152,9 @@ class ContentManager {
   bool ContentExists(const XCONTENT_AGGREGATE_DATA& data);
   X_RESULT CreateContent(const std::string_view root_name,
                          const XCONTENT_AGGREGATE_DATA& data);
+  X_RESULT MountContentToHost(const std::string_view vpath,
+                              const std::string_view root_name,
+                              XCONTENT_AGGREGATE_DATA& data);
   X_RESULT OpenContent(const std::string_view root_name,
                        const XCONTENT_AGGREGATE_DATA& data);
   X_RESULT CloseContent(const std::string_view root_name);

--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -259,8 +259,10 @@ dword_result_t XamContentOpenFile_entry(dword_t user_index,
                                         lpdword_t disposition_ptr,
                                         lpdword_t license_mask_ptr,
                                         lpvoid_t overlapped_ptr) {
-  // TODO(gibbed): arguments assumed based on XamContentCreate.
-  return X_ERROR_FILE_NOT_FOUND;
+  auto content_manager = kernel_state()->content_manager();
+  XCONTENT_AGGREGATE_DATA data;
+  return content_manager->MountContentToHost(path.value(), root_name.value(),
+                                             data);
 }
 DECLARE_XAM_EXPORT1(XamContentOpenFile, kContent, kStub);
 


### PR DESCRIPTION
Implements #1247 

Observed behaviour on 4D530A1A

before this commit it was not calling any Xam::nui functions,

1. it attempts to open 3 files
2. loads something, and plays its kinect tutorial video in a loop (soft lock)

Now it
1. attempts to open 3 files
2. calls XamNuiCameraTiltSetCallback_entry
3. loads for a few seconds
4. crashes in guest



This is my first xenia PR, Im unsure about adding the symlink "update" to mount directory but it seems correct.


