### PR TITLE
./xb setup improvements: Successful Targeting of Mac OS

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -43,6 +43,12 @@ flags({
   "FatalWarnings",        -- Treat warnings as errors.
 })
 
+filter("platforms:Mac")
+  removeflags({
+    "FatalWarnings"
+  })
+filter({})
+
 filter("kind:StaticLib")
   defines({
     "_LIB",
@@ -98,7 +104,20 @@ filter("platforms:Linux")
   buildoptions({
     -- "-mlzcnt",  -- (don't) Assume lzcnt is supported.
   })
-  pkg_config.all("gtk+-x11-3.0")
+
+  filter("platforms:Mac")
+  system("macosx")
+  toolset("clang")
+  buildoptions({
+    "-Wdeprecated-declarations",
+  })
+  links({
+    "stdc++",
+    "dl",
+    "pthread",
+  })
+  
+  pkg_config.all("gtk+-3.0")
   links({
     "stdc++fs",
     "dl",

--- a/src/xenia/app/Info.plist
+++ b/src/xenia/app/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>xenia</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>jp.xenia.emulator</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Xenia</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.13</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/src/xenia/app/premake5.lua
+++ b/src/xenia/app/premake5.lua
@@ -86,6 +86,14 @@ project("xenia-app")
   filter({"architecture:x86_64", "files:../base/main_init_"..platform_suffix..".cc"})
     vectorextensions("IA32")  -- Disable AVX for main_init_win.cc so our AVX check doesn't use AVX instructions.
 
+  filter("platforms:Mac")
+    files({
+      "Info.plist",
+    })
+    links({
+      "gtk+-3.0",
+    })
+    
   filter("platforms:not Android-*")
     links({
       "xenia-app-discord",

--- a/tools/build/scripts/pkg_config.lua
+++ b/tools/build/scripts/pkg_config.lua
@@ -12,7 +12,7 @@ local function pkg_config_call(lib, what)
 end
 
 function pkg_config.cflags(lib)
-  if not os.istarget("linux") then
+  if not (os.istarget("linux") or os.istarget("macosx")) then
     return
   end
   buildoptions({
@@ -21,7 +21,7 @@ function pkg_config.cflags(lib)
 end
 
 function pkg_config.lflags(lib)
-  if not os.istarget("linux") then
+    if not (os.istarget("linux") or os.istarget("macosx")) then
     return
   end
   linkoptions({

--- a/tools/build/scripts/platform_files.lua
+++ b/tools/build/scripts/platform_files.lua
@@ -41,6 +41,13 @@ local function match_platform_files(base_path, base_match)
       base_path.."/"..base_match.."_gtk.h",
       base_path.."/"..base_match.."_gtk.cc",
     })
+  filter("platforms:Mac")
+    files({
+      base_path.."/"..base_match.."_posix.h",
+      base_path.."/"..base_match.."_posix.cc",
+      base_path.."/"..base_match.."_mac.h",
+      base_path.."/"..base_match.."_mac.cc",
+    })
   filter("platforms:Android-*")
     files({
       base_path.."/"..base_match.."_android.h",


### PR DESCRIPTION
To properly port Xenia to Mac OS X, this PR contains 5 commits that enable ./xb setup to work on Mac OS X. This does not yet enable ./xb build: that will be my next focus, along with efficiently addressing any bugs as they arise.

I’m building Xenia via VSCode on macOS 10.13. If the included Info.plist file is too OS-specific, maintainers can cherry-pick the other working commits. I’ll keep the Info.plist private going forward if this happens