### PR TITLE
Fix per-game config values leaking across titles

### DIFF
--- a/src/xenia/base/cvar.h
+++ b/src/xenia/base/cvar.h
@@ -50,6 +50,7 @@ class IConfigVar : virtual public ICommandVar {
   virtual std::string config_value() const = 0;
   virtual void LoadConfigValue(std::shared_ptr<cpptoml::base> result) = 0;
   virtual void LoadGameConfigValue(std::shared_ptr<cpptoml::base> result) = 0;
+  virtual void ResetGameConfigValue() = 0;
   virtual void ResetConfigValueToDefault() = 0;
 };
 
@@ -95,6 +96,7 @@ class ConfigVar : public CommandVar<T>, virtual public IConfigVar {
   // one that will be stored when the global config is written next time. After
   // overriding, however, the next game config loaded may still change it.
   void OverrideConfigValue(T val);
+  void ResetGameConfigValue() override;
 
  private:
   std::string category_;
@@ -278,6 +280,13 @@ void ConfigVar<T>::OverrideConfigValue(T val) {
   this->commandline_value_.reset();
   UpdateValue();
 }
+
+template <class T>
+void ConfigVar<T>::ResetGameConfigValue() {
+  game_config_value_.reset();
+  UpdateValue();
+}
+
 template <class T>
 void ConfigVar<T>::ResetConfigValueToDefault() {
   SetConfigValue(this->default_value_);

--- a/src/xenia/config.cc
+++ b/src/xenia/config.cc
@@ -104,6 +104,16 @@ void ReadGameConfig(const std::filesystem::path& file_path) {
   XELOGI("Loaded game config: {}", xe::path_to_utf8(file_path));
 }
 
+void ResetGameConfigValues() {
+  if (!cvar::ConfigVars) {
+    return;
+  }
+  for (auto& it : *cvar::ConfigVars) {
+    auto config_var = static_cast<cvar::IConfigVar*>(it.second);
+    config_var->ResetGameConfigValue();
+  }
+}
+
 void SaveConfig() {
   if (config_path.empty()) {
     return;
@@ -238,6 +248,8 @@ void SetupConfig(const std::filesystem::path& config_folder) {
 }
 
 void LoadGameConfig(const std::string_view title_id) {
+  ResetGameConfigValues();
+
   const auto game_config_folder = config_folder / "config";
   const auto game_config_path =
       game_config_folder / (std::string(title_id) + game_config_suffix);


### PR DESCRIPTION
# Per-Game Config Bug Fix

## The Problem

Settings from one game were incorrectly persisting when loading a different game. When Game A defined configuration values in its TOML file and Game B did not override those same settings, Game B would still use Game A's values. This occurred because the cvar system retained the previous game's game_config_value_ state without clearing it before loading the next title's configuration.

## The Solution

This patch adds a cleanup step that resets all per-game overrides before loading a new title's configuration. Each game now starts from global and default values unless it explicitly defines its own overrides.

## Changes Made

1. Added reset method to config variables
   - Implemented ResetGameConfigValue in the IConfigVar interface
   - Clears the cached game_config_value_ pointer
   - Triggers UpdateValue() to recalculate the setting using the standard precedence: default → global → CLI → game-specific

2. Added system-wide reset function
   - Created ResetGameConfigValues() in src/xenia/config.cc
   - Iterates through all registered config variables and resets each one

3. Modified game config loading
   - Updated LoadGameConfig() to call ResetGameConfigValues() at the start
   - Ensures each title loads from a clean state before applying its TOML overrides

## Impact

- Eliminates unintended inheritance of config values between games
- Ensures per-title configurations operate independently
- Resolves issues where settings from a previous session would affect subsequent titles