### PR TITLE
Use system premake when premake is installed system-wide

### DIFF
--- a/tools/build/premake
+++ b/tools/build/premake
@@ -54,7 +54,7 @@ setup_premake_path_override()
 def main():
   # First try the freshly-built premake.
   premake5_bin = os.path.join(premake_path, 'bin', 'release', 'premake5')
-  # If whe have a system wide premake, skip building premake
+  # If we have a system wide premake, skip building premake
   if has_bin('premake5'):
     premake5_bin = 'premake5'
   if not has_bin(premake5_bin):


### PR DESCRIPTION
On Linux environments, it's easier to just use the system premake binary provided by a package manager. Building premake seems like an unnecessary step in the build process in this case. 